### PR TITLE
Set primary key field maxlength same with source field fix issue: #120

### DIFF
--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSchemaConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSchemaConverter.java
@@ -192,7 +192,9 @@ public class MilvusSchemaConverter {
                 fieldSchema.setDataType(io.milvus.v2.common.DataType.Int64);
             } else {
                 fieldSchema.setDataType(io.milvus.v2.common.DataType.VarChar);
-                fieldSchema.setMaxLength(65535);
+                if(Objects.isNull(fieldSchema.getMaxLength())){
+                    fieldSchema.setMaxLength(65535);
+                }
             }
         }
 


### PR DESCRIPTION
fix #120  [Primary key field is always being converted to VarChar(65535) after transfer](https://github.com/zilliztech/vts/issues/120)
set primary key field maxlength same with source field.