### PR TITLE
release 2.15.0

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/constants/CommonOptions.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/constants/CommonOptions.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 @Getter
 public enum CommonOptions {
     JSON("Json"),
-    METADATA("Metadata");
+    METADATA("Metadata"),
+    ELEMENT_TYPE("ElementType"),
+    MAX_CAPACITY("MaxCapacity"),
+    MAX_LENGTH("MaxLength"),;
 
     private final String name;
 

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriter.java
@@ -36,6 +36,7 @@ import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnecti
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.common.StageBucket;
 import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.BULK_WRITER_CONFIG;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.TOTAL_COUNT;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.state.MilvusCommitInfo;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.state.MilvusSinkState;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusConnectorUtils;
@@ -219,5 +220,9 @@ public class MilvusSinkWriter
         }
         // Wait for all waitJobFinish calls to complete
         futures.forEach(CompletableFuture::join);
+        if(writeCount.get() == 0 && config.get(TOTAL_COUNT) != null && config.get(TOTAL_COUNT) > 0) {
+            // If no data is written, throw an exception
+            throw new MilvusConnectorException(MilvusConnectionErrorCode.CLOSE_CLIENT_ERROR, "No data written to Milvus");
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkConfig.java
@@ -137,9 +137,9 @@ public class MilvusSinkConfig extends MilvusCommonConfig {
                     .mapType()
                     .defaultValue(new HashMap<>())
                     .withDescription("bulk writer config");
-    public static final Option<Integer> WRITER_CACHE =
-            Options.key("writer_cache")
+    public static final Option<Integer> TOTAL_COUNT =
+            Options.key("total_count")
                     .intType()
-                    .defaultValue(500000)
-                    .withDescription("max cache allowed");
+                    .noDefaultValue()
+                    .withDescription("num of rows to be inserted");
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
@@ -94,6 +94,9 @@ public class MilvusSinkConverter {
             case ARRAY:
                 ArrayType<?, ?> arrayType = (ArrayType<?, ?>) fieldType;
                 switch (arrayType.getElementType().getSqlType()) {
+                    case BOOLEAN:
+                        Boolean[] booleanArray = (Boolean[]) value;
+                        return Arrays.asList(booleanArray);
                     case STRING:
                         String[] stringArray = (String[]) value;
                         return Arrays.asList(stringArray);

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
@@ -165,24 +165,20 @@ public class MilvusSinkConverter {
                         && (Boolean) column.getOptions().get(CommonOptions.JSON.getName())) {
                     // check if is json
                     fieldSchema.setDataType(io.milvus.v2.common.DataType.JSON);
-                } else if (column.getColumnLength() == null || column.getColumnLength() == 0) {
-                    fieldSchema.setMaxLength(65535);
+                } else if (column.getOptions()!= null && column.getOptions().get(CommonOptions.MAX_LENGTH.getName()) != null) {
+                    fieldSchema.setMaxLength((Integer) column.getOptions().get(CommonOptions.MAX_LENGTH.getName()));
                 } else {
-                    fieldSchema.setMaxLength(column.getColumnLength().intValue());
+                    fieldSchema.setMaxLength(65535);
                 }
                 break;
             case ARRAY:
-                ArrayType arrayType = (ArrayType) column.getDataType();
-                SeaTunnelDataType elementType = arrayType.getElementType();
-                fieldSchema.setElementType(convertSqlTypeToDataType(elementType.getSqlType()));
-                fieldSchema.setMaxCapacity(4095);
-                if (Objects.requireNonNull(elementType.getSqlType()) == SqlType.STRING) {
-                    if (column.getColumnLength() == null || column.getColumnLength() == 0) {
-                        fieldSchema.setMaxLength(65535);
-                    } else {
-                        fieldSchema.setMaxLength((int) (column.getColumnLength() / 4));
-                    }
-                }
+                fieldSchema.setDataType(io.milvus.v2.common.DataType.Array);
+                Integer elementType = (Integer) column.getOptions().get(CommonOptions.ELEMENT_TYPE.getName());
+                fieldSchema.setElementType(io.milvus.v2.common.DataType.forNumber(elementType));
+                Integer maxCapacity = (Integer) column.getOptions().get(CommonOptions.MAX_CAPACITY.getName());
+                Integer maxLength = (Integer) column.getOptions().get(CommonOptions.MAX_LENGTH.getName());
+                fieldSchema.setMaxCapacity(maxCapacity);
+                fieldSchema.setMaxLength(maxLength);
                 break;
             case BINARY_VECTOR:
             case FLOAT_VECTOR:

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
@@ -83,7 +83,7 @@ public class MilvusBufferBatchWriter implements MilvusWriter {
         this.descriptionCollectionResp = describeCollectionResp;
         Gson gson = new Gson();
         Type type = new TypeToken<List<MilvusField>>() {}.getType();
-        this.milvusFields = gson.fromJson(config.get(EXTRACT_DYNAMIC).toString(), type);
+        this.milvusFields = gson.fromJson(gson.toJson(config.get(EXTRACT_DYNAMIC)), type);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
@@ -91,7 +91,7 @@ public class MilvusBufferBatchWriter implements MilvusWriter {
         // put data to cache by partition
         JsonObject data =
                 milvusSinkConverter.buildMilvusData(
-                        catalogTable, descriptionCollectionResp.getAutoID(), descriptionCollectionResp.getEnableDynamicField(), jsonFieldNames, dynamicFieldName, milvusFields, element);
+                        catalogTable, descriptionCollectionResp, jsonFieldNames, dynamicFieldName, milvusFields, element);
         milvusDataCache.add(data);
         writeCache.incrementAndGet();
         writeCount.incrementAndGet();

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
@@ -107,8 +107,7 @@ public class MilvusBulkWriter implements MilvusWriter {
     @Override
     public void write(SeaTunnelRow element) throws IOException, InterruptedException {
         JsonObject data = milvusSinkConverter.buildMilvusData(
-                        catalogTable, describeCollectionResp.getAutoID(),
-                describeCollectionResp.getEnableDynamicField(), jsonFieldNames, dynamicFieldName, milvusFields, element);
+                        catalogTable, describeCollectionResp, jsonFieldNames, dynamicFieldName, milvusFields, element);
         remoteBulkWriter.appendRow(data);
         writeCache.incrementAndGet();
         writeCount.incrementAndGet();

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
@@ -65,7 +65,7 @@ public class MilvusBulkWriter implements MilvusWriter {
 
         Gson gson = new Gson();
         Type type = new TypeToken<List<MilvusField>>() {}.getType();
-        this.milvusFields = gson.fromJson(config.get(EXTRACT_DYNAMIC).toString(), type);
+        this.milvusFields = gson.fromJson(gson.toJson(config.get(EXTRACT_DYNAMIC)), type);
 
         String collectionName = catalogTable.getTablePath().getTableName();
         StorageConnectParam storageConnectParam;

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
@@ -127,7 +127,6 @@ public class MilvusBulkWriter implements MilvusWriter {
         remoteBulkWriter.close();
         if(remoteBulkWriter.getBatchFiles().isEmpty()){
             log.warn("No data uploaded to remote");
-            return;
         }
         if(stageBucket.getAutoImport()) {
             String object = remoteBulkWriter.getBatchFiles().get(0).get(0);

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
@@ -297,8 +297,27 @@ public class MilvusSourceConverter {
                 builder.options(options);
                 break;
             case Array:
-                builder.dataType(ArrayType.STRING_ARRAY_TYPE);
+
                 DataType elementType = fieldSchema.getElementType();
+                if(elementType == DataType.Bool){
+                    builder.dataType(ArrayType.BOOLEAN_ARRAY_TYPE);
+                }else if(elementType == DataType.Int8){
+                    builder.dataType(ArrayType.BYTE_ARRAY_TYPE);
+                }else if(elementType == DataType.Int16){
+                    builder.dataType(ArrayType.SHORT_ARRAY_TYPE);
+                }else if(elementType == DataType.Int32){
+                    builder.dataType(ArrayType.INT_ARRAY_TYPE);
+                }else if(elementType == DataType.Int64){
+                    builder.dataType(ArrayType.LONG_ARRAY_TYPE);
+                }else if(elementType == DataType.Float){
+                    builder.dataType(ArrayType.FLOAT_ARRAY_TYPE);
+                }else if(elementType == DataType.Double){
+                    builder.dataType(ArrayType.DOUBLE_ARRAY_TYPE);
+                }else if(elementType == DataType.VarChar){
+                    builder.dataType(ArrayType.STRING_ARRAY_TYPE);
+                }else {
+                    builder.dataType(ArrayType.STRING_ARRAY_TYPE);
+                }
                 optionsMap.put(CommonOptions.ELEMENT_TYPE.getName(), elementType.getCode());
                 optionsMap.put(CommonOptions.MAX_CAPACITY.getName(), fieldSchema.getMaxCapacity());
                 optionsMap.put(CommonOptions.MAX_LENGTH.getName(), fieldSchema.getMaxLength());

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
@@ -259,7 +259,7 @@ public class MilvusSourceConverter {
         builder.name(fieldSchema.getName());
         builder.sourceType(dataType.name());
         builder.comment(fieldSchema.getDescription());
-
+        Map<String, Object> optionsMap = new HashMap<>();
         switch (dataType) {
             case Bool:
                 builder.dataType(BasicType.BOOLEAN_TYPE);
@@ -284,7 +284,8 @@ public class MilvusSourceConverter {
                 break;
             case VarChar:
                 builder.dataType(BasicType.STRING_TYPE);
-                builder.columnLength((long)fieldSchema.getMaxLength());
+                optionsMap.put(CommonOptions.MAX_LENGTH.getName(), fieldSchema.getMaxLength());
+                builder.options(optionsMap);
                 break;
             case String:
                 builder.dataType(BasicType.STRING_TYPE);
@@ -297,6 +298,11 @@ public class MilvusSourceConverter {
                 break;
             case Array:
                 builder.dataType(ArrayType.STRING_ARRAY_TYPE);
+                DataType elementType = fieldSchema.getElementType();
+                optionsMap.put(CommonOptions.ELEMENT_TYPE.getName(), elementType.getCode());
+                optionsMap.put(CommonOptions.MAX_CAPACITY.getName(), fieldSchema.getMaxCapacity());
+                optionsMap.put(CommonOptions.MAX_LENGTH.getName(), fieldSchema.getMaxLength());
+                builder.options(optionsMap);
                 break;
             case FloatVector:
                 builder.dataType(VectorType.VECTOR_FLOAT_TYPE);


### PR DESCRIPTION
- **update shade**
- **update jdk**
- **field mapper support primary key rename**
- **fix**
- **separate close and wait job**
- **support is null for bulk writer**
- **support tls for milvus**
- **support maxCapacity and maxlength for array**
- **fix json string parse for extract dynamic**
- **throw exception if no data saved**
- **fix array convert for milvus**
- **support bool array**
- **skip id data if autoid is enabled**
