### PR TITLE
[Fix][Connector-Milvus] filter index on non-existent target fields an…

### DIFF
--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
@@ -30,8 +30,10 @@ import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusSchemaC
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -53,20 +55,15 @@ public class CatalogUtils {
         if (config.get(FIELD_SCHEMA) != null && !config.get(FIELD_SCHEMA).isEmpty()) {
             Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
             for (Object field : config.get(FIELD_SCHEMA)) {
-                try {
-                    Type type = new TypeToken<MilvusFieldSchema>() {
-                    }.getType();
-                    String json = gson.toJson(field);
-                    MilvusFieldSchema fieldSchema = gson.fromJson(json, type);
-                    if (fieldSchema != null) {
-                        String key = fieldSchema.getEffectiveFieldName();
-                        if (key != null) {
-                            schemaMap.put(key, fieldSchema);
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Failed to parse field schema: {}, error: {}", field, e.getMessage());
+                Type type = new TypeToken<MilvusFieldSchema>() {
+                }.getType();
+                String json = gson.toJson(field);
+                MilvusFieldSchema fieldSchema = gson.fromJson(json, type);
+                if (fieldSchema == null || fieldSchema.getEffectiveFieldName() == null) {
+                    throw new MilvusConnectorException(MilvusConnectionErrorCode.CREATE_COLLECTION_ERROR,
+                            "Invalid field_schema entry, missing field name: " + field);
                 }
+                schemaMap.put(fieldSchema.getEffectiveFieldName(), fieldSchema);
             }
             log.info("Loaded field_schema config for {} fields", schemaMap.size());
         }
@@ -75,58 +72,126 @@ public class CatalogUtils {
     }
 
     void createIndex(TablePath tablePath, CatalogTable catalogTable) {
-        Map<String, String> options = catalogTable.getOptions();
-
-        List<IndexParam> indexParams = new ArrayList<>();
-
-        // Check if there are existing indexes from source metadata in options
-        if (options.containsKey(MilvusConstants.INDEX_LIST)) {
-            String indexListStr = options.get(MilvusConstants.INDEX_LIST);
-            if (StringUtils.isNotEmpty(indexListStr) && !indexListStr.equals("[]")) {
-                try {
-                    Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
-                    Type indexListType = new TypeToken<List<Map<String, String>>>() {
-                    }.getType();
-                    List<Map<String, String>> indexes = gson.fromJson(indexListStr, indexListType);
-
-                    if (indexes != null && !indexes.isEmpty()) {
-                        for (Map<String, String> indexInfo : indexes) {
-
-                            IndexParam.MetricType metricType = indexInfo.containsKey("metricType")
-                                    ? IndexParam.MetricType.valueOf(indexInfo.get("metricType"))
-                                    : null;
-
-                            IndexParam.IndexType indexType;
-                            try {
-                                indexType = IndexParam.IndexType.valueOf(indexInfo.get("indexType"));
-                            } catch (Exception e) {
-                                log.warn("Unknown index type: {}, using default AUTOINDEX", indexInfo.get("indexType"));
-                                indexType = IndexParam.IndexType.AUTOINDEX;
-                            }
-
-                            IndexParam indexParam = IndexParam.builder()
-                                    .fieldName(indexInfo.get("fieldName"))
-                                    .metricType(metricType)
-                                    .indexType(indexType)
-                                    .indexName(indexInfo.get("indexName"))
-                                    .build();
-                            indexParams.add(indexParam);
-                            log.info("Using existing index from source: {}", indexInfo);
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Failed to parse index list from options: {}, error: {}", indexListStr, e.getMessage());
-                }
-            }
-        }
+        List<IndexParam> indexParams = parseIndexParamsFromSource(catalogTable);
 
         log.info("indexParams: {}", indexParams);
-        // create index
         CreateIndexReq createIndexReq = CreateIndexReq.builder()
                 .collectionName(tablePath.getTableName())
                 .indexParams(indexParams)
                 .build();
         this.client.createIndex(createIndexReq);
+    }
+
+    List<IndexParam> parseIndexParamsFromSource(CatalogTable catalogTable) {
+        List<IndexParam> indexParams = new ArrayList<>();
+        Map<String, String> options = catalogTable.getOptions();
+
+        String indexListStr = options.get(MilvusConstants.INDEX_LIST);
+        if (StringUtils.isEmpty(indexListStr) || indexListStr.equals("[]")) {
+            return indexParams;
+        }
+
+        Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
+        List<Map<String, String>> indexes;
+        Type indexListType = new TypeToken<List<Map<String, String>>>() {}.getType();
+        indexes = gson.fromJson(indexListStr, indexListType);
+
+        if (indexes == null || indexes.isEmpty()) {
+            return indexParams;
+        }
+
+        Set<String> targetFieldNames = collectTargetFieldNames(catalogTable);
+        Set<String> sourceFieldNames = collectSourceFieldNames(catalogTable);
+        boolean enableDynamicField = getEnableDynamicField(options);
+        Type extraParamsType = new TypeToken<Map<String, Object>>() {}.getType();
+
+        for (Map<String, String> indexInfo : indexes) {
+            IndexParam indexParam = buildIndexParam(indexInfo, targetFieldNames, sourceFieldNames, enableDynamicField, gson, extraParamsType);
+            if (indexParam != null) {
+                indexParams.add(indexParam);
+                log.info("Using existing index from source: {}", indexInfo);
+            }
+        }
+
+        return indexParams;
+    }
+
+    /**
+     * Collect all non-metadata column names from the source schema.
+     * Used to distinguish explicit source fields from dynamic field keys.
+     */
+    Set<String> collectSourceFieldNames(CatalogTable catalogTable) {
+        Set<String> sourceFieldNames = new HashSet<>();
+        for (Column col : catalogTable.getTableSchema().getColumns()) {
+            if (col.getOptions() != null
+                    && col.getOptions().containsKey(CommonOptions.METADATA.getName())
+                    && Boolean.TRUE.equals(col.getOptions().get(CommonOptions.METADATA.getName()))) {
+                continue;
+            }
+            sourceFieldNames.add(col.getName());
+        }
+        return sourceFieldNames;
+    }
+
+    Set<String> collectTargetFieldNames(CatalogTable catalogTable) {
+        if (!fieldSchemaMap.isEmpty()) {
+            return new HashSet<>(fieldSchemaMap.keySet());
+        }
+        return collectSourceFieldNames(catalogTable);
+    }
+
+    IndexParam buildIndexParam(Map<String, String> indexInfo, Set<String> targetFieldNames,
+            Set<String> sourceFieldNames, boolean enableDynamicField, Gson gson, Type extraParamsType) {
+        String fieldName = indexInfo.get("fieldName");
+        if (fieldName == null) {
+            throw new MilvusConnectorException(MilvusConnectionErrorCode.CREATE_INDEX_ERROR,
+                    "Index has null fieldName: " + indexInfo);
+        }
+        if (!targetFieldNames.isEmpty() && !targetFieldNames.contains(fieldName)) {
+            if (sourceFieldNames.contains(fieldName)) {
+                // Field exists in source explicit schema but not synced to target — skip
+                log.info("Skipping index '{}' on field '{}': source schema field not synced to target",
+                        indexInfo.get("indexName"), fieldName);
+                return null;
+            } else if (enableDynamicField) {
+                // Field not in any explicit schema — dynamic field index, data lives in $meta
+                log.info("Index '{}' on field '{}' not in explicit schema, allowing as dynamic field index",
+                        indexInfo.get("indexName"), fieldName);
+            } else {
+                log.info("Skipping index '{}' on field '{}': field not present in target schema",
+                        indexInfo.get("indexName"), fieldName);
+                return null;
+            }
+        }
+
+        IndexParam.MetricType metricType = indexInfo.containsKey("metricType")
+                ? IndexParam.MetricType.valueOf(indexInfo.get("metricType"))
+                : null;
+
+        IndexParam.IndexType indexType;
+        try {
+            indexType = IndexParam.IndexType.valueOf(indexInfo.get("indexType"));
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown index type: {}, using default AUTOINDEX", indexInfo.get("indexType"));
+            indexType = IndexParam.IndexType.AUTOINDEX;
+        }
+
+        IndexParam.IndexParamBuilder builder = IndexParam.builder()
+                .fieldName(fieldName)
+                .metricType(metricType)
+                .indexType(indexType)
+                .indexName(indexInfo.get("indexName"));
+
+        // Parse and apply extraParams if present
+        if (indexInfo.containsKey("extraParams") && StringUtils.isNotEmpty(indexInfo.get("extraParams"))) {
+            Map<String, Object> extraParams = gson.fromJson(indexInfo.get("extraParams"), extraParamsType);
+            if (extraParams != null && !extraParams.isEmpty()) {
+                builder.extraParams(extraParams);
+                log.debug("Applied extraParams for index '{}': {}", indexInfo.get("indexName"), extraParams);
+            }
+        }
+
+        return builder.build();
     }
 
     void createTableInternal(TablePath tablePath, CatalogTable catalogTable) {
@@ -188,7 +253,7 @@ public class CatalogUtils {
         for (Column column : tableSchema.getColumns()) {
             if (column.getOptions() != null
                     && column.getOptions().containsKey(CommonOptions.METADATA.getName())
-                    && (Boolean) column.getOptions().get(CommonOptions.METADATA.getName())) {
+                    && Boolean.TRUE.equals(column.getOptions().get(CommonOptions.METADATA.getName()))) {
                 // skip dynamic field
                 continue;
             }
@@ -245,10 +310,10 @@ public class CatalogUtils {
         // 5. Function List - source first, then merge/add from config
         List<CreateCollectionReq.Function> functionList = getFunctionList(options, gson);
 
-        // 5. Struct Fields - passed from caller (already collected from source/config)
+        // 6. Struct Fields - passed from caller (already collected from source/config)
         log.info("Creating collection with {} struct fields", structFields.size());
 
-        // 6. Shard Number - source first, then config override (handled later in
+        // 7. Shard Number - source first, then config override (handled later in
         // createCollectionReq)
         // Build collection schema
         CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
@@ -523,38 +588,29 @@ public class CatalogUtils {
         if (options.containsKey(MilvusConstants.FUNCTION_LIST)) {
             String functionListStr = options.get(MilvusConstants.FUNCTION_LIST);
             if (StringUtils.isNotEmpty(functionListStr) && !functionListStr.equals("[]")) {
-                try {
-                    Type functionListType = new TypeToken<List<CreateCollectionReq.Function>>() {
-                    }.getType();
-                    List<CreateCollectionReq.Function> functionsFromSource = gson.fromJson(functionListStr,
-                            functionListType);
-                    if (functionsFromSource != null) {
-                        functionList = functionsFromSource;
-                        log.info("Loaded {} functions from source", functionsFromSource.size());
-                    }
-                } catch (Exception e) {
-                    log.warn("Failed to parse functionList from source: {}, error: {}", functionListStr,
-                            e.getMessage());
+                Type functionListType = new TypeToken<List<CreateCollectionReq.Function>>() {
+                }.getType();
+                List<CreateCollectionReq.Function> functionsFromSource = gson.fromJson(functionListStr,
+                        functionListType);
+                if (functionsFromSource != null) {
+                    functionList = functionsFromSource;
+                    log.info("Loaded {} functions from source", functionsFromSource.size());
                 }
             }
         }
 
         // Merge/add functions from config (additive, not override)
         if (config.get(MilvusSinkConfig.functionList) != null && !config.get(MilvusSinkConfig.functionList).isEmpty()) {
-            try {
-                List<Object> functionsFromConfigRaw = config.get(MilvusSinkConfig.functionList);
-                Type functionListType = new TypeToken<List<CreateCollectionReq.Function>>() {
-                }.getType();
-                String functionListStr = gson.toJson(functionsFromConfigRaw);
-                List<CreateCollectionReq.Function> functionsFromConfig = gson.fromJson(functionListStr,
-                        functionListType);
-                if (functionsFromConfig != null) {
-                    functionList = functionsFromConfig;
-                    log.info("Added {} functions from config, total: {}", functionsFromConfig.size(),
-                            functionList.size());
-                }
-            } catch (Exception e) {
-                log.warn("Failed to parse functionList from config, error: {}", e.getMessage());
+            List<Object> functionsFromConfigRaw = config.get(MilvusSinkConfig.functionList);
+            Type functionListType = new TypeToken<List<CreateCollectionReq.Function>>() {
+            }.getType();
+            String functionListStr = gson.toJson(functionsFromConfigRaw);
+            List<CreateCollectionReq.Function> functionsFromConfig = gson.fromJson(functionListStr,
+                    functionListType);
+            if (functionsFromConfig != null) {
+                functionList = functionsFromConfig;
+                log.info("Added {} functions from config, total: {}", functionsFromConfig.size(),
+                        functionList.size());
             }
         }
 
@@ -575,34 +631,30 @@ public class CatalogUtils {
             if (column.getOptions() != null && column.getOptions().containsKey(MilvusConstants.STRUCT_FIELDS)) {
                 String structFieldsJson = (String) column.getOptions().get(MilvusConstants.STRUCT_FIELDS);
                 if (StringUtils.isNotEmpty(structFieldsJson) && !structFieldsJson.equals("[]")) {
-                    try {
-                        // Parse the nested fields from the struct
-                        Type nestedFieldsType = new TypeToken<List<CreateCollectionReq.FieldSchema>>() {
-                        }.getType();
-                        List<CreateCollectionReq.FieldSchema> nestedFields = gson.fromJson(structFieldsJson,
-                                nestedFieldsType);
+                    // Parse the nested fields from the struct
+                    Type nestedFieldsType = new TypeToken<List<CreateCollectionReq.FieldSchema>>() {
+                    }.getType();
+                    List<CreateCollectionReq.FieldSchema> nestedFields = gson.fromJson(structFieldsJson,
+                            nestedFieldsType);
 
-                        if (nestedFields != null && !nestedFields.isEmpty()) {
-                            // Create a StructFieldSchema for this Array[Struct] field
-                            CreateCollectionReq.StructFieldSchema structFieldSchema = CreateCollectionReq.StructFieldSchema
-                                    .builder()
-                                    .name(column.getName())
-                                    .description(column.getComment() != null ? column.getComment() : "")
-                                    .fields(nestedFields)
-                                    .build();
+                    if (nestedFields != null && !nestedFields.isEmpty()) {
+                        // Create a StructFieldSchema for this Array[Struct] field
+                        CreateCollectionReq.StructFieldSchema structFieldSchema = CreateCollectionReq.StructFieldSchema
+                                .builder()
+                                .name(column.getName())
+                                .description(column.getComment() != null ? column.getComment() : "")
+                                .fields(nestedFields)
+                                .build();
 
-                            // Set maxCapacity if available
-                            if (column.getOptions().containsKey(MilvusConstants.MAX_CAPACITY)) {
-                                Integer maxCapacity = (Integer) column.getOptions().get(MilvusConstants.MAX_CAPACITY);
-                                structFieldSchema.setMaxCapacity(maxCapacity);
-                            }
-
-                            structFieldsList.add(structFieldSchema);
-                            log.info("Extracted struct field from column: {} with {} nested fields",
-                                    column.getName(), nestedFields.size());
+                        // Set maxCapacity if available
+                        if (column.getOptions().containsKey(MilvusConstants.MAX_CAPACITY)) {
+                            Integer maxCapacity = (Integer) column.getOptions().get(MilvusConstants.MAX_CAPACITY);
+                            structFieldSchema.setMaxCapacity(maxCapacity);
                         }
-                    } catch (Exception e) {
-                        log.warn("Failed to parse struct fields from column {}: {}", column.getName(), e.getMessage());
+
+                        structFieldsList.add(structFieldSchema);
+                        log.info("Extracted struct field from column: {} with {} nested fields",
+                                column.getName(), nestedFields.size());
                     }
                 }
             }

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/MilvusCatalog.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/MilvusCatalog.java
@@ -170,11 +170,16 @@ public class MilvusCatalog implements Catalog {
         checkNotNull(catalogTable, "catalogTable must not be null");
         TableSchema tableSchema = catalogTable.getTableSchema();
         checkNotNull(tableSchema, "tableSchema must not be null");
-        catalogUtils.createTableInternal(tablePath, catalogTable);
-        log.info("create table: {} success", tablePath.getTableName());
-        log.info("create index for table: {}", tablePath.getTableName());
-        catalogUtils.createIndex(tablePath, catalogTable);
-        log.info("create index for table: {} success", tablePath.getTableName());
+        try {
+            catalogUtils.createTableInternal(tablePath, catalogTable);
+            log.info("create table: {} success", tablePath.getTableName());
+            log.info("create index for table: {}", tablePath.getTableName());
+            catalogUtils.createIndex(tablePath, catalogTable);
+            log.info("create index for table: {} success", tablePath.getTableName());
+        } catch (Exception e) {
+            throw new CatalogException(
+                    String.format("Failed to create table %s", tablePath.getTableName()), e);
+        }
     }
 
 

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
@@ -149,15 +149,11 @@ public class MilvusSourceConnectorUtils {
         options.put(MilvusConstants.ENABLE_AUTO_ID, String.valueOf(describeCollectionResp.getAutoID()));
         options.put(MilvusConstants.CONSISTENCY_LEVEL,
                 String.valueOf(describeCollectionResp.getConsistencyLevel().getName()));
+        com.google.gson.Gson gson = new com.google.gson.Gson();
+
         // Serialize functionList as JSON for proper reconstruction in sink
         if (functionList != null && !functionList.isEmpty()) {
-            try {
-                com.google.gson.Gson gson = new com.google.gson.Gson();
-                options.put(MilvusConstants.FUNCTION_LIST, gson.toJson(functionList));
-            } catch (Exception e) {
-                log.warn("Failed to serialize functionList, setting empty list. Error: {}", e.getMessage());
-                options.put(MilvusConstants.FUNCTION_LIST, "[]");
-            }
+            options.put(MilvusConstants.FUNCTION_LIST, gson.toJson(functionList));
         } else {
             options.put(MilvusConstants.FUNCTION_LIST, "[]");
         }
@@ -167,36 +163,28 @@ public class MilvusSourceConnectorUtils {
 
         // Serialize vector index info as JSON for proper reconstruction in sink
         List<Object> indexList = new ArrayList<>();
-        try {
-            List<String> indexes = client.listIndexes(ListIndexesReq.builder().collectionName(collection).build());
-            for (String index : indexes) {
-                DescribeIndexReq describeIndexReq = DescribeIndexReq.builder()
-                        .collectionName(collection)
-                        .indexName(index)
-                        .build();
-                try {
-                    DescribeIndexResp describeIndexResp = client.describeIndex(describeIndexReq);
-                    for (DescribeIndexResp.IndexDesc indexDesc : describeIndexResp.getIndexDescriptions()) {
-                        Map<String, String> indexInfo = new HashMap<>();
-                        indexInfo.put("fieldName", indexDesc.getFieldName());
-                        indexInfo.put("indexName", indexDesc.getIndexName());
-                        indexInfo.put("indexType", indexDesc.getIndexType().getName());
-                        if (indexDesc.getMetricType() != MetricType.INVALID) {
-                            indexInfo.put("metricType", indexDesc.getMetricType().name());
-                        }
-                        indexList.add(indexInfo);
-                    }
-                } catch (Exception e) {
-                    log.info("describe index error, maybe index not exist {}", e.getMessage());
-                    continue;
+        List<String> indexes = client.listIndexes(ListIndexesReq.builder().collectionName(collection).build());
+        for (String index : indexes) {
+            DescribeIndexReq describeIndexReq = DescribeIndexReq.builder()
+                    .collectionName(collection)
+                    .indexName(index)
+                    .build();
+            DescribeIndexResp describeIndexResp = client.describeIndex(describeIndexReq);
+            for (DescribeIndexResp.IndexDesc indexDesc : describeIndexResp.getIndexDescriptions()) {
+                Map<String, String> indexInfo = new HashMap<>();
+                indexInfo.put("fieldName", indexDesc.getFieldName());
+                indexInfo.put("indexName", indexDesc.getIndexName());
+                indexInfo.put("indexType", indexDesc.getIndexType().getName());
+                if (indexDesc.getMetricType() != MetricType.INVALID) {
+                    indexInfo.put("metricType", indexDesc.getMetricType().name());
                 }
+                if (indexDesc.getExtraParams() != null && !indexDesc.getExtraParams().isEmpty()) {
+                    indexInfo.put("extraParams", gson.toJson(indexDesc.getExtraParams()));
+                }
+                indexList.add(indexInfo);
             }
-            com.google.gson.Gson gson = new com.google.gson.Gson();
-            options.put(MilvusConstants.INDEX_LIST, gson.toJson(indexList));
-        } catch (Exception e) {
-            log.warn("Failed to get index info, setting empty list. Error: {}", e.getMessage());
-            options.put(MilvusConstants.INDEX_LIST, "[]");
         }
+        options.put(MilvusConstants.INDEX_LIST, gson.toJson(indexList));
         options.put(MilvusConstants.SHARDS_NUM, String.valueOf(describeCollectionResp.getShardsNum()));
         if (describeCollectionResp.getProperties() != null
                 && describeCollectionResp.getProperties().containsKey(MilvusConstants.TIMEZONE)) {

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtilsTest.java
@@ -1,0 +1,512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
+import io.milvus.v2.common.IndexParam;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.CommonOptions;
+import org.apache.seatunnel.api.table.type.VectorType;
+import org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CatalogUtilsTest {
+
+    private CatalogUtils catalogUtils;
+    private final Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
+    private final Type extraParamsType = new TypeToken<Map<String, Object>>() {}.getType();
+
+    @BeforeEach
+    void setUp() {
+        // Create CatalogUtils with null client and empty config (no field_schema)
+        ReadonlyConfig config = ReadonlyConfig.fromMap(new HashMap<>());
+        catalogUtils = new CatalogUtils(null, config);
+    }
+
+    // ========================
+    // collectSourceFieldNames
+    // ========================
+
+    @Test
+    void testCollectSourceFieldNames_regularColumns() {
+        CatalogTable table = buildCatalogTable(
+                List.of(
+                        buildColumn("id", BasicType.LONG_TYPE, null),
+                        buildColumn("name", BasicType.STRING_TYPE, null),
+                        buildColumn("vec", VectorType.VECTOR_FLOAT_TYPE, null)
+                ),
+                new HashMap<>()
+        );
+
+        Set<String> result = catalogUtils.collectSourceFieldNames(table);
+        Assertions.assertEquals(Set.of("id", "name", "vec"), result);
+    }
+
+    @Test
+    void testCollectSourceFieldNames_skipsMetadataColumns() {
+        Map<String, Object> metaOptions = new HashMap<>();
+        metaOptions.put(CommonOptions.METADATA.getName(), true);
+
+        CatalogTable table = buildCatalogTable(
+                List.of(
+                        buildColumn("id", BasicType.LONG_TYPE, null),
+                        buildColumn("$meta", BasicType.STRING_TYPE, metaOptions)
+                ),
+                new HashMap<>()
+        );
+
+        Set<String> result = catalogUtils.collectSourceFieldNames(table);
+        Assertions.assertEquals(Set.of("id"), result);
+    }
+
+    @Test
+    void testCollectSourceFieldNames_metadataFalseNotSkipped() {
+        Map<String, Object> metaOptions = new HashMap<>();
+        metaOptions.put(CommonOptions.METADATA.getName(), false);
+
+        CatalogTable table = buildCatalogTable(
+                List.of(
+                        buildColumn("id", BasicType.LONG_TYPE, null),
+                        buildColumn("dynamic", BasicType.STRING_TYPE, metaOptions)
+                ),
+                new HashMap<>()
+        );
+
+        Set<String> result = catalogUtils.collectSourceFieldNames(table);
+        Assertions.assertEquals(Set.of("id", "dynamic"), result);
+    }
+
+    @Test
+    void testCollectSourceFieldNames_nullOptions() {
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("id", BasicType.LONG_TYPE, null)),
+                new HashMap<>()
+        );
+
+        Set<String> result = catalogUtils.collectSourceFieldNames(table);
+        Assertions.assertEquals(Set.of("id"), result);
+    }
+
+    // ========================
+    // collectTargetFieldNames
+    // ========================
+
+    @Test
+    void testCollectTargetFieldNames_noFieldSchemaConfig_fallsBackToSource() {
+        // catalogUtils has empty fieldSchemaMap (default setUp)
+        CatalogTable table = buildCatalogTable(
+                List.of(
+                        buildColumn("id", BasicType.LONG_TYPE, null),
+                        buildColumn("vec", VectorType.VECTOR_FLOAT_TYPE, null)
+                ),
+                new HashMap<>()
+        );
+
+        Set<String> result = catalogUtils.collectTargetFieldNames(table);
+        Assertions.assertEquals(Set.of("id", "vec"), result);
+    }
+
+    @Test
+    void testCollectTargetFieldNames_withFieldSchemaConfig() {
+        // Create CatalogUtils with field_schema config
+        // MilvusFieldSchema uses @SerializedName("field_name") for fieldName
+        Map<String, Object> fieldSchema = new HashMap<>();
+        fieldSchema.put("field_name", "target_id");
+        fieldSchema.put("data_type", 5); // Int64
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("field_schema", List.of(fieldSchema));
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        CatalogUtils utilsWithSchema = new CatalogUtils(null, config);
+
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("id", BasicType.LONG_TYPE, null)),
+                new HashMap<>()
+        );
+
+        Set<String> result = utilsWithSchema.collectTargetFieldNames(table);
+        Assertions.assertTrue(result.contains("target_id"));
+        Assertions.assertFalse(result.contains("id"));
+    }
+
+    // ========================
+    // buildIndexParam
+    // ========================
+
+    @Test
+    void testBuildIndexParam_fieldInTarget_returnsIndex() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "vec");
+        indexInfo.put("indexName", "vec_idx");
+        indexInfo.put("indexType", "HNSW");
+        indexInfo.put("metricType", "COSINE");
+
+        Set<String> targetFields = Set.of("id", "vec");
+        Set<String> sourceFields = Set.of("id", "vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, sourceFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("vec", result.getFieldName());
+        Assertions.assertEquals("vec_idx", result.getIndexName());
+        Assertions.assertEquals(IndexParam.IndexType.HNSW, result.getIndexType());
+        Assertions.assertEquals(IndexParam.MetricType.COSINE, result.getMetricType());
+    }
+
+    @Test
+    void testBuildIndexParam_fieldNotInTarget_sourceField_skipped() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "old_vec");
+        indexInfo.put("indexName", "old_vec_idx");
+        indexInfo.put("indexType", "HNSW");
+        indexInfo.put("metricType", "L2");
+
+        Set<String> targetFields = Set.of("id", "new_vec");
+        Set<String> sourceFields = Set.of("id", "old_vec", "new_vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, sourceFields, false, gson, extraParamsType);
+
+        Assertions.assertNull(result, "Should skip index on source-only field not synced to target");
+    }
+
+    @Test
+    void testBuildIndexParam_dynamicFieldIndex_enableDynamic_allowed() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "dynamic_field");
+        indexInfo.put("indexName", "dyn_idx");
+        indexInfo.put("indexType", "INVERTED");
+
+        Set<String> targetFields = Set.of("id", "vec");
+        Set<String> sourceFields = Set.of("id", "vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, sourceFields, true, gson, extraParamsType);
+
+        Assertions.assertNotNull(result, "Dynamic field index should be allowed when enableDynamicField=true");
+        Assertions.assertEquals("dynamic_field", result.getFieldName());
+    }
+
+    @Test
+    void testBuildIndexParam_dynamicFieldIndex_disableDynamic_skipped() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "dynamic_field");
+        indexInfo.put("indexName", "dyn_idx");
+        indexInfo.put("indexType", "INVERTED");
+
+        Set<String> targetFields = Set.of("id", "vec");
+        Set<String> sourceFields = Set.of("id", "vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, sourceFields, false, gson, extraParamsType);
+
+        Assertions.assertNull(result, "Dynamic field index should be skipped when enableDynamicField=false");
+    }
+
+    @Test
+    void testBuildIndexParam_nullFieldName_throwsException() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", null);
+        indexInfo.put("indexName", "idx");
+        indexInfo.put("indexType", "HNSW");
+
+        Assertions.assertThrows(MilvusConnectorException.class, () ->
+                catalogUtils.buildIndexParam(indexInfo, Set.of("id"), Set.of("id"), false, gson, extraParamsType));
+    }
+
+    @Test
+    void testBuildIndexParam_emptyTargetFieldNames_skipsFiltering() {
+        // When targetFieldNames is empty, all indexes should pass through
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "any_field");
+        indexInfo.put("indexName", "any_idx");
+        indexInfo.put("indexType", "HNSW");
+        indexInfo.put("metricType", "L2");
+
+        Set<String> emptyTarget = Collections.emptySet();
+        Set<String> emptySource = Collections.emptySet();
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, emptyTarget, emptySource, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result, "Should allow all indexes when targetFieldNames is empty");
+    }
+
+    @Test
+    void testBuildIndexParam_trieIndexType_fallsBackToAutoindex() {
+        // TRIE index type is serialized as "Trie" via getName(), which doesn't match
+        // enum constant name "TRIE", so it falls back to AUTOINDEX
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "varchar_field");
+        indexInfo.put("indexName", "trie_idx");
+        indexInfo.put("indexType", "Trie");
+
+        Set<String> targetFields = Set.of("varchar_field");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, targetFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(IndexParam.IndexType.AUTOINDEX, result.getIndexType(),
+                "Trie (getName) doesn't match TRIE (valueOf), should fall back to AUTOINDEX");
+    }
+
+    @Test
+    void testBuildIndexParam_unknownIndexType_fallsBackToAutoindex() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "vec");
+        indexInfo.put("indexName", "idx");
+        indexInfo.put("indexType", "NONEXISTENT_TYPE");
+        indexInfo.put("metricType", "L2");
+
+        Set<String> targetFields = Set.of("vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, targetFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(IndexParam.IndexType.AUTOINDEX, result.getIndexType(),
+                "Unknown index type should fall back to AUTOINDEX");
+    }
+
+    @Test
+    void testBuildIndexParam_noMetricType_setsNull() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "scalar_field");
+        indexInfo.put("indexName", "scalar_idx");
+        indexInfo.put("indexType", "INVERTED");
+
+        Set<String> targetFields = Set.of("scalar_field");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, targetFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertNull(result.getMetricType());
+    }
+
+    @Test
+    void testBuildIndexParam_withExtraParams() {
+        Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("nlist", 1024);
+        extraParams.put("M", 16);
+
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "vec");
+        indexInfo.put("indexName", "vec_idx");
+        indexInfo.put("indexType", "HNSW");
+        indexInfo.put("metricType", "L2");
+        indexInfo.put("extraParams", gson.toJson(extraParams));
+
+        Set<String> targetFields = Set.of("vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, targetFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(result.getExtraParams());
+        Assertions.assertEquals(16L, ((Number) result.getExtraParams().get("M")).longValue());
+    }
+
+    @Test
+    void testBuildIndexParam_emptyExtraParams_noExtraParamsSet() {
+        Map<String, String> indexInfo = new HashMap<>();
+        indexInfo.put("fieldName", "vec");
+        indexInfo.put("indexName", "vec_idx");
+        indexInfo.put("indexType", "HNSW");
+        indexInfo.put("extraParams", "");
+
+        Set<String> targetFields = Set.of("vec");
+
+        IndexParam result = catalogUtils.buildIndexParam(
+                indexInfo, targetFields, targetFields, false, gson, extraParamsType);
+
+        Assertions.assertNotNull(result);
+    }
+
+    // ========================
+    // parseIndexParamsFromSource (integration)
+    // ========================
+
+    @Test
+    void testParseIndexParamsFromSource_noIndexList() {
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("id", BasicType.LONG_TYPE, null)),
+                new HashMap<>()
+        );
+
+        List<IndexParam> result = catalogUtils.parseIndexParamsFromSource(table);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testParseIndexParamsFromSource_emptyIndexList() {
+        Map<String, String> options = new HashMap<>();
+        options.put(MilvusConstants.INDEX_LIST, "[]");
+
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("id", BasicType.LONG_TYPE, null)),
+                options
+        );
+
+        List<IndexParam> result = catalogUtils.parseIndexParamsFromSource(table);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testParseIndexParamsFromSource_filtersNonTargetFields() {
+        List<Map<String, String>> indexes = new ArrayList<>();
+
+        Map<String, String> idx1 = new HashMap<>();
+        idx1.put("fieldName", "vec");
+        idx1.put("indexName", "vec_idx");
+        idx1.put("indexType", "HNSW");
+        idx1.put("metricType", "L2");
+        indexes.add(idx1);
+
+        Map<String, String> idx2 = new HashMap<>();
+        idx2.put("fieldName", "old_field");
+        idx2.put("indexName", "old_idx");
+        idx2.put("indexType", "INVERTED");
+        indexes.add(idx2);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(MilvusConstants.INDEX_LIST, gson.toJson(indexes));
+        options.put(MilvusConstants.ENABLE_DYNAMIC_FIELD, "false");
+
+        // Source has both fields, but we set up field_schema config for target with only "vec"
+        Map<String, Object> fieldSchema = new HashMap<>();
+        fieldSchema.put("field_name", "vec");
+        fieldSchema.put("data_type", 101); // FloatVector
+        fieldSchema.put("dimension", 128);
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("field_schema", List.of(fieldSchema));
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        CatalogUtils utilsWithSchema = new CatalogUtils(null, config);
+
+        CatalogTable table = buildCatalogTable(
+                List.of(
+                        buildColumn("vec", VectorType.VECTOR_FLOAT_TYPE, null),
+                        buildColumn("old_field", BasicType.STRING_TYPE, null)
+                ),
+                options
+        );
+
+        List<IndexParam> result = utilsWithSchema.parseIndexParamsFromSource(table);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("vec", result.get(0).getFieldName());
+    }
+
+    @Test
+    void testParseIndexParamsFromSource_allowsDynamicFieldIndex() {
+        List<Map<String, String>> indexes = new ArrayList<>();
+
+        Map<String, String> idx1 = new HashMap<>();
+        idx1.put("fieldName", "dyn_key");
+        idx1.put("indexName", "dyn_idx");
+        idx1.put("indexType", "INVERTED");
+        indexes.add(idx1);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(MilvusConstants.INDEX_LIST, gson.toJson(indexes));
+        options.put(MilvusConstants.ENABLE_DYNAMIC_FIELD, "true");
+
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("id", BasicType.LONG_TYPE, null)),
+                options
+        );
+
+        List<IndexParam> result = catalogUtils.parseIndexParamsFromSource(table);
+        // "dyn_key" is not in source fields (only "id" is), and dynamic is enabled
+        // Since target==source (no field_schema), target is {"id"}, so dyn_key is not in target
+        // dyn_key is not in sourceFields either, so it's treated as dynamic field
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("dyn_key", result.get(0).getFieldName());
+    }
+
+    @Test
+    void testParseIndexParamsFromSource_trieIndexTypeFallback() {
+        // Simulates what the source connector serializes for a TRIE index
+        // getName() returns "Trie" which doesn't match valueOf("TRIE"), falls back to AUTOINDEX
+        List<Map<String, String>> indexes = new ArrayList<>();
+
+        Map<String, String> idx = new HashMap<>();
+        idx.put("fieldName", "name");
+        idx.put("indexName", "name_trie");
+        idx.put("indexType", "Trie"); // getName() for TRIE returns "Trie"
+        indexes.add(idx);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(MilvusConstants.INDEX_LIST, gson.toJson(indexes));
+
+        CatalogTable table = buildCatalogTable(
+                List.of(buildColumn("name", BasicType.STRING_TYPE, null)),
+                options
+        );
+
+        List<IndexParam> result = catalogUtils.parseIndexParamsFromSource(table);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(IndexParam.IndexType.AUTOINDEX, result.get(0).getIndexType());
+    }
+
+    // ========================
+    // Helpers
+    // ========================
+
+    private PhysicalColumn buildColumn(String name, org.apache.seatunnel.api.table.type.SeaTunnelDataType<?> dataType,
+                                        Map<String, Object> options) {
+        return PhysicalColumn.of(name, dataType, 0L, true, null, null, null, options);
+    }
+
+    private CatalogTable buildCatalogTable(List<PhysicalColumn> columns, Map<String, String> options) {
+        TableSchema.Builder schemaBuilder = TableSchema.builder();
+        for (PhysicalColumn col : columns) {
+            schemaBuilder.column(col);
+        }
+        return CatalogTable.of(
+                TableIdentifier.of("test", TablePath.of("default", "test_collection")),
+                schemaBuilder.build(),
+                options,
+                new ArrayList<>(),
+                ""
+        );
+    }
+}


### PR DESCRIPTION
- Extract index building logic into testable methods (parseIndexParamsFromSource, buildIndexParam, collectTargetFieldNames, collectSourceFieldNames)
- Filter source indexes based on target field existence: skip indexes on fields not synced to target, allow dynamic field indexes when enableDynamicField=true
- Propagate index extraParams from source to sink
- Remove silent exception swallowing in field schema, function list, and struct field parsing
- Wrap createTable in MilvusCatalog with CatalogException for consistent error contract
- Fix unsafe Boolean cast to Boolean.TRUE.equals() for metadata check
- Add 22 unit tests covering index filtering, dynamic field handling, extraParams, and edge cases