### PR TITLE
[Feature][Connector-Milvus] Support CDC write mode

### DIFF
--- a/docs/en/connector-v2/changelog/connector-milvus.md
+++ b/docs/en/connector-v2/changelog/connector-milvus.md
@@ -2,6 +2,7 @@
 
 | Change | Commit | Version |
 | --- | --- | --- |
+|[Feature][Connector-V2][Milvus] Support CDC write mode|-|-|
 |[Fix][Connector-V2] Fix load state check in MilvusSourceReader to consider partition-level status (#8937)|https://github.com/apache/seatunnel/commit/bde235090|2.3.10|
 |[Improve][dist]add shade check rule (#8136)|https://github.com/apache/seatunnel/commit/51ef80001|2.3.9|
 |[Improve][Core] Refactor common options of column/row (#7911)|https://github.com/apache/seatunnel/commit/d1582afee|2.3.9|

--- a/docs/en/connector-v2/sink/Milvus.md
+++ b/docs/en/connector-v2/sink/Milvus.md
@@ -47,11 +47,14 @@ This Milvus sink connector write data to Milvus or Zilliz Cloud, it has the foll
 | token                | String  | Yes      | -                            | User:password                                             |
 | database             | String  | No       | -                            | Write data to which database, default is source database. |
 | schema_save_mode     | enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Auto create table when table not exist.                   |
+| data_save_mode       | enum    | No       | APPEND_DATA                  | Data save mode. In CDC write mode only `APPEND_DATA` is supported. |
 | create_index         | boolean | No       | true                         | Create indexes when auto creating the collection.         |
 | enable_auto_id       | boolean | No       | false                        | Primary key column enable autoId.                         |
 | enable_upsert        | boolean | No       | false                        | Upsert data not insert.                                   |
 | enable_dynamic_field | boolean | No       | true                         | Enable create table with dynamic field.                   |
 | batch_size           | int     | No       | 1000                         | Write batch size.                                         |
+| cdc_batch_flush_interval_ms | long | No       | 1000                         | In CDC mode, flush pending rows when a newly received row observes that this interval has elapsed since the last successful flush. |
+| write_mode           | enum    | No       | APPEND                       | Write mode. `APPEND` writes normal insert rows by batch or bulk writer. `CDC` upserts INSERT and UPDATE_AFTER rows, deletes DELETE rows, and ignores UPDATE_BEFORE rows. |
 | partition_key        | String  | No       |                              | Milvus partition key field                                |
 | partition_num        | int     | No       |                              | Number of partitions passed to Milvus create collection request. Currently used by Milvus partition key mode. |
 | collection_rename    | Map     | No       | {}                           | Rename collections: `{source_name = "target_name"}`       |
@@ -94,6 +97,22 @@ The `timezone` property is only needed when the **source value does not carry ti
 
 **Warning:** If a source field contains a mix of values with and without timezone information (e.g. Elasticsearch `date` with multiple formats), do not configure `timezone`. The existing systemDefault-based conversion handles the timezone-aware values correctly; adding a `timezone` override would cause double-conversion for those values.
 
+## CDC Write Mode
+
+Set `write_mode = "CDC"` when the upstream source emits CDC changelog rows, especially when using the `Milvus-CDC` source.
+
+CDC write mode has the following constraints:
+
+- `schema_save_mode` must be `ERROR_WHEN_SCHEMA_NOT_EXIST`. Create the target collection schema before starting the CDC job.
+- `data_save_mode` must be `APPEND_DATA`.
+- `bulk_writer_config` is not supported.
+- The target collection must not use autoID.
+- The target collection must have exactly one primary key field.
+
+The CDC writer accepts generic keyed changelog rows and does not require `Milvus-CDC`-specific message metadata. INSERT and UPDATE_AFTER rows are applied by upsert, DELETE rows are applied by primary key delete, and UPDATE_BEFORE rows are ignored. The Milvus primary key must correspond to a stable source CDC key; a primary-key change must be emitted by the source as DELETE for the old key followed by INSERT for the new key. Duplicate primary keys within one upsert batch keep the last row. Consecutive rows with the same target operation are flushed when they reach `batch_size`. Whenever a row is added to the pending batch, the writer also checks `cdc_batch_flush_interval_ms`; when the interval since the last successful flush has elapsed, it flushes the pending batch including the current row. Any target-operation change flushes the previous pending batch. When switching from DELETE to upsert, the current upsert is also flushed immediately so the new key does not remain pending after the old key has been deleted. When switching from upsert to DELETE, the current DELETE continues to follow the normal batch, interval, checkpoint, or writer-close flush rules.
+
+`cdc_batch_flush_interval_ms` is a write-triggered check, not a background timer. If no new row arrives after the last buffered row, that row remains pending until a checkpoint or writer close. Before a database cutover, wait for a final successful checkpoint or stop the synchronization job gracefully. Transaction rows are checkpointed by the source at the source transaction commit offset, but the target Milvus write is still applied as normal INSERT and DELETE operations; it is not a target-side atomic transaction.
+
 ## Task Example
 
 ### Basic
@@ -123,6 +142,45 @@ sink {
       {field_name = "created_at", data_type = 26, is_nullable = true, timezone = "Asia/Shanghai"}
       {field_name = "embedding", data_type = 101, dimension = 768}
     ]
+  }
+}
+```
+
+### Milvus CDC to Milvus
+
+```bash
+source {
+  "Milvus-CDC" {
+    url = "http://127.0.0.1:19530"
+    token = "root:Milvus"
+    database_collections = {
+      "default" = ["source_collection"]
+    }
+    startup_mode = "cdc"
+    channel_positions = [
+      {
+        pchannel = "by-dev-rootcoord-dml_0"
+        start = {
+          wal_name = "RocksMQ"
+          resume_message_id = "-1"
+          timetick = 0
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "root:Milvus"
+    database = "default"
+    collection_rename = {
+      "source_collection" = "target_collection"
+    }
+    write_mode = "CDC"
+    schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
   }
 }
 ```

--- a/docs/zh/connector-v2/changelog/connector-milvus.md
+++ b/docs/zh/connector-v2/changelog/connector-milvus.md
@@ -2,6 +2,7 @@
 
 | Change | Commit | Version |
 | --- | --- | --- |
+|[Feature][Connector-V2][Milvus] 支持 CDC 写模式|-|-|
 |[Fix][Connector-V2] Fix load state check in MilvusSourceReader to consider partition-level status (#8937)|https://github.com/apache/seatunnel/commit/bde235090|2.3.10|
 |[Improve][dist]add shade check rule (#8136)|https://github.com/apache/seatunnel/commit/51ef80001|2.3.9|
 |[Improve][Core] Refactor common options of column/row (#7911)|https://github.com/apache/seatunnel/commit/d1582afee|2.3.9|

--- a/docs/zh/connector-v2/sink/Milvus.md
+++ b/docs/zh/connector-v2/sink/Milvus.md
@@ -47,11 +47,14 @@ Milvus sink连接器将数据写入Milvus或Zilliz Cloud，它具有以下功能
 | token                | String  | 是      | -                            | 用户：密码                                             |
 | database             | String  | 否       | -                            | 将数据写入哪个数据库，默认为源数据库。 |
 | schema_save_mode     | enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 当表不存在时自动创建表。                   |
+| data_save_mode       | enum    | 否       | APPEND_DATA                  | 数据保存模式。CDC 写模式只支持 `APPEND_DATA`。 |
 | create_index         | boolean | 否       | true                         | 自动创建 collection 时是否创建索引。       |
 | enable_auto_id       | boolean | 否       | false                        | 主键列启用autoId。                         |
 | enable_upsert        | boolean | 否       | false                        | 是否启用upsert。                                   |
 | enable_dynamic_field | boolean | 否       | true                         | 是否启用带动态字段的创建表。                   |
 | batch_size           | int     | 否       | 1000                         | 写入批大小。                                         |
+| cdc_batch_flush_interval_ms | long | 否       | 1000                         | CDC 模式下，收到新 row 时，如果距上次成功 flush 已达到该间隔，则 flush 未完成批次。单位为毫秒。 |
+| write_mode           | enum    | 否       | APPEND                       | 写入模式。`APPEND` 使用普通 batch 或 bulk writer 写入 insert row；`CDC` 对 INSERT 和 UPDATE_AFTER 执行 upsert，对 DELETE 执行删除，并忽略 UPDATE_BEFORE。 |
 | partition_key        | String  | 否       |                              | Milvus分区键字段                                |
 | partition_num        | int     | 否       |                              | 透传给 Milvus create collection 请求的分区数量。当前主要用于 Milvus 分区键模式。 |
 | collection_rename    | Map     | 否       | {}                           | 重命名集合：`{源名称 = "目标名称"}`       |
@@ -94,6 +97,22 @@ Milvus sink连接器将数据写入Milvus或Zilliz Cloud，它具有以下功能
 
 **注意：** 如果源端字段中混合存在带时区和不带时区的值（如 Elasticsearch `date` 字段使用多种格式），不要配置 `timezone`。现有的 systemDefault 转换机制会正确处理带时区的值；额外配置 `timezone` 会导致这些值被双重转换。
 
+## CDC 写模式
+
+当上游 source 输出 CDC changelog row 时，尤其是使用 `Milvus-CDC` source 时，需要设置 `write_mode = "CDC"`。
+
+CDC 写模式有以下限制：
+
+- `schema_save_mode` 必须为 `ERROR_WHEN_SCHEMA_NOT_EXIST`。启动 CDC 任务前需要先创建目标 collection schema。
+- `data_save_mode` 必须为 `APPEND_DATA`。
+- 不支持 `bulk_writer_config`。
+- 目标 collection 不能启用 autoID。
+- 目标 collection 必须只有一个主键字段。
+
+CDC writer 接受通用的 keyed changelog row，不依赖 `Milvus-CDC` 私有消息元数据。INSERT 和 UPDATE_AFTER row 会按 upsert 写入，DELETE row 会按主键删除，UPDATE_BEFORE row 会被忽略。Milvus 主键必须对应稳定的源 CDC key；源端主键变化必须由 reader 表达为旧主键的 DELETE，随后是新主键的 INSERT。同一个 upsert batch 内的重复主键保留最后一条。连续的相同目标操作达到 `batch_size` 时会 flush；每次将 row 加入待写 batch 时还会检查 `cdc_batch_flush_interval_ms`，如果距上次成功 flush 已达到该间隔，则将当前 row 一并 flush。任何目标操作切换都会先 flush 上一个待写 batch；从 DELETE 切换到 upsert 时，当前 upsert 也会立即 flush，避免旧主键已经删除后新主键仍等待后续消息或 checkpoint。从 upsert 切换到 DELETE 时，当前 DELETE 仍按正常的 batch、interval、checkpoint 或 writer close 规则 flush。
+
+`cdc_batch_flush_interval_ms` 是由新消息触发的检查，不是后台定时器。如果最后一条 row 进入 buffer 后不再有新 row，它仍会等待 checkpoint 或 writer close。数据库割接前应等待最后一次 checkpoint 成功，或者正常停止同步任务。事务 row 在 source 侧按源端事务 commit 位点推进 checkpoint，但目标 Milvus 仍按普通 INSERT 和 DELETE 操作写入，不提供目标端事务原子性。
+
 ## 任务示例
 
 ### 基础用法
@@ -123,6 +142,45 @@ sink {
       {field_name = "created_at", data_type = 26, is_nullable = true, timezone = "Asia/Shanghai"}
       {field_name = "embedding", data_type = 101, dimension = 768}
     ]
+  }
+}
+```
+
+### Milvus CDC 到 Milvus
+
+```bash
+source {
+  "Milvus-CDC" {
+    url = "http://127.0.0.1:19530"
+    token = "root:Milvus"
+    database_collections = {
+      "default" = ["source_collection"]
+    }
+    startup_mode = "cdc"
+    channel_positions = [
+      {
+        pchannel = "by-dev-rootcoord-dml_0"
+        start = {
+          wal_name = "RocksMQ"
+          resume_message_id = "-1"
+          timetick = 0
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "root:Milvus"
+    database = "default"
+    collection_rename = {
+      "source_collection" = "target_collection"
+    }
+    write_mode = "CDC"
+    schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
   }
 }
 ```

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/common/MilvusConstants.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/common/MilvusConstants.java
@@ -21,6 +21,8 @@ public class MilvusConstants {
 
     // Partition constants
     public static final String DEFAULT_PARTITION = "_default";
+    public static final String EMPTY_JSON_ARRAY = "[]";
+    public static final String MILVUS_INTERNAL_DYNAMIC_FIELD = "$meta";
 
     // Collection options
     public static final String ENABLE_DYNAMIC_FIELD = "enableDynamicField";
@@ -48,4 +50,11 @@ public class MilvusConstants {
     public static final String IS_NULLABLE = "is_nullable";
     public static final String DEFAULT_VALUE = "default_value";
     public static final String STRUCT_FIELDS = "struct_fields";
+
+    // Serialized source index metadata keys
+    public static final String INDEX_FIELD_NAME = "fieldName";
+    public static final String INDEX_NAME = "indexName";
+    public static final String INDEX_TYPE = "indexType";
+    public static final String METRIC_TYPE = "metricType";
+    public static final String EXTRA_PARAMS = "extraParams";
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSink.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSink.java
@@ -100,6 +100,7 @@ public class MilvusSink
         if (catalogTable == null) {
             return Optional.empty();
         }
+        MilvusSinkFactory.validateCdcSaveMode(config);
 
         CatalogFactory catalogFactory = new MilvusCatalogFactory();
         Catalog catalog = catalogFactory.createCatalog(catalogTable.getCatalogName(), config);

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkFactory.java
@@ -23,6 +23,8 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.sink.DataSaveMode;
+import org.apache.seatunnel.api.sink.SchemaSaveMode;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.connector.TableSink;
@@ -31,6 +33,7 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog.MilvusFieldSchema;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkWriteMode;
 
 import java.time.ZoneId;
 import java.util.List;
@@ -53,15 +56,37 @@ public class MilvusSinkFactory implements TableSinkFactory {
                         MilvusSinkConfig.DATA_SAVE_MODE,
                         MilvusSinkConfig.CREATE_INDEX,
                         MilvusSinkConfig.PARTITION_NUM,
-                        MilvusSinkConfig.FIELD_SCHEMA)
+                        MilvusSinkConfig.FIELD_SCHEMA,
+                        MilvusSinkConfig.WRITE_MODE)
                 .build();
     }
 
     public TableSink createSink(TableSinkFactoryContext context) {
         ReadonlyConfig config = context.getOptions();
+        validateCdcSaveMode(config);
         validateFieldTimezones(config);
         CatalogTable catalogTable = renameCatalogTable(config, context.getCatalogTable());
         return () -> new MilvusSink(config, catalogTable);
+    }
+
+    static void validateCdcSaveMode(ReadonlyConfig config) {
+        if (config.get(MilvusSinkConfig.WRITE_MODE) != MilvusSinkWriteMode.CDC) {
+            return;
+        }
+        SchemaSaveMode schemaSaveMode = config.get(MilvusSinkConfig.SCHEMA_SAVE_MODE);
+        if (schemaSaveMode != SchemaSaveMode.ERROR_WHEN_SCHEMA_NOT_EXIST) {
+            throw new IllegalArgumentException(
+                    "Milvus CDC write mode only supports schema_save_mode = "
+                            + "ERROR_WHEN_SCHEMA_NOT_EXIST, but received: "
+                            + schemaSaveMode);
+        }
+        DataSaveMode dataSaveMode = config.get(MilvusSinkConfig.DATA_SAVE_MODE);
+        if (dataSaveMode != DataSaveMode.APPEND_DATA) {
+            throw new IllegalArgumentException(
+                    "Milvus CDC write mode only supports data_save_mode = APPEND_DATA, "
+                            + "but received: "
+                            + dataSaveMode);
+        }
     }
 
     private void validateFieldTimezones(ReadonlyConfig config) {

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriter.java
@@ -30,20 +30,16 @@ import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import static org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants.DEFAULT_PARTITION;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
-import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.StageBucket;
-
-import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.BULK_WRITER_CONFIG;
 
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.state.MilvusCommitInfo;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.state.MilvusSinkState;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusConnectorUtils;
-import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.StageHelper;
-import org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer.MilvusBufferBatchWriter;
-import org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer.MilvusBulkWriter;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer.MilvusWriterFactory;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer.MilvusWriter;
 
 import java.io.IOException;
@@ -68,12 +64,17 @@ public class MilvusSinkWriter
     private final String collection;
     private final ReadonlyConfig config;
     private final MilvusClientV2 milvusClient;
-    private final Boolean useBulkWriter;
-    private final StageBucket stageBucket;
+    private final MilvusWriterFactory writerFactory;
     private final DescribeCollectionResp  describeCollectionResp;
     private final Boolean hasPartitionKey;
 
     private final AtomicLong writeCount = new AtomicLong(0);
+
+    private static String redactSensitiveConfig(ReadonlyConfig config) {
+        return String.valueOf(config)
+                .replaceAll("(\"token\"\\s*:\\s*\")[^\"]*(\")", "$1******$2")
+                .replaceAll("(token\\s*=\\s*)[^,}\\s]+", "$1******");
+    }
 
     public MilvusSinkWriter(
             Context context,
@@ -84,13 +85,17 @@ public class MilvusSinkWriter
         this.catalogTable = catalogTable;
         this.collection = catalogTable.getTablePath().getTableName();
         log.info("create Milvus sink writer success");
-        log.info("MilvusSinkWriter config: " + config);
+        log.info("MilvusSinkWriter config: {}", redactSensitiveConfig(config));
         this.milvusClient = new MilvusClientV2(MilvusConnectorUtils.getConnectConfig(config));
-        describeCollectionResp = milvusClient.describeCollection(DescribeCollectionReq.builder().collectionName(collection).build());
-        hasPartitionKey = describeCollectionResp.getCollectionSchema().getFieldSchemaList().stream().anyMatch(CreateCollectionReq.FieldSchema::getIsPartitionKey);
-        useBulkWriter = !config.get(BULK_WRITER_CONFIG).isEmpty();
-        // apply for a stage session bucket to store parquet files
-        stageBucket = StageHelper.getStageBucket(config.get(BULK_WRITER_CONFIG));
+        describeCollectionResp =
+                milvusClient.describeCollection(
+                        DescribeCollectionReq.builder().collectionName(collection).build());
+        hasPartitionKey =
+                describeCollectionResp.getCollectionSchema().getFieldSchemaList().stream()
+                        .anyMatch(CreateCollectionReq.FieldSchema::getIsPartitionKey);
+        writerFactory =
+                new MilvusWriterFactory(
+                        catalogTable, config, milvusClient, describeCollectionResp);
     }
 
     /**
@@ -100,7 +105,11 @@ public class MilvusSinkWriter
      */
     @Override
     public void write(SeaTunnelRow element) {
-        String partition = StringUtils.isEmpty(element.getPartitionName()) ? DEFAULT_PARTITION : element.getPartitionName();
+        writerFactory.validateRow(element);
+        String partition =
+                StringUtils.isEmpty(element.getPartitionName())
+                        ? DEFAULT_PARTITION
+                        : element.getPartitionName();
         if (hasPartitionKey) {
             partition = DEFAULT_PARTITION;
         }
@@ -130,19 +139,17 @@ public class MilvusSinkWriter
                         }
                     }
                 }
-                synchronized (batchWriters) {
-                    // flush all data before creating new writer
-                    try {
-                        for (MilvusWriter writer : batchWriters.values()) {
+                // flush all data before creating new writer
+                try {
+                    for (MilvusWriter writer : batchWriters.values()) {
+                        synchronized (writer) {
                             writer.commit(true);
                         }
-                    } catch (Exception e) {
-                        throw new MilvusConnectorException(MilvusConnectionErrorCode.COMMIT_ERROR, e);
                     }
+                } catch (Exception e) {
+                    throw new MilvusConnectorException(MilvusConnectionErrorCode.COMMIT_ERROR, e);
                 }
-                return useBulkWriter
-                        ? new MilvusBulkWriter(this.catalogTable, config, stageBucket, describeCollectionResp, finalPartition)
-                        : new MilvusBufferBatchWriter(this.catalogTable, config, milvusClient, describeCollectionResp, finalPartition);
+                return writerFactory.create(finalPartition);
             }
         });
 
@@ -164,6 +171,12 @@ public class MilvusSinkWriter
         }
     }
 
+    @Override
+    public void applySchemaChange(SchemaChangeEvent event) throws IOException {
+        throw new IOException(
+                "Milvus sink does not support runtime schema changes: " + event);
+    }
+
     /**
      * prepare the commit, will be called before {@link #snapshotState(long checkpointId)}. If you
      * need to use 2pc, you can return the commit info in this method, and receive the commit info
@@ -174,6 +187,20 @@ public class MilvusSinkWriter
      */
     @Override
     public Optional<MilvusCommitInfo> prepareCommit() throws IOException {
+        synchronized (batchWriters) {
+            for (MilvusWriter writer : batchWriters.values()) {
+                synchronized (writer) {
+                    if (!writer.needCommit()) {
+                        continue;
+                    }
+                    try {
+                        writer.commit(true);
+                    } catch (Exception e) {
+                        throw new IOException("Flush Milvus writer before checkpoint failed", e);
+                    }
+                }
+            }
+        }
         return Optional.empty();
     }
 

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
@@ -87,7 +87,8 @@ public class CatalogUtils {
         Map<String, String> options = catalogTable.getOptions();
 
         String indexListStr = options.get(MilvusConstants.INDEX_LIST);
-        if (StringUtils.isEmpty(indexListStr) || indexListStr.equals("[]")) {
+        if (StringUtils.isEmpty(indexListStr)
+                || indexListStr.equals(MilvusConstants.EMPTY_JSON_ARRAY)) {
             return indexParams;
         }
 
@@ -142,7 +143,7 @@ public class CatalogUtils {
 
     IndexParam buildIndexParam(Map<String, String> indexInfo, Set<String> targetFieldNames,
             Set<String> sourceFieldNames, boolean enableDynamicField, Gson gson, Type extraParamsType) {
-        String fieldName = indexInfo.get("fieldName");
+        String fieldName = indexInfo.get(MilvusConstants.INDEX_FIELD_NAME);
         if (fieldName == null) {
             throw new MilvusConnectorException(MilvusConnectionErrorCode.CREATE_INDEX_ERROR,
                     "Index has null fieldName: " + indexInfo);
@@ -151,39 +152,44 @@ public class CatalogUtils {
             if (sourceFieldNames.contains(fieldName)) {
                 // Field exists in source explicit schema but not synced to target — skip
                 log.info("Skipping index '{}' on field '{}': source schema field not synced to target",
-                        indexInfo.get("indexName"), fieldName);
+                        indexInfo.get(MilvusConstants.INDEX_NAME), fieldName);
                 return null;
             } else if (enableDynamicField) {
                 // Field not in any explicit schema — dynamic field index, data lives in $meta
                 log.info("Index '{}' on field '{}' not in explicit schema, allowing as dynamic field index",
-                        indexInfo.get("indexName"), fieldName);
+                        indexInfo.get(MilvusConstants.INDEX_NAME), fieldName);
             } else {
                 log.info("Skipping index '{}' on field '{}': field not present in target schema",
-                        indexInfo.get("indexName"), fieldName);
+                        indexInfo.get(MilvusConstants.INDEX_NAME), fieldName);
                 return null;
             }
         }
 
-        IndexParam.MetricType metricType = indexInfo.containsKey("metricType")
-                ? IndexParam.MetricType.valueOf(indexInfo.get("metricType"))
+        IndexParam.MetricType metricType = indexInfo.containsKey(MilvusConstants.METRIC_TYPE)
+                ? IndexParam.MetricType.valueOf(indexInfo.get(MilvusConstants.METRIC_TYPE))
                 : null;
 
-        IndexParam.IndexType indexType = parseIndexType(indexInfo.get("indexType"));
+        IndexParam.IndexType indexType = parseIndexType(indexInfo.get(MilvusConstants.INDEX_TYPE));
 
         IndexParam.IndexParamBuilder builder = IndexParam.builder()
                 .fieldName(fieldName)
                 .metricType(metricType)
-                .indexName(indexInfo.get("indexName"));
+                .indexName(indexInfo.get(MilvusConstants.INDEX_NAME));
         if (indexType != null) {
             builder.indexType(indexType);
         }
 
         // Parse and apply extraParams if present
-        if (indexInfo.containsKey("extraParams") && StringUtils.isNotEmpty(indexInfo.get("extraParams"))) {
-            Map<String, Object> extraParams = gson.fromJson(indexInfo.get("extraParams"), extraParamsType);
+        if (indexInfo.containsKey(MilvusConstants.EXTRA_PARAMS)
+                && StringUtils.isNotEmpty(indexInfo.get(MilvusConstants.EXTRA_PARAMS))) {
+            Map<String, Object> extraParams =
+                    gson.fromJson(indexInfo.get(MilvusConstants.EXTRA_PARAMS), extraParamsType);
             if (extraParams != null && !extraParams.isEmpty()) {
                 builder.extraParams(extraParams);
-                log.debug("Applied extraParams for index '{}': {}", indexInfo.get("indexName"), extraParams);
+                log.debug(
+                        "Applied extraParams for index '{}': {}",
+                        indexInfo.get(MilvusConstants.INDEX_NAME),
+                        extraParams);
             }
         }
 
@@ -609,7 +615,8 @@ public class CatalogUtils {
         // Load functions from source if available
         if (options.containsKey(MilvusConstants.FUNCTION_LIST)) {
             String functionListStr = options.get(MilvusConstants.FUNCTION_LIST);
-            if (StringUtils.isNotEmpty(functionListStr) && !functionListStr.equals("[]")) {
+            if (StringUtils.isNotEmpty(functionListStr)
+                    && !functionListStr.equals(MilvusConstants.EMPTY_JSON_ARRAY)) {
                 Type functionListType = new TypeToken<List<CreateCollectionReq.Function>>() {
                 }.getType();
                 List<CreateCollectionReq.Function> functionsFromSource = gson.fromJson(functionListStr,
@@ -652,7 +659,8 @@ public class CatalogUtils {
         for (Column column : tableSchema.getColumns()) {
             if (column.getOptions() != null && column.getOptions().containsKey(MilvusConstants.STRUCT_FIELDS)) {
                 String structFieldsJson = (String) column.getOptions().get(MilvusConstants.STRUCT_FIELDS);
-                if (StringUtils.isNotEmpty(structFieldsJson) && !structFieldsJson.equals("[]")) {
+                if (StringUtils.isNotEmpty(structFieldsJson)
+                        && !structFieldsJson.equals(MilvusConstants.EMPTY_JSON_ARRAY)) {
                     // Parse the nested fields from the struct
                     Type nestedFieldsType = new TypeToken<List<CreateCollectionReq.FieldSchema>>() {
                     }.getType();

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkConfig.java
@@ -208,10 +208,22 @@ public class MilvusSinkConfig extends MilvusCommonConfig {
                         .defaultValue(1000)
                         .withDescription("writer batch size");
 
+        public static final Option<Long> CDC_BATCH_FLUSH_INTERVAL_MS = Options.key("cdc_batch_flush_interval_ms")
+                        .longType()
+                        .defaultValue(1000L)
+                        .withDescription(
+                                        "CDC writer message-triggered batch flush interval in milliseconds");
+
         public static final Option<Map<String, String>> BULK_WRITER_CONFIG = Options.key("bulk_writer_config")
                         .mapType()
                         .defaultValue(new HashMap<>())
                         .withDescription("bulk writer config");
+
+        public static final Option<MilvusSinkWriteMode> WRITE_MODE = Options.key("write_mode")
+                        .enumType(MilvusSinkWriteMode.class)
+                        .defaultValue(MilvusSinkWriteMode.APPEND)
+                        .withDescription(
+                                        "Milvus sink write mode. APPEND uses the normal batch or bulk writer. CDC upserts INSERT and UPDATE_AFTER rows, deletes DELETE rows, and ignores UPDATE_BEFORE rows.");
 
         /**
          * How to interpret bare "x,y" coordinate strings flowing into a Geometry field.

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkWriteMode.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/config/MilvusSinkWriteMode.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.config;
+
+public enum MilvusSinkWriteMode {
+    APPEND,
+    CDC
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusImport.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusImport.java
@@ -17,6 +17,8 @@ import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.StageBucket
 import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.GetImportProgressResp;
 import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.InnerImportRequest;
 
+import static org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants.DEFAULT_PARTITION;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +83,7 @@ public class MilvusImport {
         if(StringUtils.isNotEmpty(dbName) && !dbName.equals("default")){
             importRequest.setDbName(dbName);
         }
-        if(StringUtils.isNotEmpty(partitionName) && !partitionName.equals("_default")){
+        if(StringUtils.isNotEmpty(partitionName) && !partitionName.equals(DEFAULT_PARTITION)){
             importRequest.setPartitionName(partitionName);
         }
         log.info("import objectUrl: " + objectUrl + " to collection: " + collectionName + " partition: " + partitionName);

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -33,6 +34,7 @@ import io.milvus.v2.service.collection.request.CreateCollectionReq.FieldSchema;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -41,6 +43,7 @@ import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.api.table.type.CommonOptions;
 import org.apache.seatunnel.common.utils.BufferUtils;
 import org.apache.seatunnel.common.utils.JsonUtils;
+import org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog.MilvusFieldSchema;
@@ -58,7 +61,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -162,7 +164,7 @@ public class MilvusSinkConverter {
             case BFLOAT16_VECTOR:
             case FLOAT16_VECTOR:
                 ByteBuffer binaryVector = (ByteBuffer) value;
-                return gson.toJsonTree(binaryVector.array());
+                return byteBufferToJsonArray(binaryVector);
             case SPARSE_FLOAT_VECTOR:
                 return JsonParser.parseString(JsonUtils.toJsonString(value)).getAsJsonObject();
             case FLOAT:
@@ -247,12 +249,14 @@ public class MilvusSinkConverter {
             Map<String, String> milvusFieldsMap,
             SeaTunnelRow element) {
         SeaTunnelRowType seaTunnelRowType = catalogTable.getSeaTunnelRowType();
+        List<Column> sourceColumns = catalogTable.getTableSchema().getColumns();
         JsonObject data = new JsonObject();
         Gson gson = new Gson();
 
         // Build source-to-target field name mapping from field_schema config
         // This allows renaming: source_field_name (old name) -> field_name (new name)
         for (int i = 0; i < seaTunnelRowType.getFieldNames().length; i++) {
+            Column sourceColumn = i < sourceColumns.size() ? sourceColumns.get(i) : null;
             String sourceFieldName = seaTunnelRowType.getFieldNames()[i];
             String fieldName = milvusFieldsMap.getOrDefault(sourceFieldName, sourceFieldName);
             // Skip auto-ID primary key fields
@@ -263,9 +267,8 @@ public class MilvusSinkConverter {
             Object value = element.getField(i);
 
             // Handle dynamic field extraction
-            if (Objects.equals(fieldName, CommonOptions.METADATA.getName())
-                    && describeCollectionResp.getEnableDynamicField()) {
-                if (value == null) {
+            if (isMetadataColumn(sourceColumn, fieldName)) {
+                if (!describeCollectionResp.getEnableDynamicField() || value == null) {
                     continue;
                 }
                 JsonObject dynamicData = gson.fromJson(value.toString(), JsonObject.class);
@@ -291,7 +294,7 @@ public class MilvusSinkConverter {
                                             convertedValue = extractJsonValue(entry.getValue());
                                         }
                                         Object converted = convertByMilvusType(dynamicFieldSchema, convertedValue);
-                                        data.add(matchedField, gson.toJsonTree(converted));
+                                        data.add(matchedField, toJsonElement(converted));
                                     } else {
                                         data.add(matchedField, entry.getValue());
                                     }
@@ -321,9 +324,41 @@ public class MilvusSinkConverter {
                                 + "' conflicts with a previously written dynamic field. "
                                 + "Use field_schema to rename the conflicting field.");
             }
-            data.add(fieldName, gson.toJsonTree(object));
+            data.add(fieldName, toJsonElement(object));
         }
         return data;
+    }
+
+    private boolean isMetadataColumn(Column column, String targetFieldName) {
+        if (column != null
+                && column.getOptions() != null
+                && Boolean.TRUE.equals(column.getOptions().get(CommonOptions.METADATA.getName()))) {
+            return true;
+        }
+        return MilvusConstants.MILVUS_INTERNAL_DYNAMIC_FIELD.equals(targetFieldName)
+                || CommonOptions.METADATA.getName().equals(targetFieldName);
+    }
+
+    private JsonElement toJsonElement(Object value) {
+        if (value == null) {
+            return JsonNull.INSTANCE;
+        }
+        if (value instanceof JsonElement) {
+            return (JsonElement) value;
+        }
+        if (value instanceof ByteBuffer) {
+            return byteBufferToJsonArray((ByteBuffer) value);
+        }
+        return gson.toJsonTree(value);
+    }
+
+    private JsonElement byteBufferToJsonArray(ByteBuffer value) {
+        ByteBuffer buffer = value.duplicate();
+        JsonArray array = new JsonArray();
+        while (buffer.hasRemaining()) {
+            array.add(buffer.get());
+        }
+        return array;
     }
 
     /**
@@ -514,7 +549,7 @@ public class MilvusSinkConverter {
             case BFloat16Vector:
             case Float16Vector:
                 ByteBuffer binaryVector = (ByteBuffer) value;
-                return gson.toJsonTree(binaryVector.array());
+                return byteBufferToJsonArray(binaryVector);
             case FloatVector:
                 if (value instanceof ByteBuffer) {
                     ByteBuffer floatVectorBuffer = (ByteBuffer) value;
@@ -548,6 +583,9 @@ public class MilvusSinkConverter {
                 }
                 return value;
             case Geometry:
+                if (value instanceof ByteBuffer) {
+                    return GeometryConverter.PARSE.convert(value);
+                }
                 return geometryConverter.convert(value);
             case Timestamptz:
                 // Milvus SDK requires Timestamptz as ISO 8601 String format (e.g., "2024-01-19T11:30:45Z")

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBufferBatchWriter.java
@@ -33,6 +33,7 @@ import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
 
+import static org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants.DEFAULT_PARTITION;
 import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.BATCH_SIZE;
 import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.FIELD_SCHEMA;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog.MilvusFieldSchema;
@@ -100,7 +101,6 @@ public class MilvusBufferBatchWriter implements MilvusWriter {
 
     @Override
     public void write(SeaTunnelRow element) {
-        // put data to cache by partition
         JsonObject data =
                 milvusSinkConverter.buildMilvusData(
                         catalogTable, descriptionCollectionResp, milvusFieldMapper, element);
@@ -132,7 +132,6 @@ public class MilvusBufferBatchWriter implements MilvusWriter {
             return;
         }
 
-        // default to use upsertReq, but upsert only works when autoID is disabled
         insertWrite(partitionName, milvusDataCache);
 
         writeCount.addAndGet(this.writeCache.get());
@@ -163,7 +162,9 @@ public class MilvusBufferBatchWriter implements MilvusWriter {
                         .data(data)
                         .build();
 
-        if (StringUtils.isNotEmpty(partitionName) && !partitionName.equals("_default") &&  !this.hasPartitionKey) {
+        if (StringUtils.isNotEmpty(partitionName)
+                && !partitionName.equals(DEFAULT_PARTITION)
+                && !this.hasPartitionKey) {
             insertReq.setPartitionName(partitionName);
         }
 

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusCdcWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusCdcWriter.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import io.milvus.v2.service.vector.request.DeleteReq;
+import io.milvus.v2.service.vector.request.UpsertReq;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog.MilvusFieldSchema;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusConnectorUtils;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusSinkConverter;
+
+import static org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants.DEFAULT_PARTITION;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.BATCH_SIZE;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.CDC_BATCH_FLUSH_INTERVAL_MS;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.FIELD_SCHEMA;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+@Slf4j
+public class MilvusCdcWriter implements MilvusWriter {
+    private final CatalogTable catalogTable;
+    private final String collectionName;
+    private final String partitionName;
+    private final Boolean hasPartitionKey;
+    private final MilvusClientV2 milvusClient;
+    private final DescribeCollectionResp descriptionCollectionResp;
+    private final MilvusSinkConverter milvusSinkConverter;
+    private final Map<String, String> milvusFieldMapper;
+    private final int primaryKeyIndex;
+    private final int batchSize;
+    private final long cdcBatchFlushIntervalMs;
+    private final LongSupplier currentTimeMillisSupplier;
+    private final Map<Object, SeaTunnelRow> pendingRows;
+    private RowKind pendingRowKind;
+    private RowKind lastTargetRowKind;
+    private long lastFlushTime;
+    private final AtomicLong writeCache = new AtomicLong();
+    private final AtomicLong writeCount = new AtomicLong();
+
+    public MilvusCdcWriter(
+            CatalogTable catalogTable,
+            ReadonlyConfig config,
+            MilvusClientV2 milvusClient,
+            DescribeCollectionResp describeCollectionResp,
+            String partitionName) {
+        this(
+                catalogTable,
+                config,
+                milvusClient,
+                describeCollectionResp,
+                partitionName,
+                System::currentTimeMillis);
+    }
+
+    MilvusCdcWriter(
+            CatalogTable catalogTable,
+            ReadonlyConfig config,
+            MilvusClientV2 milvusClient,
+            DescribeCollectionResp describeCollectionResp,
+            String partitionName,
+            LongSupplier currentTimeMillisSupplier) {
+        this.catalogTable = catalogTable;
+        this.collectionName = catalogTable.getTablePath().getTableName();
+        this.partitionName = partitionName;
+        this.milvusClient = milvusClient;
+        this.descriptionCollectionResp = describeCollectionResp;
+        this.hasPartitionKey = MilvusConnectorUtils.hasPartitionKey(describeCollectionResp);
+        this.milvusSinkConverter = MilvusSinkConverter.fromConfig(config);
+        this.milvusFieldMapper = buildFieldMapper(config);
+        this.primaryKeyIndex =
+                primaryKeyIndex(catalogTable, describeCollectionResp, milvusFieldMapper);
+        this.batchSize = config.get(BATCH_SIZE);
+        this.cdcBatchFlushIntervalMs = config.get(CDC_BATCH_FLUSH_INTERVAL_MS);
+        this.currentTimeMillisSupplier = currentTimeMillisSupplier;
+        this.lastFlushTime = currentTimeMillisSupplier.getAsLong();
+        this.pendingRows = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void write(SeaTunnelRow element) {
+        // Milvus is a keyed/upsert sink. UPDATE_BEFORE is only the retract image of a
+        // keyed update; primary-key changes must be represented as DELETE + INSERT.
+        if (element.getRowKind() == RowKind.UPDATE_BEFORE) {
+            return;
+        }
+        RowKind targetRowKind = targetRowKind(element);
+        Object primaryKey = requirePrimaryKeyValue(element, targetRowKind);
+        boolean operationChanged = !pendingRows.isEmpty() && pendingRowKind != targetRowKind;
+        // After a primary-key change, do not leave the new row pending until the next
+        // message or checkpoint once the old key has already been deleted.
+        boolean flushCurrentAfterSwitch =
+                lastTargetRowKind == RowKind.DELETE && targetRowKind == RowKind.INSERT;
+        if (operationChanged) {
+            flushPending();
+        }
+        pendingRowKind = targetRowKind;
+        pendingRows.remove(primaryKey);
+        pendingRows.put(primaryKey, element);
+        long pendingEventCount = writeCache.incrementAndGet();
+        if (flushCurrentAfterSwitch || pendingEventCount >= batchSize) {
+            flushPending();
+        } else {
+            flushPendingIfIntervalElapsed();
+        }
+        lastTargetRowKind = targetRowKind;
+    }
+
+    private void writeRows(RowKind rowKind, List<SeaTunnelRow> rows) {
+        long applyStartTimestampMs = System.currentTimeMillis();
+        if (rowKind == RowKind.DELETE) {
+            delete(partitionName, primaryKeys(rows));
+        } else if (rowKind == RowKind.INSERT) {
+            upsert(partitionName, rows);
+        } else {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                    "Milvus CDC sink only supports INSERT and DELETE row kinds, but received: "
+                            + rowKind);
+        }
+        long applyTimestampMs = System.currentTimeMillis();
+        long applyCostMs = applyTimestampMs - applyStartTimestampMs;
+        logAppliedBatch(rowKind, rows, applyTimestampMs, applyCostMs);
+        writeCount.addAndGet(rows.size());
+    }
+
+    @Override
+    public void commit(Boolean async) {
+        flushPending();
+    }
+
+    @Override
+    public boolean needCommit() {
+        return writeCache.get() > 0;
+    }
+
+    @Override
+    public void close() throws Exception {
+        commit(true);
+        this.milvusClient.close(10);
+    }
+
+    @Override
+    public long getWriteCache() {
+        return writeCache.get();
+    }
+
+    @Override
+    public void waitJobFinish() {}
+
+    private void upsert(String partitionName, List<SeaTunnelRow> elements) {
+        List<JsonObject> data = new ArrayList<>(elements.size());
+        for (SeaTunnelRow element : elements) {
+            data.add(
+                    milvusSinkConverter.buildMilvusData(
+                            catalogTable, descriptionCollectionResp, milvusFieldMapper, element));
+        }
+        UpsertReq upsertReq =
+                UpsertReq.builder().collectionName(this.collectionName).data(data).build();
+
+        if (StringUtils.isNotEmpty(partitionName)
+                && !partitionName.equals(DEFAULT_PARTITION)
+                && !this.hasPartitionKey) {
+            upsertReq.setPartitionName(partitionName);
+        }
+
+        try {
+            milvusClient.upsert(upsertReq);
+        } catch (Exception e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL, "upsert CDC data failed", e);
+        }
+    }
+
+    private void delete(String partitionName, List<Object> primaryKeys) {
+        DeleteReq.DeleteReqBuilder builder =
+                DeleteReq.builder().collectionName(this.collectionName).ids(primaryKeys);
+
+        if (StringUtils.isNotEmpty(partitionName)
+                && !partitionName.equals(DEFAULT_PARTITION)
+                && !this.hasPartitionKey) {
+            builder.partitionName(partitionName);
+        }
+
+        try {
+            milvusClient.delete(builder.build());
+        } catch (Exception e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL, "delete CDC data failed", e);
+        }
+    }
+
+    private Object primaryKeyValue(SeaTunnelRow element) {
+        return element.getField(primaryKeyIndex);
+    }
+
+    private List<Object> primaryKeyValues(List<SeaTunnelRow> rows) {
+        List<Object> primaryKeys = new ArrayList<>(rows.size());
+        for (SeaTunnelRow row : rows) {
+            primaryKeys.add(primaryKeyValue(row));
+        }
+        return primaryKeys;
+    }
+
+    private List<Object> primaryKeys(List<SeaTunnelRow> rows) {
+        List<Object> primaryKeys = primaryKeyValues(rows);
+        for (Object primaryKey : primaryKeys) {
+            if (primaryKey == null) {
+                throw new MilvusConnectorException(
+                        MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                        "delete row primary key must not be null");
+            }
+        }
+        return primaryKeys;
+    }
+
+    private Object requirePrimaryKeyValue(SeaTunnelRow element, RowKind targetRowKind) {
+        Object primaryKey = primaryKeyValue(element);
+        if (primaryKey == null) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                    targetRowKind == RowKind.DELETE
+                            ? "delete row primary key must not be null"
+                            : "upsert row primary key must not be null");
+        }
+        return primaryKey;
+    }
+
+    private RowKind targetRowKind(SeaTunnelRow element) {
+        RowKind rowKind = element.getRowKind();
+        if (rowKind == null) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                    "Milvus CDC row kind must not be null");
+        }
+        if (rowKind == RowKind.INSERT || rowKind == RowKind.UPDATE_AFTER) {
+            return RowKind.INSERT;
+        }
+        if (rowKind == RowKind.DELETE) {
+            return RowKind.DELETE;
+        }
+        throw new MilvusConnectorException(
+                MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                "Unsupported Milvus CDC row kind: " + rowKind);
+    }
+
+    private void flushPending() {
+        if (pendingRows.isEmpty()) {
+            return;
+        }
+        writeRows(pendingRowKind, new ArrayList<>(pendingRows.values()));
+        lastFlushTime = currentTimeMillisSupplier.getAsLong();
+        pendingRows.clear();
+        pendingRowKind = null;
+        writeCache.set(0L);
+    }
+
+    private void flushPendingIfIntervalElapsed() {
+        long currentTime = currentTimeMillisSupplier.getAsLong();
+        // TODO: Replace this write-triggered interval check with SeaTunnel engine-level
+        // timer flush after STIP-23 (#10717 / #10800) is available in this branch.
+        if (currentTime < lastFlushTime
+                || currentTime - lastFlushTime >= cdcBatchFlushIntervalMs) {
+            flushPending();
+        }
+    }
+
+    private void logAppliedBatch(
+            RowKind rowKind, List<SeaTunnelRow> rows, long applyTimestampMs, long applyCostMs) {
+        SeaTunnelRow first = rows.get(0);
+        SeaTunnelRow last = rows.get(rows.size() - 1);
+        log.info(
+                "Milvus CDC sink applied batch: collection={}, partition={}, type={}, rowCount={}, firstPrimaryKey={}, lastPrimaryKey={}, applyTimestampMs={}, applyCostMs={}",
+                collectionName,
+                effectivePartitionName(first),
+                rowKind,
+                rows.size(),
+                primaryKeyValue(first),
+                primaryKeyValue(last),
+                applyTimestampMs,
+                applyCostMs);
+    }
+
+    private String effectivePartitionName(SeaTunnelRow element) {
+        return StringUtils.defaultIfEmpty(partitionName, element.getPartitionName());
+    }
+
+    private static int primaryKeyIndex(
+            CatalogTable catalogTable,
+            DescribeCollectionResp describeCollectionResp,
+            Map<String, String> milvusFieldMapper) {
+        String primaryKeyField = describeCollectionResp.getPrimaryFieldName();
+        if (StringUtils.isEmpty(primaryKeyField)) {
+            PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
+            if (primaryKey != null && primaryKey.getColumnNames().size() == 1) {
+                primaryKeyField = primaryKey.getColumnNames().get(0);
+            }
+        }
+        if (StringUtils.isEmpty(primaryKeyField)) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                    "Milvus CDC sink requires a single primary key field");
+        }
+
+        String[] fieldNames = catalogTable.getSeaTunnelRowType().getFieldNames();
+        for (int i = 0; i < fieldNames.length; i++) {
+            String sourceFieldName = fieldNames[i];
+            String targetFieldName =
+                    milvusFieldMapper.getOrDefault(sourceFieldName, sourceFieldName);
+            if (targetFieldName.equals(primaryKeyField)) {
+                return i;
+            }
+        }
+        throw new MilvusConnectorException(
+                MilvusConnectionErrorCode.WRITE_DATA_FAIL,
+                "primary key field not found in source row schema: " + primaryKeyField);
+    }
+
+    private static Map<String, String> buildFieldMapper(ReadonlyConfig config) {
+        Gson gson = new Gson();
+        Type type = new TypeToken<List<MilvusFieldSchema>>() {}.getType();
+        List<MilvusFieldSchema> fieldSchemaList =
+                gson.fromJson(gson.toJson(config.get(FIELD_SCHEMA)), type);
+
+        Map<String, String> milvusFieldMapper = new HashMap<>();
+        if (fieldSchemaList != null) {
+            for (MilvusFieldSchema field : fieldSchemaList) {
+                String sourceFieldName = field.getSourceFieldName();
+                if (sourceFieldName != null) {
+                    milvusFieldMapper.put(sourceFieldName, field.getFieldName());
+                }
+            }
+        }
+        return milvusFieldMapper;
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusWriterFactory.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusWriterFactory.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer;
+
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.StageBucket;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkWriteMode;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.StageHelper;
+
+import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig.BULK_WRITER_CONFIG;
+
+public class MilvusWriterFactory {
+
+    private final int expectedRowArity;
+    private final MilvusWriteStrategy strategy;
+
+    public MilvusWriterFactory(
+            CatalogTable catalogTable,
+            ReadonlyConfig config,
+            MilvusClientV2 milvusClient,
+            DescribeCollectionResp describeCollectionResp) {
+        this.expectedRowArity = catalogTable.getSeaTunnelRowType().getTotalFields();
+        MilvusSinkWriteMode writeMode = config.get(MilvusSinkConfig.WRITE_MODE);
+        boolean useBulkWriter = !config.get(BULK_WRITER_CONFIG).isEmpty();
+        if (writeMode == MilvusSinkWriteMode.CDC && useBulkWriter) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INVALID_PARAM,
+                    "Milvus CDC write mode does not support bulk_writer_config");
+        }
+        if (writeMode == MilvusSinkWriteMode.CDC
+                && Boolean.TRUE.equals(describeCollectionResp.getAutoID())) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INVALID_PARAM,
+                    "Milvus CDC write mode does not support autoID collections");
+        }
+        this.strategy =
+                createStrategy(
+                        writeMode,
+                        useBulkWriter,
+                        catalogTable,
+                        config,
+                        milvusClient,
+                        describeCollectionResp);
+    }
+
+    public MilvusWriter create(String partitionName) {
+        return strategy.create(partitionName);
+    }
+
+    public void validateRow(SeaTunnelRow element) {
+        validateRowArity(element);
+        strategy.validateRowKind(element);
+    }
+
+    private void validateRowArity(SeaTunnelRow element) {
+        if (element.getArity() != expectedRowArity) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.WRITE_ERROR,
+                    String.format(
+                            "Milvus sink row field count mismatch: expected %d fields, but received %d",
+                            expectedRowArity, element.getArity()));
+        }
+    }
+
+    private MilvusWriteStrategy createStrategy(
+            MilvusSinkWriteMode writeMode,
+            boolean useBulkWriter,
+            CatalogTable catalogTable,
+            ReadonlyConfig config,
+            MilvusClientV2 milvusClient,
+            DescribeCollectionResp describeCollectionResp) {
+        if (writeMode == MilvusSinkWriteMode.CDC) {
+            return new CdcWriteStrategy(catalogTable, config, milvusClient, describeCollectionResp);
+        }
+        if (useBulkWriter) {
+            StageBucket stageBucket = StageHelper.getStageBucket(config.get(BULK_WRITER_CONFIG));
+            return new BulkAppendWriteStrategy(catalogTable, config, stageBucket, describeCollectionResp);
+        }
+        return new BatchAppendWriteStrategy(catalogTable, config, milvusClient, describeCollectionResp);
+    }
+
+    private interface MilvusWriteStrategy {
+        MilvusWriter create(String partitionName);
+
+        default void validateRowKind(SeaTunnelRow element) {}
+    }
+
+    private abstract static class AppendWriteStrategy implements MilvusWriteStrategy {
+        @Override
+        public void validateRowKind(SeaTunnelRow element) {
+            RowKind rowKind = element.getRowKind();
+            if (rowKind != null && rowKind != RowKind.INSERT) {
+                throw new MilvusConnectorException(
+                        MilvusConnectionErrorCode.WRITE_ERROR,
+                        "Milvus APPEND write mode only supports INSERT rows. "
+                                + "Set write_mode = cdc for Milvus CDC INSERT/DELETE rows.");
+            }
+        }
+    }
+
+    private static class BatchAppendWriteStrategy extends AppendWriteStrategy {
+        private final CatalogTable catalogTable;
+        private final ReadonlyConfig config;
+        private final MilvusClientV2 milvusClient;
+        private final DescribeCollectionResp describeCollectionResp;
+
+        private BatchAppendWriteStrategy(
+                CatalogTable catalogTable,
+                ReadonlyConfig config,
+                MilvusClientV2 milvusClient,
+                DescribeCollectionResp describeCollectionResp) {
+            this.catalogTable = catalogTable;
+            this.config = config;
+            this.milvusClient = milvusClient;
+            this.describeCollectionResp = describeCollectionResp;
+        }
+
+        @Override
+        public MilvusWriter create(String partitionName) {
+            return new MilvusBufferBatchWriter(
+                    catalogTable, config, milvusClient, describeCollectionResp, partitionName);
+        }
+    }
+
+    private static class BulkAppendWriteStrategy extends AppendWriteStrategy {
+        private final CatalogTable catalogTable;
+        private final ReadonlyConfig config;
+        private final StageBucket stageBucket;
+        private final DescribeCollectionResp describeCollectionResp;
+
+        private BulkAppendWriteStrategy(
+                CatalogTable catalogTable,
+                ReadonlyConfig config,
+                StageBucket stageBucket,
+                DescribeCollectionResp describeCollectionResp) {
+            this.catalogTable = catalogTable;
+            this.config = config;
+            this.stageBucket = stageBucket;
+            this.describeCollectionResp = describeCollectionResp;
+        }
+
+        @Override
+        public MilvusWriter create(String partitionName) {
+            return new MilvusBulkWriter(
+                    catalogTable, config, stageBucket, describeCollectionResp, partitionName);
+        }
+    }
+
+    private static class CdcWriteStrategy implements MilvusWriteStrategy {
+        private final CatalogTable catalogTable;
+        private final ReadonlyConfig config;
+        private final MilvusClientV2 milvusClient;
+        private final DescribeCollectionResp describeCollectionResp;
+
+        private CdcWriteStrategy(
+                CatalogTable catalogTable,
+                ReadonlyConfig config,
+                MilvusClientV2 milvusClient,
+                DescribeCollectionResp describeCollectionResp) {
+            this.catalogTable = catalogTable;
+            this.config = config;
+            this.milvusClient = milvusClient;
+            this.describeCollectionResp = describeCollectionResp;
+        }
+
+        @Override
+        public MilvusWriter create(String partitionName) {
+            return new MilvusCdcWriter(
+                    catalogTable, config, milvusClient, describeCollectionResp, partitionName);
+        }
+
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
@@ -156,7 +156,7 @@ public class MilvusSourceConnectorUtils {
         if (functionList != null && !functionList.isEmpty()) {
             options.put(MilvusConstants.FUNCTION_LIST, gson.toJson(functionList));
         } else {
-            options.put(MilvusConstants.FUNCTION_LIST, "[]");
+            options.put(MilvusConstants.FUNCTION_LIST, MilvusConstants.EMPTY_JSON_ARRAY);
         }
 
         // Note: struct fields are serialized per-column in MilvusSourceConverter, not
@@ -173,17 +173,17 @@ public class MilvusSourceConnectorUtils {
             DescribeIndexResp describeIndexResp = client.describeIndex(describeIndexReq);
             for (DescribeIndexResp.IndexDesc indexDesc : describeIndexResp.getIndexDescriptions()) {
                 Map<String, String> indexInfo = new HashMap<>();
-                indexInfo.put("fieldName", indexDesc.getFieldName());
-                indexInfo.put("indexName", indexDesc.getIndexName());
+                indexInfo.put(MilvusConstants.INDEX_FIELD_NAME, indexDesc.getFieldName());
+                indexInfo.put(MilvusConstants.INDEX_NAME, indexDesc.getIndexName());
                 IndexType indexType = indexDesc.getIndexType();
                 if (indexType != null) {
-                    indexInfo.put("indexType", indexType.getName());
+                    indexInfo.put(MilvusConstants.INDEX_TYPE, indexType.getName());
                 }
                 if (indexDesc.getMetricType() != MetricType.INVALID) {
-                    indexInfo.put("metricType", indexDesc.getMetricType().name());
+                    indexInfo.put(MilvusConstants.METRIC_TYPE, indexDesc.getMetricType().name());
                 }
                 if (indexDesc.getExtraParams() != null && !indexDesc.getExtraParams().isEmpty()) {
-                    indexInfo.put("extraParams", gson.toJson(indexDesc.getExtraParams()));
+                    indexInfo.put(MilvusConstants.EXTRA_PARAMS, gson.toJson(indexDesc.getExtraParams()));
                 }
                 indexList.add(indexInfo);
             }

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkFactoryTest.java
@@ -1,7 +1,10 @@
 package org.apache.seatunnel.connectors.seatunnel.milvus.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.DataSaveMode;
+import org.apache.seatunnel.api.sink.SchemaSaveMode;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkWriteMode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,5 +40,85 @@ class MilvusSinkFactoryTest {
         ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
 
         Assertions.assertFalse(config.get(MilvusSinkConfig.CREATE_INDEX));
+    }
+
+    @Test
+    void writeModeDefaultsToAppend() {
+        ReadonlyConfig config = ReadonlyConfig.fromMap(new HashMap<>());
+
+        Assertions.assertEquals(MilvusSinkWriteMode.APPEND, config.get(MilvusSinkConfig.WRITE_MODE));
+    }
+
+    @Test
+    void writeModeCanUseLowerCaseCdc() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "cdc");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Assertions.assertEquals(MilvusSinkWriteMode.CDC, config.get(MilvusSinkConfig.WRITE_MODE));
+    }
+
+    @Test
+    void cdcWriteModeRejectsDefaultSchemaSaveMode() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "cdc");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> MilvusSinkFactory.validateCdcSaveMode(config));
+        Assertions.assertTrue(exception.getMessage().contains("ERROR_WHEN_SCHEMA_NOT_EXIST"));
+    }
+
+    @Test
+    void cdcWriteModeAllowsExplicitNonDestructiveSaveMode() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "cdc");
+        configMap.put("schema_save_mode", SchemaSaveMode.ERROR_WHEN_SCHEMA_NOT_EXIST);
+        configMap.put("data_save_mode", DataSaveMode.APPEND_DATA);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Assertions.assertDoesNotThrow(() -> MilvusSinkFactory.validateCdcSaveMode(config));
+    }
+
+    @Test
+    void cdcWriteModeRejectsRecreateSchemaSaveMode() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "cdc");
+        configMap.put("schema_save_mode", SchemaSaveMode.RECREATE_SCHEMA);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> MilvusSinkFactory.validateCdcSaveMode(config));
+        Assertions.assertTrue(exception.getMessage().contains("ERROR_WHEN_SCHEMA_NOT_EXIST"));
+    }
+
+    @Test
+    void cdcWriteModeRejectsDropDataSaveMode() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "cdc");
+        configMap.put("schema_save_mode", SchemaSaveMode.ERROR_WHEN_SCHEMA_NOT_EXIST);
+        configMap.put("data_save_mode", DataSaveMode.DROP_DATA);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> MilvusSinkFactory.validateCdcSaveMode(config));
+        Assertions.assertTrue(exception.getMessage().contains("APPEND_DATA"));
+    }
+
+    @Test
+    void appendWriteModeDoesNotUseCdcSaveModeRestrictions() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", "append");
+        configMap.put("schema_save_mode", SchemaSaveMode.RECREATE_SCHEMA);
+        configMap.put("data_save_mode", DataSaveMode.DROP_DATA);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Assertions.assertDoesNotThrow(() -> MilvusSinkFactory.validateCdcSaveMode(config));
     }
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/MilvusSinkWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink;
+
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+class MilvusSinkWriterTest {
+
+    @Test
+    void rejectsRuntimeSchemaChanges() {
+        MilvusSinkWriter writer = mock(MilvusSinkWriter.class, CALLS_REAL_METHODS);
+        SchemaChangeEvent event = mock(SchemaChangeEvent.class);
+
+        IOException exception =
+                assertThrows(IOException.class, () -> writer.applySchemaChange(event));
+
+        assertTrue(exception.getMessage().contains("does not support runtime schema changes"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverterTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverterTest.java
@@ -37,16 +37,19 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants;
 import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,9 +441,14 @@ public class MilvusSinkConverterTest {
     @Test
     public void testBuildMilvusData_MetadataFieldConvertedByTargetSchema() {
         SeaTunnelRowType rowType = new SeaTunnelRowType(
-                new String[]{CommonOptions.METADATA.getName()},
+                new String[]{MilvusConstants.MILVUS_INTERNAL_DYNAMIC_FIELD},
                 new SeaTunnelDataType<?>[]{BasicType.STRING_TYPE});
-        CatalogTable catalogTable = buildCatalogTable(rowType);
+        CatalogTable catalogTable =
+                buildCatalogTable(
+                        rowType,
+                        Collections.singletonMap(
+                                MilvusConstants.MILVUS_INTERNAL_DYNAMIC_FIELD,
+                                metadataOptions()));
 
         JsonObject metadata = new JsonObject();
         metadata.addProperty("store_id", 100001);
@@ -473,11 +481,34 @@ public class MilvusSinkConverterTest {
     }
 
     @Test
+    public void testBuildMilvusData_InternalMetaNameWithoutOptionIsDynamicField() {
+        SeaTunnelRowType rowType = new SeaTunnelRowType(
+                new String[]{MilvusConstants.MILVUS_INTERNAL_DYNAMIC_FIELD},
+                new SeaTunnelDataType<?>[]{BasicType.STRING_TYPE});
+        CatalogTable catalogTable = buildCatalogTable(rowType);
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("dynamic_key", "dynamic-value");
+        SeaTunnelRow row = new SeaTunnelRow(new Object[]{metadata.toString()});
+
+        JsonObject data =
+                converter.buildMilvusData(
+                        catalogTable, buildDescribeCollectionResp(), new HashMap<>(), row);
+
+        Assertions.assertEquals("dynamic-value", data.get("dynamic_key").getAsString());
+        Assertions.assertFalse(data.has(MilvusConstants.MILVUS_INTERNAL_DYNAMIC_FIELD));
+    }
+
+    @Test
     public void testBuildMilvusData_MetadataArrayPassedThrough() {
         SeaTunnelRowType rowType = new SeaTunnelRowType(
                 new String[]{CommonOptions.METADATA.getName()},
                 new SeaTunnelDataType<?>[]{BasicType.STRING_TYPE});
-        CatalogTable catalogTable = buildCatalogTable(rowType);
+        CatalogTable catalogTable =
+                buildCatalogTable(
+                        rowType,
+                        Collections.singletonMap(
+                                CommonOptions.METADATA.getName(), metadataOptions()));
 
         JsonArray tags = new JsonArray();
         tags.add(100001);
@@ -507,11 +538,54 @@ public class MilvusSinkConverterTest {
         Assertions.assertEquals("MSID-A001", result.get(1).getAsString());
     }
 
-    // --- Geometry: in practice every VTS source connector emits Geometry as
-    //     String. The sink tests below therefore only cover the String path
-    //     (PASSTHROUGH and PARSE) and the contract that PASSTHROUGH returns
-    //     whatever it gets, as-is. Byte-level WKB tests live alongside
-    //     GeometryConverter.convertWkbBytes in the geometry-specific test class.
+    @Test
+    public void testBuildMilvusData_LegacyMetadataNameWithoutOptionIsDynamicWhenNoTargetField() {
+        SeaTunnelRowType rowType = new SeaTunnelRowType(
+                new String[]{CommonOptions.METADATA.getName()},
+                new SeaTunnelDataType<?>[]{BasicType.STRING_TYPE});
+        CatalogTable catalogTable = buildCatalogTable(rowType);
+
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("legacy_key", "legacy-value");
+        SeaTunnelRow row = new SeaTunnelRow(new Object[]{metadata.toString()});
+
+        JsonObject data =
+                converter.buildMilvusData(
+                        catalogTable, buildDescribeCollectionResp(), new HashMap<>(), row);
+
+        Assertions.assertEquals("legacy-value", data.get("legacy_key").getAsString());
+        Assertions.assertFalse(data.has(CommonOptions.METADATA.getName()));
+    }
+
+    @Test
+    public void testBuildMilvusData_MetadataNameWithoutOptionKeepsLegacyDynamicSemantics() {
+        SeaTunnelRowType rowType = new SeaTunnelRowType(
+                new String[]{CommonOptions.METADATA.getName()},
+                new SeaTunnelDataType<?>[]{BasicType.STRING_TYPE});
+        CatalogTable catalogTable = buildCatalogTable(rowType);
+        JsonObject metadata = new JsonObject();
+        metadata.addProperty("legacy_key", "legacy-value");
+        SeaTunnelRow row = new SeaTunnelRow(new Object[]{metadata.toString()});
+
+        DescribeCollectionResp describeCollectionResp =
+                buildDescribeCollectionResp(
+                        FieldSchema.builder()
+                                .name(CommonOptions.METADATA.getName())
+                                .dataType(DataType.VarChar)
+                                .maxLength(200)
+                                .build());
+
+        JsonObject data =
+                converter.buildMilvusData(
+                        catalogTable, describeCollectionResp, new HashMap<>(), row);
+
+        Assertions.assertEquals("legacy-value", data.get("legacy_key").getAsString());
+        Assertions.assertFalse(data.has(CommonOptions.METADATA.getName()));
+    }
+
+    // --- Geometry: most VTS source connectors emit Geometry as String. Milvus CDC
+    //     can emit raw WKB bytes, so the sink must parse ByteBuffer values before
+    //     handing data to the Milvus SDK.
 
     @Test
     public void testConvertByMilvusType_Geometry_StringWkt() {
@@ -534,6 +608,39 @@ public class MilvusSinkConverterTest {
         FieldSchema schema = FieldSchema.builder()
                 .name("loc").dataType(DataType.Geometry).build();
         Assertions.assertNull(converter.convertByMilvusType(schema, null));
+    }
+
+    @Test
+    public void testConvertByMilvusType_Geometry_ByteBufferWkbParsesToWkt() {
+        FieldSchema schema = FieldSchema.builder()
+                .name("loc").dataType(DataType.Geometry).build();
+        byte[] wkb = hexToBytes("0101000000000000000000F03F000000000000F03F");
+
+        Object result = converter.convertByMilvusType(schema, ByteBuffer.wrap(wkb));
+
+        Assertions.assertEquals("POINT (1 1)", result);
+    }
+
+    @Test
+    public void testBuildMilvusData_Geometry_ByteBufferWkbDoesNotSerializeByteBuffer() {
+        SeaTunnelRowType rowType = new SeaTunnelRowType(
+                new String[]{"loc"},
+                new SeaTunnelDataType<?>[]{GeometryType.GEOMETRY_TYPE});
+        CatalogTable catalogTable = buildCatalogTable(rowType);
+        DescribeCollectionResp describeCollectionResp = buildDescribeCollectionResp(
+                FieldSchema.builder()
+                        .name("loc")
+                        .dataType(DataType.Geometry)
+                        .build());
+        byte[] wkb = hexToBytes("0101000000000000000000F03F000000000000F03F");
+
+        JsonObject data = converter.buildMilvusData(
+                catalogTable,
+                describeCollectionResp,
+                new HashMap<>(),
+                new SeaTunnelRow(new Object[]{ByteBuffer.wrap(wkb)}));
+
+        Assertions.assertEquals("POINT (1 1)", data.get("loc").getAsString());
     }
 
     @Test
@@ -710,18 +817,21 @@ public class MilvusSinkConverterTest {
     }
 
     private static CatalogTable buildCatalogTable(SeaTunnelRowType rowType) {
+        return buildCatalogTable(rowType, Collections.emptyMap());
+    }
+
+    private static CatalogTable buildCatalogTable(
+            SeaTunnelRowType rowType, Map<String, Map<String, Object>> columnOptions) {
         TableSchema.Builder schemaBuilder = TableSchema.builder();
         String[] fieldNames = rowType.getFieldNames();
         for (int i = 0; i < fieldNames.length; i++) {
-            schemaBuilder.column(PhysicalColumn.of(
-                    fieldNames[i],
-                    rowType.getFieldType(i),
-                    0L,
-                    true,
-                    null,
-                    null,
-                    null,
-                    null));
+            schemaBuilder.column(
+                    PhysicalColumn.builder()
+                            .name(fieldNames[i])
+                            .dataType(rowType.getFieldType(i))
+                            .nullable(true)
+                            .options(columnOptions.get(fieldNames[i]))
+                            .build());
         }
         return CatalogTable.of(
                 TableIdentifier.of("test", TablePath.of("default", "test_collection")),
@@ -744,5 +854,20 @@ public class MilvusSinkConverterTest {
                 .autoID(false)
                 .collectionSchema(schema)
                 .build();
+    }
+
+    private static Map<String, Object> metadataOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(CommonOptions.METADATA.getName(), true);
+        return options;
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        int len = hex.length();
+        byte[] out = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            out[i / 2] = (byte) Integer.parseInt(hex.substring(i, i + 2), 16);
+        }
+        return out;
     }
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusCdcWriterTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusCdcWriterTest.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer;
+
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import io.milvus.v2.service.vector.request.DeleteReq;
+import io.milvus.v2.service.vector.request.UpsertReq;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class MilvusCdcWriterTest {
+
+    private static final String CURRENT_MESSAGE_ID = "MilvusCdcCurrentMessageId";
+    private static final String MESSAGE_END = "MilvusCdcMessageEnd";
+
+    @Test
+    void metadataFreeRowsFlushAtConfiguredBatchSize() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 2);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        verify(client, never()).upsert(any(UpsertReq.class));
+
+        writer.write(rowWithoutMilvusMetadata(2L, "bob", RowKind.INSERT));
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(2, captor.getValue().getData().size());
+
+        writer.write(rowWithoutMilvusMetadata(3L, "carol", RowKind.INSERT));
+        verify(client, times(1)).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void metadataFreeRowKindChangePreservesOperationOrder() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 10);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.DELETE));
+
+        verify(client).upsert(any(UpsertReq.class));
+        verify(client, never()).delete(any(DeleteReq.class));
+
+        writer.commit(true);
+
+        org.mockito.InOrder order = inOrder(client);
+        order.verify(client).upsert(any(UpsertReq.class));
+        order.verify(client).delete(any(DeleteReq.class));
+    }
+
+    @Test
+    void commitFlushesPendingInsertRows() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        writer.write(rowWithoutMilvusMetadata(2L, "bob", RowKind.INSERT));
+        verify(client, never()).upsert(any(UpsertReq.class));
+
+        writer.commit(true);
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(2, captor.getValue().getData().size());
+        verify(client, never()).delete(any(DeleteReq.class));
+    }
+
+    @Test
+    void commitFlushesPendingDeleteRows() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+        SeaTunnelRow first = rowWithoutMilvusMetadata(1L, "alice", RowKind.DELETE);
+        SeaTunnelRow second = rowWithoutMilvusMetadata(2L, "bob", RowKind.DELETE);
+
+        writer.write(first);
+        writer.write(second);
+        verify(client, never()).delete(any(DeleteReq.class));
+
+        writer.commit(true);
+
+        ArgumentCaptor<DeleteReq> captor = ArgumentCaptor.forClass(DeleteReq.class);
+        verify(client).delete(captor.capture());
+        assertEquals(Arrays.asList(1L, 2L), captor.getValue().getIds());
+        verify(client, never()).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void milvusReaderMetadataDoesNotAffectBatching() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 10);
+
+        writer.write(cdcRow(1L, "alice", "message-1", false));
+        writer.write(cdcRow(2L, "bob", "message-2", true));
+        verify(client, never()).upsert(any(UpsertReq.class));
+
+        writer.commit(true);
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client, times(1)).upsert(captor.capture());
+        assertEquals(2, captor.getValue().getData().size());
+    }
+
+    @Test
+    void writeTriggeredIntervalFlushesPendingRowsIncludingCurrentRow() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        AtomicLong currentTimeMillis = new AtomicLong(0L);
+        MilvusCdcWriter writer = newWriter(client, 10, 1000L, currentTimeMillis);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        currentTimeMillis.set(999L);
+        writer.write(rowWithoutMilvusMetadata(2L, "bob", RowKind.INSERT));
+        verify(client, never()).upsert(any(UpsertReq.class));
+
+        currentTimeMillis.set(1000L);
+        writer.write(rowWithoutMilvusMetadata(3L, "carol", RowKind.INSERT));
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(3, captor.getValue().getData().size());
+    }
+
+    @Test
+    void successfulIntervalFlushResetsTheNextInterval() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        AtomicLong currentTimeMillis = new AtomicLong(0L);
+        MilvusCdcWriter writer = newWriter(client, 10, 1000L, currentTimeMillis);
+
+        currentTimeMillis.set(1000L);
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        currentTimeMillis.set(1999L);
+        writer.write(rowWithoutMilvusMetadata(2L, "bob", RowKind.INSERT));
+        verify(client, times(1)).upsert(any(UpsertReq.class));
+
+        currentTimeMillis.set(2000L);
+        writer.write(rowWithoutMilvusMetadata(3L, "carol", RowKind.INSERT));
+
+        verify(client, times(2)).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void systemTimeRollbackFlushesPendingRows() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        AtomicLong currentTimeMillis = new AtomicLong(1000L);
+        MilvusCdcWriter writer = newWriter(client, 10, 1000L, currentTimeMillis);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "alice", RowKind.INSERT));
+        currentTimeMillis.set(900L);
+        writer.write(rowWithoutMilvusMetadata(2L, "bob", RowKind.INSERT));
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(2, captor.getValue().getData().size());
+
+        writer.write(rowWithoutMilvusMetadata(3L, "carol", RowKind.INSERT));
+        verify(client, times(1)).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void writeDeleteRowUsesMappedPrimaryKeyField() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        Map<String, Object> fieldSchema = new HashMap<>();
+        fieldSchema.put("source_field_name", "source_id");
+        fieldSchema.put("field_name", "id");
+        Map<String, Object> config = new HashMap<>();
+        config.put("field_schema", Collections.singletonList(fieldSchema));
+        MilvusCdcWriter writer =
+                new MilvusCdcWriter(
+                        renamedPrimaryKeyCatalogTable(),
+                        ReadonlyConfig.fromMap(config),
+                        client,
+                        describeCollectionResp(),
+                        "_default");
+        SeaTunnelRow row = rowWithoutMilvusMetadata(7L, "alice", RowKind.DELETE);
+
+        writer.write(row);
+        writer.commit(true);
+
+        ArgumentCaptor<DeleteReq> captor = ArgumentCaptor.forClass(DeleteReq.class);
+        verify(client).delete(captor.capture());
+        assertEquals(Collections.singletonList(7L), captor.getValue().getIds());
+    }
+
+    @Test
+    void updateBeforeAndUpdateAfterAreAppliedAsSingleUpsert() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "before", RowKind.UPDATE_BEFORE));
+        writer.write(rowWithoutMilvusMetadata(1L, "after", RowKind.UPDATE_AFTER));
+        writer.commit(true);
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client, never()).delete(any(DeleteReq.class));
+        verify(client).upsert(captor.capture());
+        assertEquals(1, captor.getValue().getData().size());
+        assertEquals("after", captor.getValue().getData().get(0).get("name").getAsString());
+    }
+
+    @Test
+    void updateBeforeDoesNotCreatePendingMutation() throws Exception {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "before", RowKind.UPDATE_BEFORE));
+
+        assertEquals(0, pendingRowCount(writer));
+        assertFalse(writer.needCommit());
+        writer.commit(true);
+        verify(client, never()).delete(any(DeleteReq.class));
+        verify(client, never()).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void nullRowKindIsRejected() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+        SeaTunnelRow row = rowWithoutMilvusMetadata(1L, "alice", null);
+
+        MilvusConnectorException exception =
+                assertThrows(MilvusConnectorException.class, () -> writer.write(row));
+
+        assertTrue(exception.getMessage().contains("CDC row kind must not be null"));
+        assertFalse(writer.needCommit());
+        verify(client, never()).delete(any(DeleteReq.class));
+        verify(client, never()).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void primaryKeyChangeAsDeleteThenInsertRemovesOldKeyAndUpsertsNewKey() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "before", RowKind.DELETE));
+        writer.write(rowWithoutMilvusMetadata(2L, "after", RowKind.INSERT));
+
+        ArgumentCaptor<DeleteReq> deleteCaptor = ArgumentCaptor.forClass(DeleteReq.class);
+        ArgumentCaptor<UpsertReq> upsertCaptor = ArgumentCaptor.forClass(UpsertReq.class);
+        org.mockito.InOrder order = inOrder(client);
+        order.verify(client).delete(deleteCaptor.capture());
+        order.verify(client).upsert(upsertCaptor.capture());
+        assertEquals(Collections.singletonList(1L), deleteCaptor.getValue().getIds());
+        assertEquals(2L, upsertCaptor.getValue().getData().get(0).get("id").getAsLong());
+        assertFalse(writer.needCommit());
+    }
+
+    @Test
+    void deleteFlushedByIntervalStillFlushesFollowingInsertImmediately() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        AtomicLong currentTimeMillis = new AtomicLong(0L);
+        MilvusCdcWriter writer = newWriter(client, 10, 1000L, currentTimeMillis);
+
+        currentTimeMillis.set(1000L);
+        writer.write(rowWithoutMilvusMetadata(1L, "before", RowKind.DELETE));
+        verify(client).delete(any(DeleteReq.class));
+        assertFalse(writer.needCommit());
+
+        currentTimeMillis.set(1001L);
+        writer.write(rowWithoutMilvusMetadata(2L, "after", RowKind.INSERT));
+        verify(client).upsert(any(UpsertReq.class));
+        assertFalse(writer.needCommit());
+    }
+
+    @Test
+    void insertAndUpdateAfterShareTheSameUpsertBatch() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 10);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "insert", RowKind.INSERT));
+        writer.write(rowWithoutMilvusMetadata(2L, "update", RowKind.UPDATE_AFTER));
+        verify(client, never()).upsert(any(UpsertReq.class));
+
+        writer.commit(true);
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(2, captor.getValue().getData().size());
+    }
+
+    @Test
+    void duplicatePrimaryKeysAreDeduplicatedWhilePending() throws Exception {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 10);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "first", RowKind.INSERT));
+        writer.write(rowWithoutMilvusMetadata(1L, "last", RowKind.UPDATE_AFTER));
+
+        assertEquals(1, pendingRowCount(writer));
+        verify(client, never()).upsert(any(UpsertReq.class));
+    }
+
+    @Test
+    void duplicatePrimaryKeysInUpsertBatchKeepTheLastRow() {
+        MilvusClientV2 client = mock(MilvusClientV2.class);
+        MilvusCdcWriter writer = newWriter(client, 2);
+
+        writer.write(rowWithoutMilvusMetadata(1L, "first", RowKind.INSERT));
+        writer.write(rowWithoutMilvusMetadata(1L, "last", RowKind.UPDATE_AFTER));
+
+        ArgumentCaptor<UpsertReq> captor = ArgumentCaptor.forClass(UpsertReq.class);
+        verify(client).upsert(captor.capture());
+        assertEquals(1, captor.getValue().getData().size());
+        assertEquals("last", captor.getValue().getData().get(0).get("name").getAsString());
+    }
+
+    private static int pendingRowCount(MilvusCdcWriter writer) throws Exception {
+        Field pendingRowsField = MilvusCdcWriter.class.getDeclaredField("pendingRows");
+        pendingRowsField.setAccessible(true);
+        Object pendingRows = pendingRowsField.get(writer);
+        if (pendingRows instanceof Map) {
+            return ((Map<?, ?>) pendingRows).size();
+        }
+        return ((List<?>) pendingRows).size();
+    }
+
+    private static MilvusCdcWriter newWriter(MilvusClientV2 client) {
+        return newWriter(client, 1000);
+    }
+
+    private static MilvusCdcWriter newWriter(MilvusClientV2 client, int batchSize) {
+        return newWriter(client, batchSize, 1000L, new AtomicLong(0L));
+    }
+
+    private static MilvusCdcWriter newWriter(
+            MilvusClientV2 client,
+            int batchSize,
+            long cdcBatchFlushIntervalMs,
+            AtomicLong currentTimeMillis) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("batch_size", batchSize);
+        config.put("cdc_batch_flush_interval_ms", cdcBatchFlushIntervalMs);
+        return new MilvusCdcWriter(
+                catalogTable(),
+                ReadonlyConfig.fromMap(config),
+                client,
+                describeCollectionResp(),
+                "_default",
+                currentTimeMillis::get);
+    }
+
+    private static SeaTunnelRow rowWithoutMilvusMetadata(
+            long id, String name, RowKind rowKind) {
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {id, name});
+        row.setRowKind(rowKind);
+        return row;
+    }
+
+    private static SeaTunnelRow cdcRow(
+            long id, String name, String currentMessageId, boolean messageEnd) {
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {id, name});
+        row.getOptions().put(CURRENT_MESSAGE_ID, currentMessageId);
+        if (messageEnd) {
+            row.getOptions().put(MESSAGE_END, true);
+        }
+        return row;
+    }
+
+    private static CatalogTable catalogTable() {
+        List<Column> columns =
+                Arrays.asList(
+                        PhysicalColumn.builder().name("id").dataType(BasicType.LONG_TYPE).build(),
+                        PhysicalColumn.builder()
+                                .name("name")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+
+        return CatalogTable.of(
+                TableIdentifier.of("test", TablePath.of("default", "test_collection")),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                Collections.emptyList(),
+                "");
+    }
+
+    private static CatalogTable renamedPrimaryKeyCatalogTable() {
+        List<Column> columns =
+                Arrays.asList(
+                        PhysicalColumn.builder()
+                                .name("source_id")
+                                .dataType(BasicType.LONG_TYPE)
+                                .build(),
+                        PhysicalColumn.builder()
+                                .name("name")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+
+        return CatalogTable.of(
+                TableIdentifier.of("test", TablePath.of("default", "test_collection")),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                Collections.emptyList(),
+                "");
+    }
+
+    private static DescribeCollectionResp describeCollectionResp() {
+        CreateCollectionReq.FieldSchema idField =
+                CreateCollectionReq.FieldSchema.builder()
+                        .name("id")
+                        .dataType(DataType.Int64)
+                        .isPrimaryKey(true)
+                        .build();
+        CreateCollectionReq.FieldSchema nameField =
+                CreateCollectionReq.FieldSchema.builder()
+                        .name("name")
+                        .dataType(DataType.VarChar)
+                        .maxLength(128)
+                        .build();
+        CreateCollectionReq.CollectionSchema schema =
+                CreateCollectionReq.CollectionSchema.builder()
+                        .enableDynamicField(true)
+                        .fieldSchemaList(Arrays.asList(idField, nameField))
+                        .functionList(new ArrayList<>())
+                        .build();
+        return DescribeCollectionResp.builder()
+                .collectionName("test_collection")
+                .primaryFieldName("id")
+                .enableDynamicField(true)
+                .autoID(false)
+                .collectionSchema(schema)
+                .build();
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusWriterFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusWriterFactoryTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.writer;
+
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.MilvusSinkWriteMode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class MilvusWriterFactoryTest {
+
+    @Test
+    void validatesRowFieldCountBeforeWriting() {
+        MilvusWriterFactory factory = createFactory();
+
+        assertDoesNotThrow(() -> factory.validateRow(new SeaTunnelRow(new Object[] {1L, "alice"})));
+
+        MilvusConnectorException exception =
+                assertThrows(
+                        MilvusConnectorException.class,
+                        () -> factory.validateRow(new SeaTunnelRow(new Object[] {1L})));
+        assertTrue(exception.getMessage().contains("expected 2 fields, but received 1"));
+    }
+
+    @Test
+    void cdcWriteModeRejectsAutoIdCollection() {
+        HashMap<String, Object> configMap = new HashMap<>();
+        configMap.put("write_mode", MilvusSinkWriteMode.CDC);
+        DescribeCollectionResp describeCollectionResp =
+                DescribeCollectionResp.builder().autoID(true).build();
+
+        MilvusConnectorException exception =
+                assertThrows(
+                        MilvusConnectorException.class,
+                        () ->
+                                new MilvusWriterFactory(
+                                        catalogTable(),
+                                        ReadonlyConfig.fromMap(configMap),
+                                        mock(MilvusClientV2.class),
+                                        describeCollectionResp));
+
+        assertTrue(exception.getMessage().contains("does not support autoID"));
+    }
+
+    private static MilvusWriterFactory createFactory() {
+        return new MilvusWriterFactory(
+                catalogTable(),
+                ReadonlyConfig.fromMap(new HashMap<>()),
+                mock(MilvusClientV2.class),
+                mock(DescribeCollectionResp.class));
+    }
+
+    private static CatalogTable catalogTable() {
+        List<Column> columns =
+                Arrays.asList(
+                        PhysicalColumn.builder().name("id").dataType(BasicType.LONG_TYPE).build(),
+                        PhysicalColumn.builder()
+                                .name("name")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+
+        return CatalogTable.of(
+                TableIdentifier.of("test", TablePath.of("default", "test_collection")),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                Collections.emptyList(),
+                "");
+    }
+}


### PR DESCRIPTION
## Purpose

Add a generic CDC write mode to the Milvus sink independently of the Milvus CDC source connector, so existing SeaTunnel CDC readers can write changelog rows to Milvus first.

## Changes

- Add `write_mode = CDC` with INSERT/UPDATE_AFTER upsert, DELETE handling, and UPDATE_BEFORE filtering.
- Add primary-key deduplication, batch/interval/checkpoint flushing, and ordered DELETE-to-upsert switching.
- Validate CDC save modes, target primary key, autoID, row shape, and runtime schema changes.
- Extend Milvus sink conversion for CDC row values and dynamic metadata fields.
- Add sink documentation and unit coverage.

This PR contains the `connector-milvus` changes from `0601_feat_milvus_cdc` and intentionally excludes the `connector-cdc-milvus` reader module, reader registration, distribution changes, and reader documentation.

## Test

```bash
./mvnw -pl seatunnel-connectors-v2/connector-milvus \
  "-Dtest=*,!MilvusSinkTest" \
  -Dmaven.test.skip=false -DskipTests=false -DskipUT=false test
```

Result: 201 tests run, 0 failures, 0 errors, 1 skipped.