### PR TITLE
[Feature][Connector-Postgres-CDC] Restore PostgreSQL CDC with geometry support

### DIFF
--- a/docs/en/connector-v2/sink/Milvus.md
+++ b/docs/en/connector-v2/sink/Milvus.md
@@ -55,6 +55,8 @@ This Milvus sink connector write data to Milvus or Zilliz Cloud, it has the foll
 | batch_size           | int     | No       | 1000                         | Write batch size.                                         |
 | cdc_batch_flush_interval_ms | long | No       | 1000                         | In CDC mode, flush pending rows when a newly received row observes that this interval has elapsed since the last successful flush. |
 | write_mode           | enum    | No       | APPEND                       | Write mode. `APPEND` writes normal insert rows by batch or bulk writer. `CDC` upserts INSERT and UPDATE_AFTER rows, deletes DELETE rows, and ignores UPDATE_BEFORE rows. |
+| geometry_convert_mode | String | No       | passthrough                  | How to handle String values for Milvus Geometry fields. `passthrough` sends the value unchanged; `parse` converts WKT/EWKT/GeoJSON/WKB hex and supported coordinate formats to WKT. |
+| geometry_string_coord_order | String | No | lat_lon                     | Coordinate order for bare numeric pair strings in `parse` mode. Supported values are `lat_lon` and `lon_lat`. WKT, GeoJSON and WKB inputs are unaffected. |
 | partition_key        | String  | No       |                              | Milvus partition key field                                |
 | partition_num        | int     | No       |                              | Number of partitions passed to Milvus create collection request. Currently used by Milvus partition key mode. |
 | collection_rename    | Map     | No       | {}                           | Rename collections: `{source_name = "target_name"}`       |
@@ -108,6 +110,8 @@ CDC write mode has the following constraints:
 - `bulk_writer_config` is not supported.
 - The target collection must not use autoID.
 - The target collection must have exactly one primary key field.
+
+For PostgreSQL CDC sources containing PostGIS `GEOMETRY` or `GEOGRAPHY` columns, set `geometry_convert_mode = "parse"`. PostgreSQL CDC emits these values as WKB/EWKB hexadecimal strings, and the Milvus sink converts them to WKT. The target collection must already define the corresponding field as Milvus `GEOMETRY`.
 
 The CDC writer accepts generic keyed changelog rows and does not require `Milvus-CDC`-specific message metadata. INSERT and UPDATE_AFTER rows are applied by upsert, DELETE rows are applied by primary key delete, and UPDATE_BEFORE rows are ignored. The Milvus primary key must correspond to a stable source CDC key; a primary-key change must be emitted by the source as DELETE for the old key followed by INSERT for the new key. Duplicate primary keys within one upsert batch keep the last row. Consecutive rows with the same target operation are flushed when they reach `batch_size`. Whenever a row is added to the pending batch, the writer also checks `cdc_batch_flush_interval_ms`; when the interval since the last successful flush has elapsed, it flushes the pending batch including the current row. Any target-operation change flushes the previous pending batch. When switching from DELETE to upsert, the current upsert is also flushed immediately so the new key does not remain pending after the old key has been deleted. When switching from upsert to DELETE, the current DELETE continues to follow the normal batch, interval, checkpoint, or writer-close flush rules.
 

--- a/docs/en/connector-v2/source/PostgreSQL-CDC.md
+++ b/docs/en/connector-v2/source/PostgreSQL-CDC.md
@@ -28,7 +28,7 @@ describes how to set up the Postgre CDC connector to run SQL queries against Pos
 | Datasource |                     Supported versions                     |        Driver         |                  Url                  |                                  Maven                                   |
 |------------|------------------------------------------------------------|-----------------------|---------------------------------------|--------------------------------------------------------------------------|
 | PostgreSQL | Different dependency version has different driver class.   | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
-| PostgreSQL | If you want to manipulate the GEOMETRY type in PostgreSQL. | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [Download](https://mvnrepository.com/artifact/net.postgis/postgis-jdbc)  |
+| PostgreSQL | If you want to manipulate the GEOMETRY/GEOGRAPHY type in PostgreSQL. | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [Download](https://mvnrepository.com/artifact/net.postgis/postgis-jdbc)  |
 
 ## Using Dependency
 
@@ -85,6 +85,12 @@ ALTER TABLE your_table_name REPLICA IDENTITY FULL;
 | TIME<br/>                                                                               | TIME                                                                                                                                           |
 | DATE<br/>                                                                               | DATE                                                                                                                                           |
 | OTHER DATA TYPES                                                                        | NOT SUPPORTED YET                                                                                                                              |
+
+### PostGIS Geometry And Geography
+
+PostgreSQL CDC converts Debezium `Geometry` and `Geography` logical values to uppercase WKB/EWKB hexadecimal strings. This conversion is used for both the initial snapshot and WAL change events.
+
+When writing these fields to a Milvus `GEOMETRY` field, configure the Milvus sink with `geometry_convert_mode = "parse"`. The parse mode converts the hexadecimal WKB/EWKB value to WKT before writing it to Milvus. It does not reproject coordinates between spatial reference systems.
 
 ## Source Options
 

--- a/docs/zh/connector-v2/sink/Milvus.md
+++ b/docs/zh/connector-v2/sink/Milvus.md
@@ -55,6 +55,8 @@ Milvus sink连接器将数据写入Milvus或Zilliz Cloud，它具有以下功能
 | batch_size           | int     | 否       | 1000                         | 写入批大小。                                         |
 | cdc_batch_flush_interval_ms | long | 否       | 1000                         | CDC 模式下，收到新 row 时，如果距上次成功 flush 已达到该间隔，则 flush 未完成批次。单位为毫秒。 |
 | write_mode           | enum    | 否       | APPEND                       | 写入模式。`APPEND` 使用普通 batch 或 bulk writer 写入 insert row；`CDC` 对 INSERT 和 UPDATE_AFTER 执行 upsert，对 DELETE 执行删除，并忽略 UPDATE_BEFORE。 |
+| geometry_convert_mode | String | 否       | passthrough                  | Milvus Geometry 字段的 String 值处理方式。`passthrough` 原样发送；`parse` 将 WKT/EWKT/GeoJSON/WKB hex 和支持的坐标格式转换为 WKT。 |
+| geometry_string_coord_order | String | 否 | lat_lon                     | `parse` 模式下裸数字坐标字符串的顺序，支持 `lat_lon` 和 `lon_lat`。不影响 WKT、GeoJSON 和 WKB 输入。 |
 | partition_key        | String  | 否       |                              | Milvus分区键字段                                |
 | partition_num        | int     | 否       |                              | 透传给 Milvus create collection 请求的分区数量。当前主要用于 Milvus 分区键模式。 |
 | collection_rename    | Map     | 否       | {}                           | 重命名集合：`{源名称 = "目标名称"}`       |
@@ -108,6 +110,8 @@ CDC 写模式有以下限制：
 - 不支持 `bulk_writer_config`。
 - 目标 collection 不能启用 autoID。
 - 目标 collection 必须只有一个主键字段。
+
+如果 PostgreSQL CDC source 包含 PostGIS `GEOMETRY` 或 `GEOGRAPHY` 列，需要设置 `geometry_convert_mode = "parse"`。PostgreSQL CDC 会将这些值输出为 WKB/EWKB 十六进制字符串，Milvus sink 会将其转换为 WKT。目标 collection 中对应字段必须预先定义为 Milvus `GEOMETRY`。
 
 CDC writer 接受通用的 keyed changelog row，不依赖 `Milvus-CDC` 私有消息元数据。INSERT 和 UPDATE_AFTER row 会按 upsert 写入，DELETE row 会按主键删除，UPDATE_BEFORE row 会被忽略。Milvus 主键必须对应稳定的源 CDC key；源端主键变化必须由 reader 表达为旧主键的 DELETE，随后是新主键的 INSERT。同一个 upsert batch 内的重复主键保留最后一条。连续的相同目标操作达到 `batch_size` 时会 flush；每次将 row 加入待写 batch 时还会检查 `cdc_batch_flush_interval_ms`，如果距上次成功 flush 已达到该间隔，则将当前 row 一并 flush。任何目标操作切换都会先 flush 上一个待写 batch；从 DELETE 切换到 upsert 时，当前 upsert 也会立即 flush，避免旧主键已经删除后新主键仍等待后续消息或 checkpoint。从 upsert 切换到 DELETE 时，当前 DELETE 仍按正常的 batch、interval、checkpoint 或 writer close 规则 flush。
 

--- a/docs/zh/connector-v2/source/PostgreSQL-CDC.md
+++ b/docs/zh/connector-v2/source/PostgreSQL-CDC.md
@@ -27,7 +27,7 @@ Postgre CDC 连接器允许从 Postgre 数据库读取快照数据和增量数�
 | 数据源      |                     支持的版本                      |        驱动        |                  Url                  |                                  Maven                                   |
 |------------|-----------------------------------------------------|---------------------|---------------------------------------|--------------------------------------------------------------------------|
 | PostgreSQL | 不同的依赖版本有不同的驱动类。                       | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [下载](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
-| PostgreSQL | 如果您想在 PostgreSQL 中操作 GEOMETRY 类型。        | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [下载](https://mvnrepository.com/artifact/net.postgis/postgis-jdbc)  |
+| PostgreSQL | 如果您想在 PostgreSQL 中操作 GEOMETRY/GEOGRAPHY 类型。        | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [下载](https://mvnrepository.com/artifact/net.postgis/postgis-jdbc)  |
 
 ## 使用依赖
 
@@ -83,6 +83,12 @@ ALTER TABLE your_table_name REPLICA IDENTITY FULL;
 | TIME<br/>                                                                               | TIME                                                                                                                                           |
 | DATE<br/>                                                                               | DATE                                                                                                                                           |
 | 其他数据类型                                                                            | 尚不支持                                                                                                                                       |
+
+### PostGIS Geometry 和 Geography
+
+PostgreSQL CDC 会将 Debezium `Geometry` 和 `Geography` logical value 转换为大写的 WKB/EWKB 十六进制字符串。初始化快照和 WAL 增量事件都会使用该转换逻辑。
+
+将这些字段写入 Milvus `GEOMETRY` 字段时，需要在 Milvus sink 中配置 `geometry_convert_mode = "parse"`。parse 模式会在写入 Milvus 前将十六进制 WKB/EWKB 转换成 WKT，但不会在不同空间参考系统之间执行坐标重投影。
 
 ## 源选项
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>connector-cdc</artifactId>
+        <version>2.3.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>connector-cdc-base</artifactId>
+    <name>SeaTunnel : Connectors V2 : CDC : Base</name>
+
+    <properties>
+        <hikaricp.version>4.0.3</hikaricp.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>${hikaricp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>connector-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>seatunnel-format-compatible-debezium-json</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <!-- Debezium dependencies -->
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-api</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-embedded</artifactId>
+                <version>${debezium.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.kafka</groupId>
+                        <artifactId>kafka-log4j-appender</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.core</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!--The lower version is no longer compatible with Apple M1-->
+                        <groupId>com.github.luben</groupId>
+                        <artifactId>zstd-jni</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>1.5.5-5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Debezium dependencies -->
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-compatible-debezium-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.base;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.SingleThreadAccess;
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.config.ConfigurationDefaults;
+import io.debezium.time.Temporals;
+import io.debezium.util.Clock;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.LoggingContext.PreviousContext;
+import io.debezium.util.Metronome;
+import io.debezium.util.ObjectSizeCalculator;
+import io.debezium.util.Threads;
+import io.debezium.util.Threads.Timer;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Copied from debezium 1.6.4.Final to avoid the OOM in snapshot phase. Because this class in
+ * debezium 1.9.8.Final which use the ArrayDeque that need to preallocated memory. A queue which
+ * serves as handover point between producer threads (e.g. MySQL's binlog reader thread) and the
+ * Kafka Connect polling loop.
+ *
+ * <p>The queue is configurable in different aspects, e.g. its maximum size and the time to sleep
+ * (block) between two subsequent poll calls. See the {@link Builder} for the different options. The
+ * queue applies back-pressure semantics, i.e. if it holds the maximum number of elements,
+ * subsequent calls to {@link #enqueue(Object)} will block until elements have been removed from the
+ * queue.
+ *
+ * <p>If an exception occurs on the producer side, the producer should make that exception known by
+ * calling {@link #producerException(RuntimeException)} before stopping its operation. Upon the next
+ * call to {@link #poll()}, that exception will be raised, causing Kafka Connect to stop the
+ * connector and mark it as {@code FAILED}.
+ *
+ * @author Gunnar Morling
+ * @param <T> the type of events in this queue. Usually {@link SourceRecord} is used, but in cases
+ *     where additional metadata must be passed from producers to the consumer, a custom type
+ *     wrapping source records may be used.
+ */
+@ThreadSafe
+public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventQueue.class);
+
+    private final Duration pollInterval;
+    private final int maxBatchSize;
+    private final int maxQueueSize;
+    private final long maxQueueSizeInBytes;
+    private final BlockingQueue<T> queue;
+    private final Metronome metronome;
+    private final Supplier<PreviousContext> loggingContextSupplier;
+    private final AtomicLong currentQueueSizeInBytes = new AtomicLong(0);
+    private final Map<T, Long> objectMap = new ConcurrentHashMap<>();
+
+    // Sometimes it is necessary to update the record before it is delivered depending on the
+    // content
+    // of the following record. In that cases the easiest solution is to provide a single cell
+    // buffer
+    // that will allow the modification of it during the explicit flush.
+    // Typical example is MySQL connector when sometimes it is impossible to detect when the record
+    // in process is the last one. In this case the snapshot flags are set during the explicit
+    // flush.
+    @SingleThreadAccess("producer thread")
+    private boolean buffering;
+
+    @SingleThreadAccess("producer thread")
+    private T bufferedEvent;
+
+    private volatile RuntimeException producerException;
+
+    private ChangeEventQueue(
+            Duration pollInterval,
+            int maxQueueSize,
+            int maxBatchSize,
+            Supplier<LoggingContext.PreviousContext> loggingContextSupplier,
+            long maxQueueSizeInBytes,
+            boolean buffering) {
+        this.pollInterval = pollInterval;
+        this.maxBatchSize = maxBatchSize;
+        this.maxQueueSize = maxQueueSize;
+        this.queue = new LinkedBlockingDeque<>(maxQueueSize);
+        this.metronome = Metronome.sleeper(pollInterval, Clock.SYSTEM);
+        this.loggingContextSupplier = loggingContextSupplier;
+        this.maxQueueSizeInBytes = maxQueueSizeInBytes;
+        this.buffering = buffering;
+    }
+
+    public static class Builder<T> {
+
+        private Duration pollInterval;
+        private int maxQueueSize;
+        private int maxBatchSize;
+        private Supplier<LoggingContext.PreviousContext> loggingContextSupplier;
+        private long maxQueueSizeInBytes;
+        private boolean buffering;
+
+        public Builder<T> pollInterval(Duration pollInterval) {
+            this.pollInterval = pollInterval;
+            return this;
+        }
+
+        public Builder<T> maxQueueSize(int maxQueueSize) {
+            this.maxQueueSize = maxQueueSize;
+            return this;
+        }
+
+        public Builder<T> maxBatchSize(int maxBatchSize) {
+            this.maxBatchSize = maxBatchSize;
+            return this;
+        }
+
+        public Builder<T> loggingContextSupplier(
+                Supplier<LoggingContext.PreviousContext> loggingContextSupplier) {
+            this.loggingContextSupplier = loggingContextSupplier;
+            return this;
+        }
+
+        public Builder<T> maxQueueSizeInBytes(long maxQueueSizeInBytes) {
+            this.maxQueueSizeInBytes = maxQueueSizeInBytes;
+            return this;
+        }
+
+        public Builder<T> buffering() {
+            this.buffering = true;
+            return this;
+        }
+
+        public ChangeEventQueue<T> build() {
+            return new ChangeEventQueue<T>(
+                    pollInterval,
+                    maxQueueSize,
+                    maxBatchSize,
+                    loggingContextSupplier,
+                    maxQueueSizeInBytes,
+                    buffering);
+        }
+    }
+
+    /**
+     * Enqueues a record so that it can be obtained via {@link #poll()}. This method will block if
+     * the queue is full.
+     *
+     * @param record the record to be enqueued
+     * @throws InterruptedException if this thread has been interrupted
+     */
+    public void enqueue(T record) throws InterruptedException {
+        if (record == null) {
+            return;
+        }
+
+        // The calling thread has been interrupted, let's abort
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+
+        if (buffering) {
+            final T newEvent = record;
+            record = bufferedEvent;
+            bufferedEvent = newEvent;
+            if (record == null) {
+                // Can happen only for the first coming event
+                return;
+            }
+        }
+
+        doEnqueue(record);
+    }
+
+    /**
+     * Applies a function to the event and the buffer and adds it to the queue. Buffer is emptied.
+     *
+     * @param recordModifier
+     * @throws InterruptedException
+     */
+    public void flushBuffer(Function<T, T> recordModifier) throws InterruptedException {
+        assert buffering : "Unsuported for queues with disabled buffering";
+        if (bufferedEvent != null) {
+            doEnqueue(recordModifier.apply(bufferedEvent));
+            bufferedEvent = null;
+        }
+    }
+
+    /** Disable buffering for the queue */
+    public void disableBuffering() {
+        assert bufferedEvent == null : "Buffer must be flushed";
+        buffering = false;
+    }
+
+    protected void doEnqueue(T record) throws InterruptedException {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Enqueuing source record '{}'", record);
+        }
+        // Waiting for queue to add more record.
+        while (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes.get() > maxQueueSizeInBytes) {
+            Thread.sleep(pollInterval.toMillis());
+        }
+        // If we pass a positiveLong max.queue.size.in.bytes to enable handling queue size in bytes
+        // feature
+        if (maxQueueSizeInBytes > 0) {
+            long messageSize = ObjectSizeCalculator.getObjectSize(record);
+            objectMap.put(record, messageSize);
+            currentQueueSizeInBytes.addAndGet(messageSize);
+        }
+
+        // this will also raise an InterruptedException if the thread is interrupted while waiting
+        // for space in the queue
+        queue.put(record);
+    }
+
+    /**
+     * Returns the next batch of elements from this queue. May be empty in case no elements have
+     * arrived in the maximum waiting time.
+     *
+     * @throws InterruptedException if this thread has been interrupted while waiting for more
+     *     elements to arrive
+     */
+    public List<T> poll() throws InterruptedException {
+        LoggingContext.PreviousContext previousContext = loggingContextSupplier.get();
+
+        try {
+            LOGGER.debug("polling records...");
+            List<T> records = new ArrayList<>();
+            final Timer timeout =
+                    Threads.timer(
+                            Clock.SYSTEM,
+                            Temporals.min(
+                                    pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
+            while (!timeout.expired() && queue.drainTo(records, maxBatchSize) == 0) {
+                throwProducerExceptionIfPresent();
+
+                LOGGER.debug("no records available yet, sleeping a bit...");
+                // no records yet, so wait a bit
+                metronome.pause();
+                LOGGER.debug("checking for more records...");
+            }
+            if (maxQueueSizeInBytes > 0 && records.size() > 0) {
+                records.parallelStream()
+                        .forEach(
+                                (record) -> {
+                                    if (objectMap.containsKey(record)) {
+                                        currentQueueSizeInBytes.addAndGet(-objectMap.get(record));
+                                        objectMap.remove(record);
+                                    }
+                                });
+            }
+            return records;
+        } finally {
+            previousContext.restore();
+        }
+    }
+
+    public void producerException(final RuntimeException producerException) {
+        this.producerException = producerException;
+    }
+
+    private void throwProducerExceptionIfPresent() {
+        if (producerException != null) {
+            throw producerException;
+        }
+    }
+
+    @Override
+    public int totalCapacity() {
+        return maxQueueSize;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return queue.remainingCapacity();
+    }
+
+    @Override
+    public long maxQueueSizeInBytes() {
+        return maxQueueSizeInBytes;
+    }
+
+    @Override
+    public long currentQueueSizeInBytes() {
+        return currentQueueSizeInBytes.get();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/heartbeat/HeartbeatFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/heartbeat/HeartbeatFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.heartbeat;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+import io.debezium.util.Strings;
+
+import java.time.Duration;
+
+/**
+ * Copied from Debezium 1.9.8.Final. A factory for creating the appropriate {@link Heartbeat}
+ * implementation based on the connector type and its configured properties.
+ *
+ * <p>Line 66~91: If heartbeatInterval is zero, then set it 5000(Come from
+ * https://github.com/apache/seatunnel/pull/6554/files#diff-3f5146dd3b9e6ed097d4dd3a08a3d0575ac8d139230f74c111b30e163c354cdc)
+ */
+public class HeartbeatFactory<T extends DataCollectionId> {
+
+    private final CommonConnectorConfig connectorConfig;
+    private final TopicSelector<T> topicSelector;
+    private final SchemaNameAdjuster schemaNameAdjuster;
+    private final HeartbeatConnectionProvider connectionProvider;
+    private final HeartbeatErrorHandler errorHandler;
+
+    public HeartbeatFactory(
+            CommonConnectorConfig connectorConfig,
+            TopicSelector<T> topicSelector,
+            SchemaNameAdjuster schemaNameAdjuster) {
+        this(connectorConfig, topicSelector, schemaNameAdjuster, null, null);
+    }
+
+    public HeartbeatFactory(
+            CommonConnectorConfig connectorConfig,
+            TopicSelector<T> topicSelector,
+            SchemaNameAdjuster schemaNameAdjuster,
+            HeartbeatConnectionProvider connectionProvider,
+            HeartbeatErrorHandler errorHandler) {
+        this.connectorConfig = connectorConfig;
+        this.topicSelector = topicSelector;
+        this.schemaNameAdjuster = schemaNameAdjuster;
+
+        this.connectionProvider = connectionProvider;
+        this.errorHandler = errorHandler;
+    }
+
+    public Heartbeat createHeartbeat() {
+        Duration heartbeatInterval = connectorConfig.getHeartbeatInterval();
+        if (heartbeatInterval.isZero()) {
+            heartbeatInterval = Duration.ofMillis(5000);
+        }
+
+        if (connectorConfig instanceof RelationalDatabaseConnectorConfig) {
+            RelationalDatabaseConnectorConfig relConfig =
+                    (RelationalDatabaseConnectorConfig) connectorConfig;
+            if (!Strings.isNullOrBlank(relConfig.getHeartbeatActionQuery())) {
+                return new DatabaseHeartbeatImpl(
+                        heartbeatInterval,
+                        topicSelector.getHeartbeatTopic(),
+                        connectorConfig.getLogicalName(),
+                        connectionProvider.get(),
+                        relConfig.getHeartbeatActionQuery(),
+                        errorHandler,
+                        schemaNameAdjuster);
+            }
+        }
+
+        return new HeartbeatImpl(
+                heartbeatInterval,
+                topicSelector.getHeartbeatTopic(),
+                connectorConfig.getLogicalName(),
+                schemaNameAdjuster);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.relational;
+
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceConnector;
+
+import io.debezium.config.ConfigDefinition;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.relational.Selectors.TableIdToStringMapper;
+import io.debezium.relational.Tables.TableFilter;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.DatabaseHistoryMetrics;
+import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.KafkaDatabaseHistory;
+
+/**
+ * Copied from Debezium project. Configuration options shared across the relational CDC connectors
+ * which use a persistent database schema history.
+ *
+ * <p>Added JMX_METRICS_ENABLED option.
+ *
+ * <p>Line 147: set classloader to load the EmbeddedDatabaseHistory in seatunnel
+ */
+public abstract class HistorizedRelationalDatabaseConnectorConfig
+        extends RelationalDatabaseConnectorConfig {
+
+    protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 2_000;
+
+    private boolean useCatalogBeforeSchema;
+    private final String logicalName;
+    private final Class<? extends SourceConnector> connectorClass;
+    private final boolean multiPartitionMode;
+
+    /**
+     * The database history class is hidden in the {@link #configDef()} since that is designed to
+     * work with a user interface, and in these situations using Kafka is the only way to go.
+     */
+    public static final Field DATABASE_HISTORY =
+            Field.create("database.history")
+                    .withDisplayName("Database history class")
+                    .withType(Type.CLASS)
+                    .withWidth(Width.LONG)
+                    .withImportance(Importance.LOW)
+                    .withInvisibleRecommender()
+                    .withDescription(
+                            "The name of the DatabaseHistory class that should be used to store and recover database schema changes. "
+                                    + "The configuration properties for the history are prefixed with the '"
+                                    + DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING
+                                    + "' string.")
+                    .withDefault(KafkaDatabaseHistory.class.getName());
+
+    public static final Field JMX_METRICS_ENABLED =
+            Field.create(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "metrics.enabled")
+                    .withDisplayName("Skip DDL statements that cannot be parsed")
+                    .withType(Type.BOOLEAN)
+                    .withImportance(Importance.LOW)
+                    .withDescription("Whether to enable JMX history metrics")
+                    .withDefault(false);
+
+    protected static final ConfigDefinition CONFIG_DEFINITION =
+            RelationalDatabaseConnectorConfig.CONFIG_DEFINITION
+                    .edit()
+                    .history(
+                            DATABASE_HISTORY,
+                            DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS,
+                            DatabaseHistory.STORE_ONLY_MONITORED_TABLES_DDL,
+                            DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL,
+                            KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
+                            KafkaDatabaseHistory.TOPIC,
+                            KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
+                            KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS,
+                            KafkaDatabaseHistory.KAFKA_QUERY_TIMEOUT_MS)
+                    .create();
+
+    protected HistorizedRelationalDatabaseConnectorConfig(
+            Class<? extends SourceConnector> connectorClass,
+            Configuration config,
+            String logicalName,
+            TableFilter systemTablesFilter,
+            boolean useCatalogBeforeSchema,
+            int defaultSnapshotFetchSize,
+            ColumnFilterMode columnFilterMode,
+            boolean multiPartitionMode) {
+        super(
+                config,
+                logicalName,
+                systemTablesFilter,
+                TableId::toString,
+                defaultSnapshotFetchSize,
+                columnFilterMode);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
+        this.logicalName = logicalName;
+        this.connectorClass = connectorClass;
+        this.multiPartitionMode = multiPartitionMode;
+    }
+
+    protected HistorizedRelationalDatabaseConnectorConfig(
+            Class<? extends SourceConnector> connectorClass,
+            Configuration config,
+            String logicalName,
+            TableFilter systemTablesFilter,
+            TableIdToStringMapper tableIdMapper,
+            boolean useCatalogBeforeSchema,
+            ColumnFilterMode columnFilterMode,
+            boolean multiPartitionMode) {
+        super(
+                config,
+                logicalName,
+                systemTablesFilter,
+                tableIdMapper,
+                DEFAULT_SNAPSHOT_FETCH_SIZE,
+                columnFilterMode);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
+        this.logicalName = logicalName;
+        this.connectorClass = connectorClass;
+        this.multiPartitionMode = multiPartitionMode;
+    }
+
+    /** Returns a configured (but not yet started) instance of the database history. */
+    public DatabaseHistory getDatabaseHistory() {
+        Configuration config = getConfig();
+        DatabaseHistory databaseHistory =
+                config.getInstance(
+                        HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY,
+                        DatabaseHistory.class,
+                        () -> HistorizedRelationalDatabaseConnectorConfig.class.getClassLoader());
+        if (databaseHistory == null) {
+            throw new ConnectException(
+                    "Unable to instantiate the database history class "
+                            + config.getString(
+                                    HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY));
+        }
+
+        // Do not remove the prefix from the subset of config properties ...
+        Configuration dbHistoryConfig =
+                config.subset(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING, false)
+                        .edit()
+                        .withDefault(DatabaseHistory.NAME, getLogicalName() + "-dbhistory")
+                        .withDefault(
+                                KafkaDatabaseHistory.INTERNAL_CONNECTOR_CLASS,
+                                connectorClass.getName())
+                        .withDefault(KafkaDatabaseHistory.INTERNAL_CONNECTOR_ID, logicalName)
+                        .build();
+
+        DatabaseHistoryListener listener =
+                config.getBoolean(JMX_METRICS_ENABLED)
+                        ? new DatabaseHistoryMetrics(this, multiPartitionMode)
+                        : DatabaseHistoryListener.NOOP;
+
+        HistoryRecordComparator historyComparator = getHistoryRecordComparator();
+        databaseHistory.configure(
+                dbHistoryConfig, historyComparator, listener, useCatalogBeforeSchema); // validates
+
+        return databaseHistory;
+    }
+
+    public boolean useCatalogBeforeSchema() {
+        return useCatalogBeforeSchema;
+    }
+
+    /**
+     * Returns a comparator to be used when recovering records from the schema history, making sure
+     * no history entries newer than the offset we resume from are recovered (which could happen
+     * when restarting a connector after history records have been persisted but no new offset has
+     * been committed yet).
+     */
+    protected abstract HistoryRecordComparator getHistoryRecordComparator();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/relational/TableId.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/io/debezium/relational/TableId.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.relational;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.relational.Selectors.TableIdToStringMapper;
+import io.debezium.schema.DataCollectionId;
+import lombok.NonNull;
+
+import java.io.Serializable;
+
+/** Unique identifier for a database table. */
+@Immutable
+public final class TableId implements DataCollectionId, Comparable<TableId>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Parse the supplied string, extracting up to the first 3 parts into a TableID.
+     *
+     * @param str the string representation of the table identifier; may not be null
+     * @return the table ID, or null if it could not be parsed
+     */
+    public static TableId parse(String str) {
+        return parse(str, true);
+    }
+
+    /**
+     * Parse the supplied string, extracting up to the first 3 parts into a TableID.
+     *
+     * @param str the string representation of the table identifier; may not be null
+     * @param useCatalogBeforeSchema {@code true} if the parsed string contains only 2 items and the
+     *     first should be used as the catalog and the second as the table name, or {@code false} if
+     *     the first should be used as the schema and the second as the table name
+     * @return the table ID, or null if it could not be parsed
+     */
+    public static TableId parse(String str, boolean useCatalogBeforeSchema) {
+        String[] parts = TableIdParser.parse(str).toArray(new String[0]);
+
+        return TableId.parse(parts, parts.length, useCatalogBeforeSchema);
+    }
+
+    /**
+     * Parse the supplied string, extracting up to the first 3 parts into a TableID.
+     *
+     * @param parts the parts of the identifier; may not be null
+     * @param numParts the number of parts to use for the table identifier
+     * @param useCatalogBeforeSchema {@code true} if the parsed string contains only 2 items and the
+     *     first should be used as the catalog and the second as the table name, or {@code false} if
+     *     the first should be used as the schema and the second as the table name
+     * @return the table ID, or null if it could not be parsed
+     */
+    protected static TableId parse(String[] parts, int numParts, boolean useCatalogBeforeSchema) {
+        if (numParts == 0) {
+            return null;
+        }
+        if (numParts == 1) {
+            return new TableId(null, null, parts[0]); // table only
+        }
+        if (numParts == 2) {
+            if (useCatalogBeforeSchema) {
+                return new TableId(parts[0], null, parts[1]); // catalog & table only
+            }
+            return new TableId(null, parts[0], parts[1]); // schema & table only
+        }
+        return new TableId(parts[0], parts[1], parts[2]); // catalog, schema & table
+    }
+
+    private final String catalogName;
+    private final String schemaName;
+    private final String tableName;
+    private final String id;
+
+    /**
+     * Create a new table identifier.
+     *
+     * @param catalogName the name of the database catalog that contains the table; may be null if
+     *     the JDBC driver does not show a schema for this table
+     * @param schemaName the name of the database schema that contains the table; may be null if the
+     *     JDBC driver does not show a schema for this table
+     * @param tableName the name of the table; may not be null
+     * @param tableIdMapper the customization of fully quailified table name
+     */
+    public TableId(
+            String catalogName,
+            String schemaName,
+            @NonNull String tableName,
+            TableIdToStringMapper tableIdMapper) {
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.id =
+                tableIdMapper == null
+                        ? tableId(this.catalogName, this.schemaName, this.tableName)
+                        : tableIdMapper.toString(this);
+    }
+
+    /**
+     * Create a new table identifier.
+     *
+     * @param catalogName the name of the database catalog that contains the table; may be null if
+     *     the JDBC driver does not show a schema for this table
+     * @param schemaName the name of the database schema that contains the table; may be null if the
+     *     JDBC driver does not show a schema for this table
+     * @param tableName the name of the table; may not be null
+     */
+    public TableId(String catalogName, String schemaName, String tableName) {
+        this(catalogName, schemaName, tableName, null);
+    }
+
+    /**
+     * Get the name of the JDBC catalog.
+     *
+     * @return the catalog name, or null if the table does not belong to a catalog
+     */
+    public String catalog() {
+        return catalogName;
+    }
+
+    /**
+     * Get the name of the JDBC schema.
+     *
+     * @return the JDBC schema name, or null if the table does not belong to a JDBC schema
+     */
+    public String schema() {
+        return schemaName;
+    }
+
+    /**
+     * Get the name of the table.
+     *
+     * @return the table name; never null
+     */
+    public String table() {
+        return tableName;
+    }
+
+    @Override
+    public String identifier() {
+        return id;
+    }
+
+    @Override
+    public int compareTo(TableId that) {
+        if (this == that) {
+            return 0;
+        }
+        return this.id.compareTo(that.id);
+    }
+
+    public int compareToIgnoreCase(TableId that) {
+        if (this == that) {
+            return 0;
+        }
+        return this.id.compareToIgnoreCase(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TableId) {
+            return this.compareTo((TableId) obj) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return identifier();
+    }
+
+    /**
+     * Returns a dot-separated String representation of this identifier, quoting all name parts with
+     * the {@code "} char.
+     */
+    public String toDoubleQuotedString() {
+        return toQuotedString('"');
+    }
+
+    /** Returns a new {@link TableId} with all parts of the identifier using {@code "} character. */
+    public TableId toDoubleQuoted() {
+        return toQuoted('"');
+    }
+
+    /**
+     * Returns a new {@link TableId} that has all parts of the identifier quoted.
+     *
+     * @param quotingChar the character to be used to quote the identifier parts.
+     */
+    public TableId toQuoted(char quotingChar) {
+        String catalogName = null;
+        if (this.catalogName != null && !this.catalogName.isEmpty()) {
+            catalogName = quote(this.catalogName, quotingChar);
+        }
+
+        String schemaName = null;
+        if (this.schemaName != null && !this.schemaName.isEmpty()) {
+            schemaName = quote(this.schemaName, quotingChar);
+        }
+
+        return new TableId(catalogName, schemaName, quote(this.tableName, quotingChar));
+    }
+
+    /**
+     * Returns a dot-separated String representation of this identifier, quoting all name parts with
+     * the given quoting char.
+     */
+    public String toQuotedString(char quotingChar) {
+        StringBuilder quoted = new StringBuilder();
+
+        if (catalogName != null && !catalogName.isEmpty()) {
+            quoted.append(quote(catalogName, quotingChar)).append(".");
+        }
+
+        if (schemaName != null && !schemaName.isEmpty()) {
+            quoted.append(quote(schemaName, quotingChar)).append(".");
+        }
+
+        quoted.append(quote(tableName, quotingChar));
+
+        return quoted.toString();
+    }
+
+    private static String tableId(String catalog, String schema, String table) {
+        if (catalog == null || catalog.length() == 0) {
+            if (schema == null || schema.length() == 0) {
+                return table;
+            }
+            return schema + "." + table;
+        }
+        if (schema == null || schema.length() == 0) {
+            return catalog + "." + table;
+        }
+        return catalog + "." + schema + "." + table;
+    }
+
+    /** Quotes the given identifier part, e.g. schema or table name. */
+    private static String quote(String identifierPart, char quotingChar) {
+        if (identifierPart == null) {
+            return null;
+        }
+
+        if (identifierPart.isEmpty()) {
+            return new StringBuilder().append(quotingChar).append(quotingChar).toString();
+        }
+
+        if (identifierPart.charAt(0) != quotingChar
+                && identifierPart.charAt(identifierPart.length() - 1) != quotingChar) {
+            identifierPart = identifierPart.replace(quotingChar + "", repeat(quotingChar));
+            identifierPart = quotingChar + identifierPart + quotingChar;
+        }
+
+        return identifierPart;
+    }
+
+    private static String repeat(char quotingChar) {
+        return new StringBuilder().append(quotingChar).append(quotingChar).toString();
+    }
+
+    public TableId toLowercase() {
+        return new TableId(catalogName, schemaName, tableName.toLowerCase());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/BaseSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/BaseSourceConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import org.apache.seatunnel.connectors.cdc.base.source.IncrementalSource;
+
+import io.debezium.config.Configuration;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Properties;
+
+/** A basic Source configuration which is used by {@link IncrementalSource}. */
+public abstract class BaseSourceConfig implements SourceConfig {
+
+    private static final long serialVersionUID = 1L;
+
+    @Getter protected final StartupConfig startupConfig;
+
+    @Getter protected final StopConfig stopConfig;
+
+    @Getter protected final int splitSize;
+    @Getter protected final Map<String, String> splitColumn;
+
+    @Getter protected final double distributionFactorUpper;
+    @Getter protected final double distributionFactorLower;
+    @Getter protected final int sampleShardingThreshold;
+    @Getter protected final int inverseSamplingRate;
+    @Getter protected final boolean exactlyOnce;
+
+    // --------------------------------------------------------------------------------------------
+    // Debezium Configurations
+    // --------------------------------------------------------------------------------------------
+    protected final Properties dbzProperties;
+
+    public BaseSourceConfig(
+            StartupConfig startupConfig,
+            StopConfig stopConfig,
+            int splitSize,
+            Map<String, String> splitColumn,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            int sampleShardingThreshold,
+            int inverseSamplingRate,
+            boolean exactlyOnce,
+            Properties dbzProperties) {
+        this.startupConfig = startupConfig;
+        this.stopConfig = stopConfig;
+        this.splitSize = splitSize;
+        this.splitColumn = splitColumn;
+        this.distributionFactorUpper = distributionFactorUpper;
+        this.distributionFactorLower = distributionFactorLower;
+        this.sampleShardingThreshold = sampleShardingThreshold;
+        this.inverseSamplingRate = inverseSamplingRate;
+        this.exactlyOnce = exactlyOnce;
+        this.dbzProperties = dbzProperties;
+    }
+
+    public Configuration getDbzConfiguration() {
+        return Configuration.from(dbzProperties);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfig.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import org.apache.seatunnel.connectors.cdc.base.source.IncrementalSource;
+
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * A Source configuration which is used by {@link IncrementalSource} which used JDBC data source.
+ */
+public abstract class JdbcSourceConfig extends BaseSourceConfig {
+
+    protected final String driverClassName;
+    protected final String hostname;
+    protected final int port;
+    protected final String username;
+    protected final String password;
+    protected final String originUrl;
+    protected final List<String> databaseList;
+    protected final List<String> tableList;
+    protected final int fetchSize;
+    protected final String serverTimeZone;
+    protected final long connectTimeoutMillis;
+    protected final int connectMaxRetries;
+    protected final int connectionPoolSize;
+
+    public JdbcSourceConfig(
+            StartupConfig startupConfig,
+            StopConfig stopConfig,
+            List<String> databaseList,
+            List<String> tableList,
+            int splitSize,
+            Map<String, String> splitColumn,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            int sampleShardingThreshold,
+            int inverseSamplingRate,
+            Properties dbzProperties,
+            String driverClassName,
+            String hostname,
+            int port,
+            String username,
+            String password,
+            String originUrl,
+            int fetchSize,
+            String serverTimeZone,
+            long connectTimeoutMillis,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            boolean exactlyOnce) {
+        super(
+                startupConfig,
+                stopConfig,
+                splitSize,
+                splitColumn,
+                distributionFactorUpper,
+                distributionFactorLower,
+                sampleShardingThreshold,
+                inverseSamplingRate,
+                exactlyOnce,
+                dbzProperties);
+        this.driverClassName = driverClassName;
+        this.hostname = hostname;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.originUrl = originUrl;
+        this.databaseList = databaseList;
+        this.tableList = tableList;
+        this.fetchSize = fetchSize;
+        this.serverTimeZone = serverTimeZone;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.connectMaxRetries = connectMaxRetries;
+        this.connectionPoolSize = connectionPoolSize;
+    }
+
+    public abstract RelationalDatabaseConnectorConfig getDbzConnectorConfig();
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getOriginUrl() {
+        return originUrl;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public List<String> getDatabaseList() {
+        return databaseList;
+    }
+
+    public List<String> getTableList() {
+        return tableList;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public String getServerTimeZone() {
+        return serverTimeZone;
+    }
+
+    public long getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public int getConnectMaxRetries() {
+        return connectMaxRetries;
+    }
+
+    public int getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfigFactory.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
+
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/** A {@link SourceConfig.Factory} to provide {@link SourceConfig} of JDBC data source. */
+public abstract class JdbcSourceConfigFactory implements SourceConfig.Factory<JdbcSourceConfig> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected int port;
+    protected String hostname;
+    protected String username;
+    protected String password;
+    protected String originUrl;
+    protected List<String> databaseList;
+    protected List<String> tableList;
+    protected String databasePattern;
+    protected String tablePattern;
+    protected StartupConfig startupConfig;
+    protected StopConfig stopConfig;
+    protected double distributionFactorUpper =
+            JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.defaultValue();
+    protected double distributionFactorLower =
+            JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.defaultValue();
+    protected int sampleShardingThreshold =
+            JdbcSourceOptions.SAMPLE_SHARDING_THRESHOLD.defaultValue();
+    protected int inverseSamplingRate = JdbcSourceOptions.INVERSE_SAMPLING_RATE.defaultValue();
+    protected int splitSize = SourceOptions.SNAPSHOT_SPLIT_SIZE.defaultValue();
+    protected Map<String, String> splitColumn;
+    protected int fetchSize = SourceOptions.SNAPSHOT_FETCH_SIZE.defaultValue();
+    protected String serverTimeZone = JdbcSourceOptions.SERVER_TIME_ZONE.defaultValue();
+    protected long connectTimeoutMillis = JdbcSourceOptions.CONNECT_TIMEOUT_MS.defaultValue();
+    protected int connectMaxRetries = JdbcSourceOptions.CONNECT_MAX_RETRIES.defaultValue();
+    protected int connectionPoolSize = JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue();
+    @Setter protected boolean exactlyOnce = JdbcSourceOptions.EXACTLY_ONCE.defaultValue();
+
+    @Setter
+    protected boolean schemaChangeEnabled = JdbcSourceOptions.SCHEMA_CHANGES_ENABLED.defaultValue();
+
+    protected Properties dbzProperties;
+
+    /** String hostname of the database server. */
+    public JdbcSourceConfigFactory hostname(String hostname) {
+        this.hostname = hostname;
+        return this;
+    }
+
+    public JdbcSourceConfigFactory splitColumn(Map<String, String> splitColumn) {
+        this.splitColumn = splitColumn;
+        return this;
+    }
+
+    /** Integer port number of the database server. */
+    public JdbcSourceConfigFactory port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public JdbcSourceConfigFactory originUrl(String originUrl) {
+        this.originUrl = originUrl;
+        return this;
+    }
+
+    /**
+     * An optional list of regular expressions that match database names to be monitored; any
+     * database name not included in the whitelist will be excluded from monitoring. By default all
+     * databases will be monitored.
+     */
+    public JdbcSourceConfigFactory databaseList(String... databaseList) {
+        this.databaseList = Arrays.asList(databaseList);
+        return this;
+    }
+
+    /**
+     * An optional list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored; any table not included in the list will be excluded from monitoring.
+     * Each identifier is of the form databaseName.tableName. by default the connector will monitor
+     * every non-system table in each monitored database.
+     */
+    public JdbcSourceConfigFactory tableList(String... tableList) {
+        this.tableList = Arrays.asList(tableList);
+        return this;
+    }
+
+    /** Name of the user to use when connecting to the database server. */
+    public JdbcSourceConfigFactory username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    /** Password to use when connecting to the database server. */
+    public JdbcSourceConfigFactory password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    /**
+     * The session time zone in database server, e.g. "America/Los_Angeles". It controls how the
+     * TIMESTAMP type converted to STRING. See more
+     * https://debezium.io/documentation/reference/1.5/connectors/mysql.html#mysql-temporal-types
+     */
+    public JdbcSourceConfigFactory serverTimeZone(String timeZone) {
+        this.serverTimeZone = timeZone;
+        return this;
+    }
+
+    /**
+     * The split size (number of rows) of table snapshot, captured tables are split into multiple
+     * splits when read the snapshot of table.
+     */
+    public JdbcSourceConfigFactory splitSize(int splitSize) {
+        this.splitSize = splitSize;
+        return this;
+    }
+
+    /**
+     * The upper bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public JdbcSourceConfigFactory distributionFactorUpper(double distributionFactorUpper) {
+        this.distributionFactorUpper = distributionFactorUpper;
+        return this;
+    }
+
+    /**
+     * The lower bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public JdbcSourceConfigFactory distributionFactorLower(double distributionFactorLower) {
+        this.distributionFactorLower = distributionFactorLower;
+        return this;
+    }
+
+    /**
+     * The threshold for the row count to trigger sample-based sharding strategy. When the
+     * distribution factor is within the upper and lower bounds, if the approximate row count
+     * exceeds this threshold, the sample-based sharding strategy will be used. This can help to
+     * handle large datasets in a more efficient manner.
+     *
+     * @param sampleShardingThreshold The threshold of row count.
+     * @return This JdbcSourceConfigFactory.
+     */
+    public JdbcSourceConfigFactory sampleShardingThreshold(int sampleShardingThreshold) {
+        this.sampleShardingThreshold = sampleShardingThreshold;
+        return this;
+    }
+
+    /**
+     * The inverse of the sampling rate to be used for data sharding based on sampling. The actual
+     * sampling rate is 1 / inverseSamplingRate. For instance, if inverseSamplingRate is 1000, then
+     * the sampling rate is 1/1000, meaning every 1000th record will be included in the sample used
+     * for sharding.
+     *
+     * @param inverseSamplingRate The value representing the inverse of the desired sampling rate.
+     * @return this JdbcSourceConfigFactory instance.
+     */
+    public JdbcSourceConfigFactory inverseSamplingRate(int inverseSamplingRate) {
+        this.inverseSamplingRate = inverseSamplingRate;
+        return this;
+    }
+
+    /** The maximum fetch size for per poll when read table snapshot. */
+    public JdbcSourceConfigFactory fetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
+        return this;
+    }
+
+    /**
+     * The maximum time that the connector should wait after trying to connect to the database
+     * server before timing out.
+     */
+    public JdbcSourceConfigFactory connectTimeoutMillis(long connectTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        return this;
+    }
+
+    /** The connection pool size. */
+    public JdbcSourceConfigFactory connectionPoolSize(int connectionPoolSize) {
+        this.connectionPoolSize = connectionPoolSize;
+        return this;
+    }
+
+    /** The max retry times to get connection. */
+    public JdbcSourceConfigFactory connectMaxRetries(int connectMaxRetries) {
+        this.connectMaxRetries = connectMaxRetries;
+        return this;
+    }
+
+    /** Whether the {@link SourceConfig} should output the schema changes or not. */
+    public JdbcSourceConfigFactory schemaChangeEnabled(boolean schemaChangeEnabled) {
+        this.schemaChangeEnabled = schemaChangeEnabled;
+        return this;
+    }
+
+    /** The Debezium connector properties. For example, "snapshot.mode". */
+    public JdbcSourceConfigFactory debeziumProperties(Properties properties) {
+        this.dbzProperties = properties;
+        return this;
+    }
+
+    /** Specifies the startup options. */
+    public JdbcSourceConfigFactory startupOptions(StartupConfig startupConfig) {
+        this.startupConfig = startupConfig;
+        return this;
+    }
+
+    /** Specifies the stop options. */
+    public JdbcSourceConfigFactory stopOptions(StopConfig stopConfig) {
+        this.stopConfig = stopConfig;
+        return this;
+    }
+
+    public JdbcSourceConfigFactory fromReadonlyConfig(ReadonlyConfig config) {
+        this.port = config.get(JdbcSourceOptions.PORT);
+        this.hostname = config.get(JdbcSourceOptions.HOSTNAME);
+        this.username = config.get(JdbcSourceOptions.USERNAME);
+        this.password = config.get(JdbcSourceOptions.PASSWORD);
+        this.databaseList = config.get(JdbcSourceOptions.DATABASE_NAMES);
+        this.tableList = config.get(ConnectorCommonOptions.TABLE_NAMES);
+        this.databasePattern = config.get(ConnectorCommonOptions.DATABASE_PATTERN);
+        this.tablePattern = config.get(ConnectorCommonOptions.TABLE_PATTERN);
+        this.distributionFactorUpper =
+                config.get(JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND);
+        this.distributionFactorLower =
+                config.get(JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
+        this.sampleShardingThreshold = config.get(JdbcSourceOptions.SAMPLE_SHARDING_THRESHOLD);
+        this.inverseSamplingRate = config.get(JdbcSourceOptions.INVERSE_SAMPLING_RATE);
+        this.splitSize = config.get(SourceOptions.SNAPSHOT_SPLIT_SIZE);
+        this.splitColumn = new HashMap<>();
+        config.getOptional(JdbcSourceOptions.TABLE_NAMES_CONFIG)
+                .ifPresent(
+                        jtcs -> {
+                            jtcs.forEach(
+                                    jtc -> {
+                                        this.splitColumn.put(
+                                                jtc.getTable(), jtc.getSnapshotSplitColumn());
+                                    });
+                        });
+
+        this.fetchSize = config.get(SourceOptions.SNAPSHOT_FETCH_SIZE);
+        this.serverTimeZone = config.get(JdbcSourceOptions.SERVER_TIME_ZONE);
+        this.connectTimeoutMillis = config.get(JdbcSourceOptions.CONNECT_TIMEOUT_MS);
+        this.connectMaxRetries = config.get(JdbcSourceOptions.CONNECT_MAX_RETRIES);
+        this.connectionPoolSize = config.get(JdbcSourceOptions.CONNECTION_POOL_SIZE);
+        this.exactlyOnce = config.get(JdbcSourceOptions.EXACTLY_ONCE);
+        this.schemaChangeEnabled = config.get(JdbcSourceOptions.SCHEMA_CHANGES_ENABLED);
+        this.dbzProperties = new Properties();
+        config.getOptional(SourceOptions.DEBEZIUM_PROPERTIES)
+                .ifPresent(map -> dbzProperties.putAll(map));
+        return this;
+    }
+
+    @Override
+    public abstract JdbcSourceConfig create(int subtask);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceTableConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+public class JdbcSourceTableConfig implements Serializable {
+    private String table;
+    private List<String> primaryKeys;
+    private String snapshotSplitColumn;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/SourceConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/SourceConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import java.io.Serializable;
+
+/** The source configuration which offers basic source configuration. */
+public interface SourceConfig extends Serializable {
+
+    StartupConfig getStartupConfig();
+
+    StopConfig getStopConfig();
+
+    int getSplitSize();
+
+    boolean isExactlyOnce();
+
+    /** Factory for the {@code SourceConfig}. */
+    @FunctionalInterface
+    interface Factory<C extends SourceConfig> extends Serializable {
+
+        C create(int subtask);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/StartupConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/StartupConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+public final class StartupConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+    @Getter private final StartupMode startupMode;
+    private final String specificOffsetFile;
+    private final Long specificOffsetPos;
+    private final Long timestamp;
+
+    public Offset getStartupOffset(OffsetFactory offsetFactory) {
+        switch (startupMode) {
+            case EARLIEST:
+                return offsetFactory.earliest();
+            case LATEST:
+                return offsetFactory.latest();
+            case INITIAL:
+                return null;
+            case SPECIFIC:
+                return offsetFactory.specific(specificOffsetFile, specificOffsetPos);
+            case TIMESTAMP:
+                return offsetFactory.timestamp(timestamp);
+            default:
+                throw new IllegalArgumentException(
+                        String.format("The %s mode is not supported.", startupMode));
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/StopConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/StopConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.config;
+
+import org.apache.seatunnel.connectors.cdc.base.option.StopMode;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+public final class StopConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Getter private final StopMode stopMode;
+    private final String specificOffsetFile;
+    private final Long specificOffsetPos;
+    private final Long timestamp;
+
+    public Offset getStopOffset(OffsetFactory offsetFactory) {
+        switch (stopMode) {
+            case LATEST:
+                return offsetFactory.latest();
+            case NEVER:
+                return offsetFactory.neverStop();
+            case SPECIFIC:
+                return offsetFactory.specific(specificOffsetFile, specificOffsetPos);
+            case TIMESTAMP:
+                return offsetFactory.timestamp(timestamp);
+            default:
+                throw new IllegalArgumentException(
+                        String.format("The %s mode is not supported.", stopMode));
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/DataSourceDialect.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/DataSourceDialect.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.dialect;
+
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import io.debezium.relational.TableId;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The dialect of data source.
+ *
+ * @param <C> The source config of data source.
+ */
+public interface DataSourceDialect<C extends SourceConfig> extends Serializable {
+
+    /** Get the name of dialect. */
+    String getName();
+
+    /** Discovers the list of data collection to capture. */
+    List<TableId> discoverDataCollections(C sourceConfig);
+
+    /** Check if the CollectionId is case-sensitive or not. */
+    boolean isDataCollectionIdCaseSensitive(C sourceConfig);
+
+    /** Returns the {@link ChunkSplitter} which used to split collection to splits. */
+    ChunkSplitter createChunkSplitter(C sourceConfig);
+
+    /** The fetch task used to fetch data of a snapshot split or incremental split. */
+    FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase);
+
+    /** The task context used for fetch task to fetch data from external systems. */
+    FetchTask.Context createFetchTaskContext(SourceSplitBase sourceSplitBase, C sourceConfig);
+
+    /**
+     * We have an empty default implementation here because most dialects do not have to implement
+     * the method.
+     */
+    default void commitChangeLogOffset(Offset offset) throws Exception {}
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/JdbcDataSourceDialect.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/JdbcDataSourceDialect.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.dialect;
+
+import org.apache.seatunnel.api.table.catalog.ConstraintKey;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.relational.connection.JdbcConnectionPoolFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public interface JdbcDataSourceDialect extends DataSourceDialect<JdbcSourceConfig> {
+
+    /** Discovers the list of table to capture. */
+    @Override
+    List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig);
+
+    default void checkAllTablesEnabledCapture(JdbcConnection jdbcConnection, List<TableId> tableIds)
+            throws SQLException {}
+
+    /**
+     * Creates and opens a new {@link JdbcConnection} backing connection pool.
+     *
+     * @param sourceConfig a basic source configuration.
+     * @return a utility that simplifies using a JDBC connection.
+     */
+    JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig);
+
+    /** Get a connection pool factory to create connection pool. */
+    default JdbcConnectionPoolFactory getPooledDataSourceFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Query and build the schema of table. */
+    TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId);
+
+    @Override
+    FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase);
+
+    @Override
+    JdbcSourceFetchTaskContext createFetchTaskContext(
+            SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig);
+
+    default Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)
+            throws SQLException {
+
+        DatabaseMetaData metaData = jdbcConnection.connection().getMetaData();
+
+        // seq -> column name
+        List<Pair<Integer, String>> primaryKeyColumns = new ArrayList<>();
+        String pkName = null;
+
+        // According to the Javadoc of java.sql.DatabaseMetaData#getPrimaryKeys,
+        // the returned primary key columns are ordered by COLUMN_NAME, not by KEY_SEQ.
+        // We need to sort them based on the KEY_SEQ value.
+
+        try (ResultSet rs =
+                metaData.getPrimaryKeys(tableId.catalog(), tableId.schema(), tableId.table())) {
+            while (rs.next()) {
+                // all the PK_NAME should be the same
+                pkName = rs.getString("PK_NAME");
+                String columnName = rs.getString("COLUMN_NAME");
+                int keySeq = rs.getInt("KEY_SEQ");
+                // KEY_SEQ is 1-based index
+                primaryKeyColumns.add(Pair.of(keySeq, columnName));
+            }
+        }
+        // initialize size
+        List<String> pkFields =
+                primaryKeyColumns.stream()
+                        .sorted(Comparator.comparingInt(Pair::getKey))
+                        .map(Pair::getValue)
+                        .distinct()
+                        .collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(pkFields)) {
+            return Optional.empty();
+        }
+        return Optional.of(PrimaryKey.of(pkName, pkFields));
+    }
+
+    default List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
+            throws SQLException {
+        return getConstraintKeys(jdbcConnection, tableId).stream()
+                .filter(
+                        constraintKey ->
+                                constraintKey.getConstraintType()
+                                        == ConstraintKey.ConstraintType.UNIQUE_KEY)
+                .collect(Collectors.toList());
+    }
+
+    default List<ConstraintKey> getConstraintKeys(JdbcConnection jdbcConnection, TableId tableId)
+            throws SQLException {
+        DatabaseMetaData metaData = jdbcConnection.connection().getMetaData();
+
+        try (ResultSet resultSet =
+                metaData.getIndexInfo(
+                        tableId.catalog(), tableId.schema(), tableId.table(), false, false)) {
+            // index name -> index
+            Map<String, ConstraintKey> constraintKeyMap = new HashMap<>();
+            while (resultSet.next()) {
+                String columnName = resultSet.getString("COLUMN_NAME");
+                if (columnName == null) {
+                    continue;
+                }
+
+                String indexName = resultSet.getString("INDEX_NAME");
+                boolean noUnique = resultSet.getBoolean("NON_UNIQUE");
+
+                ConstraintKey constraintKey =
+                        constraintKeyMap.computeIfAbsent(
+                                indexName,
+                                s -> {
+                                    ConstraintKey.ConstraintType constraintType =
+                                            ConstraintKey.ConstraintType.INDEX_KEY;
+                                    if (!noUnique) {
+                                        constraintType = ConstraintKey.ConstraintType.UNIQUE_KEY;
+                                    }
+                                    return ConstraintKey.of(
+                                            constraintType, indexName, new ArrayList<>());
+                                });
+
+                ConstraintKey.ColumnSortType sortType =
+                        "A".equals(resultSet.getString("ASC_OR_DESC"))
+                                ? ConstraintKey.ColumnSortType.ASC
+                                : ConstraintKey.ColumnSortType.DESC;
+                ConstraintKey.ConstraintKeyColumn constraintKeyColumn =
+                        new ConstraintKey.ConstraintKeyColumn(columnName, sortType);
+                constraintKey.getColumnNames().add(constraintKeyColumn);
+            }
+            return new ArrayList<>(constraintKeyMap.values());
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/JdbcSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/JdbcSourceOptions.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.option;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceTableConfig;
+import org.apache.seatunnel.connectors.cdc.base.source.IncrementalSource;
+
+import java.time.ZoneId;
+import java.util.List;
+
+/** Configurations for {@link IncrementalSource} of JDBC data source. */
+public class JdbcSourceOptions extends SourceOptions {
+
+    public static final Option<String> HOSTNAME =
+            Options.key("hostname")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("IP address or hostname of the database server.");
+
+    public static final Option<Integer> PORT =
+            Options.key("port")
+                    .intType()
+                    .defaultValue(3306)
+                    .withDescription("Integer port number of the database server.");
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of the database to use when connecting to the database server.");
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Password to use when connecting to the database server.");
+
+    public static final Option<List<String>> DATABASE_NAMES =
+            Options.key("database-names")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Database name of the database to monitor.");
+
+    public static final Option<String> SERVER_TIME_ZONE =
+            Options.key("server-time-zone")
+                    .stringType()
+                    .defaultValue(ZoneId.systemDefault().getId())
+                    .withDescription(
+                            "The session time zone in database server."
+                                    + "If not set, then ZoneId.systemDefault() is used to determine the server time zone");
+
+    public static final Option<String> SERVER_ID =
+            Options.key("server-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A numeric ID or a numeric ID range of this database client, "
+                                    + "The numeric ID syntax is like '5400', the numeric ID range syntax "
+                                    + "is like '5400-5408'. Every ID must be unique across all "
+                                    + "currently-running database processes in the MySQL cluster. This connector"
+                                    + " joins the MySQL  cluster as another server (with this unique ID) "
+                                    + "so it can read the binlog. By default, a random number is generated between"
+                                    + " 6500 and 2,148,492,146, though we recommend setting an explicit value.");
+
+    public static final Option<Long> CONNECT_TIMEOUT_MS =
+            Options.key("connect.timeout.ms")
+                    .longType()
+                    .defaultValue(30000L)
+                    .withDescription(
+                            "The maximum time that the connector should wait after trying to connect to the database server before timing out.");
+
+    public static final Option<Integer> CONNECTION_POOL_SIZE =
+            Options.key("connection.pool.size")
+                    .intType()
+                    .defaultValue(20)
+                    .withDescription("The connection pool size.");
+
+    public static final Option<Integer> CONNECT_MAX_RETRIES =
+            Options.key("connect.max-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "The max retry times that the connector should retry to build database server connection.");
+
+    public static final Option<Double> CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND =
+            Options.key("chunk-key.even-distribution.factor.upper-bound")
+                    .doubleType()
+                    .defaultValue(100.0d)
+                    .withDescription(
+                            "The upper bound of chunk key distribution factor. The distribution factor is used to determine whether the"
+                                    + " table is evenly distribution or not."
+                                    + " The table chunks would use evenly calculation optimization when the data distribution is even,"
+                                    + " and the query for splitting would happen when it is uneven."
+                                    + " The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.");
+
+    public static final Option<Double> CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND =
+            Options.key("chunk-key.even-distribution.factor.lower-bound")
+                    .doubleType()
+                    .defaultValue(0.05d)
+                    .withDescription(
+                            "The lower bound of chunk key distribution factor. The distribution factor is used to determine whether the"
+                                    + " table is evenly distribution or not."
+                                    + " The table chunks would use evenly calculation optimization when the data distribution is even,"
+                                    + " and the query for splitting would happen when it is uneven."
+                                    + " The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.");
+
+    public static final Option<Integer> SAMPLE_SHARDING_THRESHOLD =
+            Options.key("sample-sharding.threshold")
+                    .intType()
+                    .defaultValue(1000) // 1000 shards
+                    .withDescription(
+                            "The threshold of estimated shard count to trigger the sample sharding strategy. "
+                                    + "When the distribution factor is outside the upper and lower bounds, "
+                                    + "and if the estimated shard count (approximateRowCnt/chunkSize) exceeds this threshold, "
+                                    + "the sample sharding strategy will be used. "
+                                    + "This strategy can help to handle large datasets more efficiently. "
+                                    + "The default value is 1000 shards.");
+    public static final Option<Integer> INVERSE_SAMPLING_RATE =
+            Options.key("inverse-sampling.rate")
+                    .intType()
+                    .defaultValue(1000) // 1/1000 sampling rate
+                    .withDescription(
+                            "The inverse of the sampling rate for the sample sharding strategy. "
+                                    + "The value represents the denominator of the sampling rate fraction. "
+                                    + "For example, a value of 1000 means a sampling rate of 1/1000. "
+                                    + "This parameter is used when the sample sharding strategy is triggered.");
+
+    public static final Option<List<JdbcSourceTableConfig>> TABLE_NAMES_CONFIG =
+            Options.key("table-names-config")
+                    .listType(JdbcSourceTableConfig.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            "Config table configs. Example: "
+                                    + "["
+                                    + "   {"
+                                    + "       \"table\": \"db1.schema1.table1\","
+                                    + "       \"primaryKeys\": [\"key1\",\"key2\"],"
+                                    + "       \"snapshotSplitColumn\": \"key2\""
+                                    + "   }"
+                                    + "]");
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/SourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/SourceOptions.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.option;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.connectors.cdc.debezium.DeserializeFormat;
+
+import java.util.Map;
+
+@SuppressWarnings("MagicNumber")
+public class SourceOptions {
+
+    public static final String STARTUP_MODE_KEY = "startup.mode";
+    public static final String STOP_MODE_KEY = "stop.mode";
+
+    public static final Option<Integer> SNAPSHOT_SPLIT_SIZE =
+            Options.key("snapshot.split.size")
+                    .intType()
+                    .defaultValue(8096)
+                    .withDescription(
+                            "The split size (number of rows) of table snapshot, captured tables are split into multiple splits when read the snapshot of table.");
+    public static final Option<Integer> SNAPSHOT_FETCH_SIZE =
+            Options.key("snapshot.fetch.size")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription(
+                            "The maximum fetch size for per poll when read table snapshot.");
+
+    public static final Option<Long> STARTUP_TIMESTAMP =
+            Options.key("startup.timestamp")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional timestamp(mills) used in case of \"timestamp\" startup mode");
+
+    public static final Option<String> STARTUP_SPECIFIC_OFFSET_FILE =
+            Options.key("startup.specific-offset.file")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional offsets used in case of \"specific\" startup mode");
+
+    public static final Option<Long> STARTUP_SPECIFIC_OFFSET_POS =
+            Options.key("startup.specific-offset.pos")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Optional offsets used in case of \"specific\" startup mode");
+
+    public static final Option<Integer> INCREMENTAL_PARALLELISM =
+            Options.key("incremental.parallelism")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("The number of parallel readers in the incremental phase.");
+
+    public static final Option<Long> STOP_TIMESTAMP =
+            Options.key("stop.timestamp")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional timestamp(mills) used in case of \"timestamp\" stop mode");
+
+    public static final Option<String> STOP_SPECIFIC_OFFSET_FILE =
+            Options.key("stop.specific-offset.file")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional offsets used in case of \"specific\" stop mode");
+
+    public static final Option<Long> STOP_SPECIFIC_OFFSET_POS =
+            Options.key("stop.specific-offset.pos")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Optional offsets used in case of \"specific\" stop mode");
+
+    public static final Option<Map<String, String>> DEBEZIUM_PROPERTIES =
+            Options.key("debezium")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Decides if the table options contains Debezium client properties that start with prefix 'debezium'.");
+
+    public static final Option<DeserializeFormat> FORMAT =
+            Options.key("format")
+                    .enumType(DeserializeFormat.class)
+                    .defaultValue(DeserializeFormat.DEFAULT)
+                    .withDescription(
+                            "Data format. The default format is seatunnel row. Optional compatible with debezium-json format.");
+
+    public static final Option<Boolean> EXACTLY_ONCE =
+            Options.key("exactly_once")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Enable exactly once semantic.");
+
+    public static final Option<Boolean> SCHEMA_CHANGES_ENABLED =
+            Options.key("schema-changes.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable send schema change events, by default is false. If set to true, the schema changes will be sent to downstream.");
+
+    public static OptionRule.Builder getBaseRule() {
+        return OptionRule.builder()
+                .optional(FORMAT)
+                .optional(SNAPSHOT_SPLIT_SIZE, SNAPSHOT_FETCH_SIZE)
+                .optional(INCREMENTAL_PARALLELISM)
+                .optional(DEBEZIUM_PROPERTIES);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/StartupMode.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/StartupMode.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.option;
+
+/** Startup modes for the CDC Connectors, see {@link SourceOptions#STARTUP_MODE}. */
+public enum StartupMode {
+    /** Startup from the earliest offset possible. */
+    EARLIEST,
+    /** Startup from the latest offset. */
+    LATEST,
+    /** Synchronize historical data at startup, and then synchronize incremental data. */
+    INITIAL,
+    /** Start from user-supplied timestamp. */
+    TIMESTAMP,
+    /** Startup from user-supplied specific offsets. */
+    SPECIFIC
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/StopMode.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/StopMode.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.option;
+
+/** Stop mode for the CDC Connectors, see {@link SourceOptions#STOP_MODE}. */
+public enum StopMode {
+    /** Stop from the latest offset. */
+    LATEST,
+    /** Stop from user-supplied timestamp. */
+    TIMESTAMP,
+    /** Stop from user-supplied specific offset. */
+    SPECIFIC,
+    /** Real-time job don't stop the source. */
+    NEVER
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/JdbcSourceEventDispatcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/JdbcSourceEventDispatcher.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.schema.DataCollectionFilters;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+
+/**
+ * A subclass implementation of {@link EventDispatcher}.
+ *
+ * <pre>
+ *  1. This class shares one {@link ChangeEventQueue} between multiple readers.
+ *  2. This class override some methods for dispatching {@link HistoryRecord} directly,
+ *     this is useful for downstream to deserialize the {@link HistoryRecord} back.
+ * </pre>
+ */
+public class JdbcSourceEventDispatcher<P extends Partition> extends EventDispatcher<P, TableId> {
+
+    private final ChangeEventQueue<DataChangeEvent> queue;
+
+    private final String topic;
+
+    public JdbcSourceEventDispatcher(
+            CommonConnectorConfig connectorConfig,
+            TopicSelector<TableId> topicSelector,
+            DatabaseSchema<TableId> schema,
+            ChangeEventQueue<DataChangeEvent> queue,
+            DataCollectionFilters.DataCollectionFilter<TableId> filter,
+            ChangeEventCreator changeEventCreator,
+            EventMetadataProvider metadataProvider,
+            SchemaNameAdjuster schemaNameAdjuster) {
+        super(
+                connectorConfig,
+                topicSelector,
+                schema,
+                queue,
+                filter,
+                changeEventCreator,
+                metadataProvider,
+                schemaNameAdjuster);
+        this.queue = queue;
+        this.topic = topicSelector.getPrimaryTopic();
+    }
+
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            SourceSplitBase sourceSplit,
+            Offset watermark,
+            WatermarkKind watermarkKind)
+            throws InterruptedException {
+
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, topic, sourceSplit.splitId(), watermarkKind, watermark);
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/ConnectionPoolId.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/ConnectionPoolId.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational.connection;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** The connection pool identifier. */
+public class ConnectionPoolId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String host;
+    private final int port;
+    private final String username;
+
+    public ConnectionPoolId(String host, int port, String username) {
+        this.host = host;
+        this.port = port;
+        this.username = username;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectionPoolId)) {
+            return false;
+        }
+        ConnectionPoolId that = (ConnectionPoolId) o;
+        return Objects.equals(host, that.host)
+                && Objects.equals(port, that.port)
+                && Objects.equals(username, that.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port, username);
+    }
+
+    @Override
+    public String toString() {
+        return username + '@' + host + ':' + port;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/ConnectionPools.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/ConnectionPools.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational.connection;
+
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+
+/** A pool collection that consists of multiple connection pools. */
+public interface ConnectionPools<P, C extends SourceConfig> {
+
+    /**
+     * Gets a connection pool from pools, create a new pool if the pool does not exists in the
+     * connection pools .
+     */
+    P getOrCreateConnectionPool(ConnectionPoolId poolId, C sourceConfig);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational.connection;
+
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/** A factory to create JDBC connection. */
+public class JdbcConnectionFactory implements JdbcConnection.ConnectionFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionFactory.class);
+
+    private final JdbcSourceConfig sourceConfig;
+    private final JdbcConnectionPoolFactory jdbcConnectionPoolFactory;
+
+    public JdbcConnectionFactory(
+            JdbcSourceConfig sourceConfig, JdbcConnectionPoolFactory jdbcConnectionPoolFactory) {
+        this.sourceConfig = sourceConfig;
+        this.jdbcConnectionPoolFactory = jdbcConnectionPoolFactory;
+    }
+
+    @Override
+    public Connection connect(JdbcConfiguration config) throws SQLException {
+        final int connectRetryTimes = sourceConfig.getConnectMaxRetries();
+
+        final ConnectionPoolId connectionPoolId =
+                new ConnectionPoolId(
+                        sourceConfig.getHostname(),
+                        sourceConfig.getPort(),
+                        sourceConfig.getUsername());
+
+        HikariDataSource dataSource =
+                JdbcConnectionPools.getInstance(jdbcConnectionPoolFactory)
+                        .getOrCreateConnectionPool(connectionPoolId, sourceConfig);
+
+        int i = 0;
+        while (i < connectRetryTimes) {
+            try {
+                return dataSource.getConnection();
+            } catch (SQLException e) {
+                if (i < connectRetryTimes - 1) {
+                    try {
+                        Thread.sleep(300);
+                    } catch (InterruptedException ie) {
+                        throw new SeaTunnelException(
+                                "Failed to get connection, interrupted while doing another attempt",
+                                ie);
+                    }
+                    LOG.warn("Get connection failed, retry times {}", i + 1);
+                } else {
+                    LOG.error("Get connection failed after retry {} times", i + 1);
+                    throw new SeaTunnelException(e);
+                }
+            }
+            i++;
+        }
+        return dataSource.getConnection();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionPoolFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionPoolFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational.connection;
+
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+/** A connection pool factory to create pooled DataSource {@link HikariDataSource}. */
+public abstract class JdbcConnectionPoolFactory {
+
+    public static final String CONNECTION_POOL_PREFIX = "connection-pool-";
+    public static final String SERVER_TIMEZONE_KEY = "serverTimezone";
+    public static final int MINIMUM_POOL_SIZE = 1;
+
+    public HikariDataSource createPooledDataSource(JdbcSourceConfig sourceConfig) {
+        final HikariConfig config = new HikariConfig();
+
+        String hostName = sourceConfig.getHostname();
+        int port = sourceConfig.getPort();
+
+        config.setPoolName(CONNECTION_POOL_PREFIX + hostName + ":" + port);
+        config.setJdbcUrl(sourceConfig.getOriginUrl());
+        config.setUsername(sourceConfig.getUsername());
+        config.setPassword(sourceConfig.getPassword());
+        config.setDriverClassName(sourceConfig.getDriverClassName());
+        config.setMinimumIdle(MINIMUM_POOL_SIZE);
+        config.setMaximumPoolSize(sourceConfig.getConnectionPoolSize());
+        config.setConnectionTimeout(sourceConfig.getConnectTimeoutMillis());
+        config.addDataSourceProperty(SERVER_TIMEZONE_KEY, sourceConfig.getServerTimeZone());
+
+        // optional optimization configurations for pooled DataSource
+        config.addDataSourceProperty("cachePrepStmts", "true");
+        config.addDataSourceProperty("prepStmtCacheSize", "250");
+        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+
+        return new HikariDataSource(config);
+    }
+
+    /**
+     * due to relational database url of the forms are different, e.g. Mysql <code>
+     * jdbc:mysql://<em>hostname</em>:<em>port</em></code>, Oracle Thin <code>
+     * jdbc:oracle:thin:@<em>hostname</em>:<em>port</em>:<em>dbName</em></code> DB2 <code>
+     * jdbc:db2://<em>hostname</em>:<em>port</em>/<em>dbName</em></code> Sybase <code>
+     * jdbc:sybase:Tds:<em>hostname</em>:<em>port</em></code>, so generate a jdbc url by specific
+     * database.
+     *
+     * @param sourceConfig a basic Source configuration.
+     * @return a database url.
+     */
+    public abstract String getJdbcUrl(JdbcSourceConfig sourceConfig);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionPools.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/connection/JdbcConnectionPools.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.relational.connection;
+
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** A Jdbc Connection pools implementation. */
+public class JdbcConnectionPools implements ConnectionPools<HikariDataSource, JdbcSourceConfig> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionPools.class);
+
+    private static JdbcConnectionPools INSTANCE;
+    private final Map<ConnectionPoolId, HikariDataSource> pools = new HashMap<>();
+    private static JdbcConnectionPoolFactory JDBCCONNECTIONPOOLFACTORY;
+
+    private JdbcConnectionPools() {}
+
+    public static synchronized JdbcConnectionPools getInstance(
+            JdbcConnectionPoolFactory jdbcConnectionPoolFactory) {
+        if (INSTANCE == null) {
+            JdbcConnectionPools.JDBCCONNECTIONPOOLFACTORY = jdbcConnectionPoolFactory;
+            INSTANCE = new JdbcConnectionPools();
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public HikariDataSource getOrCreateConnectionPool(
+            ConnectionPoolId poolId, JdbcSourceConfig sourceConfig) {
+        synchronized (pools) {
+            if (!pools.containsKey(poolId)) {
+                LOG.debug("Create and register connection pool {}", poolId);
+                pools.put(poolId, JDBCCONNECTIONPOOLFACTORY.createPooledDataSource(sourceConfig));
+            }
+            return pools.get(poolId);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.schema;
+
+import org.apache.seatunnel.shade.com.google.common.collect.Lists;
+
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.schema.event.AlterTableColumnEvent;
+import org.apache.seatunnel.api.table.schema.event.AlterTableColumnsEvent;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.relational.Tables;
+import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.history.HistoryRecord;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+public abstract class AbstractSchemaChangeResolver implements SchemaChangeResolver {
+
+    protected static final List<String> SUPPORT_DDL = Lists.newArrayList("ALTER TABLE");
+
+    protected final JdbcSourceConfig jdbcSourceConfig;
+    @Setter protected transient DdlParser ddlParser;
+    @Setter protected transient Tables tables;
+    @Setter protected String sourceDialectName;
+
+    public AbstractSchemaChangeResolver(JdbcSourceConfig jdbcSourceConfig) {
+        this.jdbcSourceConfig = jdbcSourceConfig;
+    }
+
+    @Override
+    public boolean support(SourceRecord record) {
+        String ddl = SourceRecordUtils.getDdl(record);
+        Struct value = (Struct) record.value();
+        List<Struct> tableChanges = value.getArray(HistoryRecord.Fields.TABLE_CHANGES);
+        if (tableChanges == null || tableChanges.isEmpty()) {
+            log.warn("Ignoring statement for non-captured table {}", ddl);
+            return false;
+        }
+        return StringUtils.isNotBlank(ddl)
+                && SUPPORT_DDL.stream()
+                        .map(String::toUpperCase)
+                        .anyMatch(prefix -> ddl.toUpperCase().contains(prefix));
+    }
+
+    @Override
+    public SchemaChangeEvent resolve(SourceRecord record, SeaTunnelDataType dataType) {
+        TablePath tablePath = SourceRecordUtils.getTablePath(record);
+        String ddl = SourceRecordUtils.getDdl(record);
+        if (Objects.isNull(ddlParser)) {
+            this.ddlParser = createDdlParser(tablePath);
+        }
+        if (Objects.isNull(tables)) {
+            this.tables = new Tables();
+        }
+        ddlParser.setCurrentDatabase(tablePath.getDatabaseName());
+        ddlParser.setCurrentSchema(tablePath.getSchemaName());
+        // Parse DDL statement using Debezium's Antlr parser
+        ddlParser.parse(ddl, tables);
+        List<AlterTableColumnEvent> parsedEvents = getAndClearParsedEvents();
+        parsedEvents.forEach(e -> e.setSourceDialectName(getSourceDialectName()));
+        AlterTableColumnsEvent alterTableColumnsEvent =
+                new AlterTableColumnsEvent(
+                        TableIdentifier.of(
+                                StringUtils.EMPTY,
+                                tablePath.getDatabaseName(),
+                                tablePath.getSchemaName(),
+                                tablePath.getTableName()),
+                        parsedEvents);
+        alterTableColumnsEvent.setStatement(ddl);
+        alterTableColumnsEvent.setSourceDialectName(getSourceDialectName());
+        return parsedEvents.isEmpty() ? null : alterTableColumnsEvent;
+    }
+
+    protected abstract DdlParser createDdlParser(TablePath tablePath);
+
+    protected abstract List<AlterTableColumnEvent> getAndClearParsedEvents();
+
+    protected abstract String getSourceDialectName();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/SchemaChangeResolver.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/SchemaChangeResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.schema;
+
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.Serializable;
+
+public interface SchemaChangeResolver extends Serializable {
+
+    boolean support(SourceRecord record);
+
+    SchemaChangeEvent resolve(SourceRecord record, SeaTunnelDataType dataType);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/BaseChangeStreamTableSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/BaseChangeStreamTableSourceFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.ChangeStreamTableSourceFactory;
+import org.apache.seatunnel.api.table.factory.ChangeStreamTableSourceState;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * CDC Base class for {@link ChangeStreamTableSourceFactory}. It provides a default implementation
+ * for {@link ChangeStreamTableSourceFactory#restoreSource(TableSourceFactoryContext,
+ * ChangeStreamTableSourceState)}. The default implementation will restore the source using the
+ * checkpoint tables in the {@link ChangeStreamTableSourceState}.
+ */
+@Slf4j
+public abstract class BaseChangeStreamTableSourceFactory implements ChangeStreamTableSourceFactory {
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        return restoreSource(context, Collections.emptyList());
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> restoreSource(
+                    TableSourceFactoryContext context,
+                    ChangeStreamTableSourceState<StateT, SplitT> state) {
+        return restoreSource(context, getRestoreTableStruct(state));
+    }
+
+    public abstract <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> restoreSource(
+                    TableSourceFactoryContext context, List<CatalogTable> restoreTableStruct);
+
+    protected <SplitT extends SourceSplit, StateT extends Serializable>
+            List<CatalogTable> getRestoreTableStruct(
+                    ChangeStreamTableSourceState<StateT, SplitT> state) {
+        List<IncrementalSplit> incrementalSplits =
+                state.getSplits().stream()
+                        .flatMap(List::stream)
+                        .filter(e -> e != null)
+                        .map(e -> SourceSplitBase.class.cast(e))
+                        .filter(e -> e.isIncrementalSplit())
+                        .map(e -> e.asIncrementalSplit())
+                        .collect(Collectors.toList());
+        if (incrementalSplits.size() > 1) {
+            throw new UnsupportedOperationException(
+                    "Multiple incremental splits are not supported");
+        }
+
+        if (incrementalSplits.size() == 1) {
+            IncrementalSplit incrementalSplit = incrementalSplits.get(0);
+            if (incrementalSplit.getCheckpointTables() != null) {
+                List<CatalogTable> checkpointTableStruct = incrementalSplit.getCheckpointTables();
+                log.info("Restore source using checkpoint tables: {}", checkpointTableStruct);
+                return checkpointTableStruct;
+            }
+            if (incrementalSplit.getCheckpointDataType() != null) {
+                // TODO: Waiting for remove of compatible logic
+                List<CatalogTable> checkpointDataTypeStruct =
+                        CatalogTableUtil.convertDataTypeToCatalogTables(
+                                incrementalSplit.getCheckpointDataType(), "default.default");
+                log.info("Restore source using checkpoint tables: {}", checkpointDataTypeStruct);
+                return checkpointDataTypeStruct;
+            }
+        }
+
+        log.info("Restore source using checkpoint tables is empty");
+        return Collections.emptyList();
+    }
+
+    protected List<CatalogTable> mergeTableStruct(
+            List<CatalogTable> dbTableStruct, List<CatalogTable> restoreTableStruct) {
+        if (!restoreTableStruct.isEmpty()) {
+            Map<TablePath, CatalogTable> restoreTableMap =
+                    restoreTableStruct.stream()
+                            .collect(Collectors.toMap(CatalogTable::getTablePath, t -> t));
+
+            List<CatalogTable> mergedTableStruct =
+                    dbTableStruct.stream()
+                            .map(e -> restoreTableMap.getOrDefault(e.getTablePath(), e))
+                            .collect(Collectors.toList());
+            log.info("Merge db table struct with checkpoint table struct: {}", mergedTableStruct);
+            return mergedTableStruct;
+        }
+        return dbTableStruct;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/IncrementalSource.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/IncrementalSource.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source;
+
+import org.apache.seatunnel.shade.com.google.common.collect.Sets;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.StartupConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.StopConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.option.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.option.StopMode;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.HybridSplitAssigner;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.IncrementalSplitAssigner;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.SplitAssigner;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.HybridPendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.IncrementalPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.PendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.SnapshotPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.IncrementalSourceReader;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.IncrementalSourceRecordEmitter;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.IncrementalSourceSplitReader;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.SourceSplitStateBase;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.seatunnel.connectors.cdc.debezium.DeserializeFormat;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordEmitter;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SourceReaderOptions;
+import org.apache.seatunnel.format.compatible.debezium.json.CompatibleDebeziumJsonDeserializationSchema;
+
+import io.debezium.relational.TableId;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@NoArgsConstructor
+public abstract class IncrementalSource<T, C extends SourceConfig>
+        implements SeaTunnelSource<T, SourceSplitBase, PendingSplitsState> {
+
+    protected ReadonlyConfig readonlyConfig;
+    protected SourceConfig.Factory<C> configFactory;
+    protected OffsetFactory offsetFactory;
+
+    protected DataSourceDialect<C> dataSourceDialect;
+    protected StartupConfig startupConfig;
+
+    protected int incrementalParallelism;
+    protected StopConfig stopConfig;
+    protected List<CatalogTable> catalogTables;
+
+    protected StopMode stopMode;
+    protected DebeziumDeserializationSchema<T> deserializationSchema;
+
+    protected IncrementalSource(ReadonlyConfig options, List<CatalogTable> catalogTables) {
+        this.catalogTables = catalogTables;
+        this.readonlyConfig = options;
+        this.startupConfig = getStartupConfig(readonlyConfig);
+        this.stopConfig = getStopConfig(readonlyConfig);
+        this.stopMode = stopConfig.getStopMode();
+        this.incrementalParallelism = readonlyConfig.get(SourceOptions.INCREMENTAL_PARALLELISM);
+        this.configFactory = createSourceConfigFactory(readonlyConfig);
+        this.dataSourceDialect = createDataSourceDialect(readonlyConfig);
+        this.deserializationSchema = createDebeziumDeserializationSchema(readonlyConfig);
+        this.offsetFactory = createOffsetFactory(readonlyConfig);
+    }
+
+    protected StartupConfig getStartupConfig(ReadonlyConfig config) {
+        return new StartupConfig(
+                config.get(getStartupModeOption()),
+                config.get(SourceOptions.STARTUP_SPECIFIC_OFFSET_FILE),
+                config.get(SourceOptions.STARTUP_SPECIFIC_OFFSET_POS),
+                config.get(SourceOptions.STARTUP_TIMESTAMP));
+    }
+
+    private StopConfig getStopConfig(ReadonlyConfig config) {
+        return new StopConfig(
+                config.get(getStopModeOption()),
+                config.get(SourceOptions.STOP_SPECIFIC_OFFSET_FILE),
+                config.get(SourceOptions.STOP_SPECIFIC_OFFSET_POS),
+                config.get(SourceOptions.STOP_TIMESTAMP));
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        if (DeserializeFormat.COMPATIBLE_DEBEZIUM_JSON.equals(
+                readonlyConfig.get(JdbcSourceOptions.FORMAT))) {
+            return Collections.singletonList(
+                    CatalogTableUtil.getCatalogTable(
+                            "default.default",
+                            CompatibleDebeziumJsonDeserializationSchema.DEBEZIUM_DATA_ROW_TYPE));
+        }
+        return catalogTables;
+    }
+
+    public abstract Option<StartupMode> getStartupModeOption();
+
+    public abstract Option<StopMode> getStopModeOption();
+
+    public abstract SourceConfig.Factory<C> createSourceConfigFactory(ReadonlyConfig config);
+
+    public abstract DebeziumDeserializationSchema<T> createDebeziumDeserializationSchema(
+            ReadonlyConfig config);
+
+    public abstract DataSourceDialect<C> createDataSourceDialect(ReadonlyConfig config);
+
+    public abstract OffsetFactory createOffsetFactory(ReadonlyConfig config);
+
+    @Override
+    public Boundedness getBoundedness() {
+        return stopMode == StopMode.NEVER ? Boundedness.UNBOUNDED : Boundedness.BOUNDED;
+    }
+
+    @SuppressWarnings("MagicNumber")
+    @Override
+    public SourceReader<T, SourceSplitBase> createReader(SourceReader.Context readerContext)
+            throws Exception {
+        // create source config for the given subtask (e.g. unique server id)
+        C sourceConfig = configFactory.create(readerContext.getIndexOfSubtask());
+        BlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
+                new LinkedBlockingQueue<>(2);
+
+        SchemaChangeResolver schemaChangeResolver = deserializationSchema.getSchemaChangeResolver();
+        Supplier<IncrementalSourceSplitReader<C>> splitReaderSupplier =
+                () ->
+                        new IncrementalSourceSplitReader<>(
+                                readerContext.getIndexOfSubtask(),
+                                dataSourceDialect,
+                                sourceConfig,
+                                schemaChangeResolver);
+        return new IncrementalSourceReader<>(
+                dataSourceDialect,
+                elementsQueue,
+                splitReaderSupplier,
+                createRecordEmitter(sourceConfig, readerContext),
+                new SourceReaderOptions(readonlyConfig),
+                readerContext,
+                sourceConfig,
+                deserializationSchema);
+    }
+
+    protected RecordEmitter<SourceRecords, T, SourceSplitStateBase> createRecordEmitter(
+            SourceConfig sourceConfig, SourceReader.Context context) {
+        return new IncrementalSourceRecordEmitter<>(deserializationSchema, offsetFactory, context);
+    }
+
+    @Override
+    public SourceSplitEnumerator<SourceSplitBase, PendingSplitsState> createEnumerator(
+            SourceSplitEnumerator.Context<SourceSplitBase> enumeratorContext) throws Exception {
+        C sourceConfig = configFactory.create(0);
+        final List<TableId> remainingTables =
+                dataSourceDialect.discoverDataCollections(sourceConfig);
+        final SplitAssigner splitAssigner;
+        SplitAssigner.Context<C> assignerContext =
+                new SplitAssigner.Context<>(
+                        sourceConfig,
+                        new HashSet<>(remainingTables),
+                        new HashMap<>(),
+                        new HashMap<>());
+        if (sourceConfig.getStartupConfig().getStartupMode() == StartupMode.INITIAL) {
+            try {
+
+                boolean isTableIdCaseSensitive =
+                        dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                splitAssigner =
+                        new HybridSplitAssigner<>(
+                                assignerContext,
+                                enumeratorContext.currentParallelism(),
+                                incrementalParallelism,
+                                remainingTables,
+                                isTableIdCaseSensitive,
+                                dataSourceDialect,
+                                offsetFactory);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to discover captured tables for enumerator", e);
+            }
+        } else {
+            splitAssigner =
+                    new IncrementalSplitAssigner<>(
+                            assignerContext, incrementalParallelism, offsetFactory);
+        }
+
+        return new IncrementalSourceEnumerator(enumeratorContext, splitAssigner);
+    }
+
+    @Override
+    public SourceSplitEnumerator<SourceSplitBase, PendingSplitsState> restoreEnumerator(
+            SourceSplitEnumerator.Context<SourceSplitBase> enumeratorContext,
+            PendingSplitsState checkpointState)
+            throws Exception {
+        C sourceConfig = configFactory.create(0);
+        Set<TableId> capturedTables =
+                new HashSet<>(dataSourceDialect.discoverDataCollections(sourceConfig));
+
+        final SplitAssigner splitAssigner;
+        if (checkpointState instanceof HybridPendingSplitsState) {
+            checkpointState = restore(capturedTables, (HybridPendingSplitsState) checkpointState);
+            SnapshotPhaseState checkpointSnapshotState =
+                    ((HybridPendingSplitsState) checkpointState).getSnapshotPhaseState();
+            SplitAssigner.Context<C> assignerContext =
+                    new SplitAssigner.Context<>(
+                            sourceConfig,
+                            capturedTables,
+                            checkpointSnapshotState.getAssignedSplits(),
+                            checkpointSnapshotState.getSplitCompletedOffsets());
+            splitAssigner =
+                    new HybridSplitAssigner<>(
+                            assignerContext,
+                            enumeratorContext.currentParallelism(),
+                            incrementalParallelism,
+                            (HybridPendingSplitsState) checkpointState,
+                            dataSourceDialect,
+                            offsetFactory);
+        } else if (checkpointState instanceof IncrementalPhaseState) {
+            SplitAssigner.Context<C> assignerContext =
+                    new SplitAssigner.Context<>(
+                            sourceConfig, capturedTables, new HashMap<>(), new HashMap<>());
+            splitAssigner =
+                    new IncrementalSplitAssigner<>(
+                            assignerContext, incrementalParallelism, offsetFactory);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported restored PendingSplitsState: " + checkpointState);
+        }
+        return new IncrementalSourceEnumerator(enumeratorContext, splitAssigner);
+    }
+
+    private HybridPendingSplitsState restore(
+            Set<TableId> capturedTables, HybridPendingSplitsState checkpointState) {
+        SnapshotPhaseState checkpointSnapshotState = checkpointState.getSnapshotPhaseState();
+        Set<TableId> checkpointCapturedTables =
+                Stream.concat(
+                                checkpointSnapshotState.getAlreadyProcessedTables().stream(),
+                                checkpointSnapshotState.getRemainingTables().stream())
+                        .collect(Collectors.toSet());
+        Set<TableId> newTables = Sets.difference(capturedTables, checkpointCapturedTables);
+        Set<TableId> deletedTables = Sets.difference(checkpointCapturedTables, capturedTables);
+
+        checkpointSnapshotState.getRemainingTables().addAll(newTables);
+        checkpointSnapshotState.getRemainingTables().removeAll(deletedTables);
+        checkpointSnapshotState.getAlreadyProcessedTables().removeAll(deletedTables);
+        Set<String> deletedSplitIds = new HashSet<>();
+        Iterator<SnapshotSplit> splitIterator =
+                checkpointSnapshotState.getRemainingSplits().iterator();
+        while (splitIterator.hasNext()) {
+            SnapshotSplit split = splitIterator.next();
+            if (deletedTables.contains(split.getTableId())) {
+                splitIterator.remove();
+                deletedSplitIds.add(split.splitId());
+            }
+        }
+        for (Map.Entry<String, SnapshotSplit> entry :
+                checkpointSnapshotState.getAssignedSplits().entrySet()) {
+            SnapshotSplit split = entry.getValue();
+            if (deletedTables.contains(split.getTableId())) {
+                deletedSplitIds.add(entry.getKey());
+            }
+        }
+        deletedSplitIds.forEach(
+                splitId -> {
+                    checkpointSnapshotState.getAssignedSplits().remove(splitId);
+                    checkpointSnapshotState.getSplitCompletedOffsets().remove(splitId);
+                });
+
+        if ((!checkpointSnapshotState.getRemainingTables().isEmpty()
+                        || !checkpointSnapshotState.getRemainingSplits().isEmpty())
+                && checkpointSnapshotState.isAssignerCompleted()) {
+            // If there are still unprocessed tables or splits, and the assigner has completed, the
+            // assigner status needs to be reset
+            return new HybridPendingSplitsState(
+                    new SnapshotPhaseState(
+                            checkpointSnapshotState.getAlreadyProcessedTables(),
+                            checkpointSnapshotState.getRemainingSplits(),
+                            checkpointSnapshotState.getAssignedSplits(),
+                            checkpointSnapshotState.getSplitCompletedOffsets(),
+                            false,
+                            checkpointSnapshotState.getRemainingTables(),
+                            checkpointSnapshotState.isTableIdCaseSensitive(),
+                            checkpointSnapshotState.isRemainingTablesCheckpointed()),
+                    checkpointState.getIncrementalPhaseState());
+        }
+        return checkpointState;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/HybridSplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/HybridSplitAssigner.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.HybridPendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.PendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.relational.TableId;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/** Assigner for Hybrid split which contains snapshot splits and incremental splits. */
+public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HybridSplitAssigner.class);
+
+    private final SnapshotSplitAssigner<C> snapshotSplitAssigner;
+
+    private final IncrementalSplitAssigner<C> incrementalSplitAssigner;
+
+    public HybridSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int currentParallelism,
+            int incrementalParallelism,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            DataSourceDialect<C> dialect,
+            OffsetFactory offsetFactory) {
+        this(
+                new SnapshotSplitAssigner<>(
+                        context,
+                        currentParallelism,
+                        remainingTables,
+                        isTableIdCaseSensitive,
+                        dialect),
+                new IncrementalSplitAssigner<>(context, incrementalParallelism, offsetFactory));
+    }
+
+    public HybridSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int currentParallelism,
+            int incrementalParallelism,
+            HybridPendingSplitsState checkpoint,
+            DataSourceDialect<C> dialect,
+            OffsetFactory offsetFactory) {
+        this(
+                new SnapshotSplitAssigner<>(
+                        context, currentParallelism, checkpoint.getSnapshotPhaseState(), dialect),
+                new IncrementalSplitAssigner<>(context, incrementalParallelism, offsetFactory));
+    }
+
+    private HybridSplitAssigner(
+            SnapshotSplitAssigner<C> snapshotSplitAssigner,
+            IncrementalSplitAssigner<C> incrementalSplitAssigner) {
+        this.snapshotSplitAssigner = snapshotSplitAssigner;
+        this.incrementalSplitAssigner = incrementalSplitAssigner;
+    }
+
+    @Override
+    public void open() {
+        snapshotSplitAssigner.open();
+    }
+
+    @Override
+    public Optional<SourceSplitBase> getNext() {
+        if (!snapshotSplitAssigner.noMoreSplits()) {
+            // snapshot assigner still have remaining splits, assign split from it
+            return snapshotSplitAssigner.getNext();
+        }
+        if (!snapshotSplitAssigner.isCompleted()) {
+            // incremental split is not ready by now
+            return Optional.empty();
+        }
+        // incremental split assigning
+        if (!incrementalSplitAssigner.noMoreSplits()) {
+            // we need to wait snapshot-assigner to be completed before
+            // assigning the incremental split. Otherwise, records emitted from incremental split
+            // might be out-of-order in terms of same primary key with snapshot splits.
+            return incrementalSplitAssigner.getNext();
+        }
+        // no more splits for the assigner
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean waitingForCompletedSplits() {
+        return snapshotSplitAssigner.waitingForCompletedSplits()
+                || incrementalSplitAssigner.waitingForAssignedSplits();
+    }
+
+    @Override
+    public void onCompletedSplits(List<SnapshotSplitWatermark> completedSplitWatermarks) {
+        snapshotSplitAssigner.onCompletedSplits(completedSplitWatermarks);
+        incrementalSplitAssigner.onCompletedSplits(completedSplitWatermarks);
+    }
+
+    @Override
+    public void addSplits(Collection<SourceSplitBase> splits) {
+        List<SourceSplitBase> snapshotSplits = new ArrayList<>();
+        List<SourceSplitBase> incrementalSplits = new ArrayList<>();
+        for (SourceSplitBase split : splits) {
+            if (split.isSnapshotSplit()) {
+                snapshotSplits.add(split);
+            } else {
+                incrementalSplits.add(split);
+            }
+        }
+        snapshotSplitAssigner.addSplits(snapshotSplits);
+        incrementalSplitAssigner.addSplits(incrementalSplits);
+    }
+
+    @Override
+    public PendingSplitsState snapshotState(long checkpointId) {
+        return new HybridPendingSplitsState(
+                snapshotSplitAssigner.snapshotState(checkpointId),
+                incrementalSplitAssigner.snapshotState(checkpointId));
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        snapshotSplitAssigner.notifyCheckpointComplete(checkpointId);
+        incrementalSplitAssigner.notifyCheckpointComplete(checkpointId);
+    }
+
+    @VisibleForTesting
+    IncrementalSplitAssigner<C> getIncrementalSplitAssigner() {
+        return incrementalSplitAssigner;
+    }
+
+    @VisibleForTesting
+    SnapshotSplitAssigner<C> getSnapshotSplitAssigner() {
+        return snapshotSplitAssigner;
+    }
+
+    public boolean completedSnapshotPhase(List<TableId> tableIds) {
+        return Arrays.asList(
+                        snapshotSplitAssigner.completedSnapshotPhase(tableIds),
+                        incrementalSplitAssigner.completedSnapshotPhase(tableIds))
+                .stream()
+                .allMatch(Predicate.isEqual(true));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumerator.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumerator.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.PendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotPhaseEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotSplitsAckEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotSplitsReportEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Incremental source enumerator that enumerates receive the split request and assign the split to
+ * source readers.
+ */
+public class IncrementalSourceEnumerator
+        implements SourceSplitEnumerator<SourceSplitBase, PendingSplitsState> {
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementalSourceEnumerator.class);
+
+    private final SourceSplitEnumerator.Context<SourceSplitBase> context;
+    private final SplitAssigner splitAssigner;
+
+    /** using TreeSet to prefer assigning incremental split to task-0 for easier debug */
+    private final TreeSet<Integer> readersAwaitingSplit;
+
+    private volatile boolean running;
+
+    public IncrementalSourceEnumerator(
+            SourceSplitEnumerator.Context<SourceSplitBase> context, SplitAssigner splitAssigner) {
+        this.context = context;
+        this.splitAssigner = splitAssigner;
+        this.readersAwaitingSplit = new TreeSet<>();
+        this.running = false;
+    }
+
+    @Override
+    public void open() {
+        splitAssigner.open();
+    }
+
+    @Override
+    public synchronized void run() throws Exception {
+        this.running = true;
+        assignSplits();
+    }
+
+    @Override
+    public synchronized void handleSplitRequest(int subtaskId) {
+        if (!context.registeredReaders().contains(subtaskId)) {
+            // reader failed between sending the request and now. skip this request.
+            return;
+        }
+
+        readersAwaitingSplit.add(subtaskId);
+        if (running) {
+            assignSplits();
+        }
+    }
+
+    @Override
+    public void addSplitsBack(List<SourceSplitBase> splits, int subtaskId) {
+        LOG.debug("Incremental Source Enumerator adds splits back: {}", splits);
+        splitAssigner.addSplits(splits);
+    }
+
+    @Override
+    public int currentUnassignedSplitSize() {
+        return 0;
+    }
+
+    @Override
+    public void registerReader(int subtaskId) {
+        // do nothing
+    }
+
+    @Override
+    public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+        if (sourceEvent instanceof CompletedSnapshotSplitsReportEvent) {
+            LOG.debug(
+                    "The enumerator receives completed split watermarks(log offset) {} from subtask {}.",
+                    sourceEvent,
+                    subtaskId);
+            CompletedSnapshotSplitsReportEvent reportEvent =
+                    (CompletedSnapshotSplitsReportEvent) sourceEvent;
+            List<SnapshotSplitWatermark> completedSplitWatermarks =
+                    reportEvent.getCompletedSnapshotSplitWatermarks();
+            synchronized (context) {
+                splitAssigner.onCompletedSplits(completedSplitWatermarks);
+            }
+
+            // send acknowledge event
+            CompletedSnapshotSplitsAckEvent ackEvent =
+                    new CompletedSnapshotSplitsAckEvent(
+                            completedSplitWatermarks.stream()
+                                    .map(SnapshotSplitWatermark::getSplitId)
+                                    .collect(Collectors.toList()));
+            context.sendEventToSourceReader(subtaskId, ackEvent);
+        } else if (sourceEvent instanceof CompletedSnapshotPhaseEvent) {
+            LOG.debug(
+                    "The enumerator receives completed snapshot phase event {} from subtask {}.",
+                    sourceEvent,
+                    subtaskId);
+            CompletedSnapshotPhaseEvent event = (CompletedSnapshotPhaseEvent) sourceEvent;
+            if (splitAssigner instanceof HybridSplitAssigner) {
+                ((HybridSplitAssigner) splitAssigner).completedSnapshotPhase(event.getTableIds());
+                LOG.info(
+                        "Clean the SnapshotSplitAssigner#assignedSplits/splitCompletedOffsets to empty.");
+            }
+        }
+    }
+
+    @Override
+    public PendingSplitsState snapshotState(long checkpointId) {
+        return splitAssigner.snapshotState(checkpointId);
+    }
+
+    @Override
+    public synchronized void notifyCheckpointComplete(long checkpointId) {
+        splitAssigner.notifyCheckpointComplete(checkpointId);
+        // incremental split may be available after checkpoint complete
+        assignSplits();
+    }
+
+    @Override
+    public void close() {
+        LOG.info("Closing enumerator...");
+        splitAssigner.close();
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    private void assignSplits() {
+        final Iterator<Integer> awaitingReader = readersAwaitingSplit.iterator();
+
+        while (awaitingReader.hasNext()) {
+            int nextAwaiting = awaitingReader.next();
+            // if the reader that requested another split has failed in the meantime, remove
+            // it from the list of waiting readers
+            if (!context.registeredReaders().contains(nextAwaiting)) {
+                awaitingReader.remove();
+                continue;
+            }
+
+            Optional<SourceSplitBase> split;
+            synchronized (context) {
+                split = splitAssigner.getNext();
+            }
+            if (split.isPresent()) {
+                final SourceSplitBase sourceSplit = split.get();
+                context.assignSplit(nextAwaiting, sourceSplit);
+                awaitingReader.remove();
+                LOG.debug("Assign split {} to subtask {}", sourceSplit, nextAwaiting);
+            } else {
+                if (splitAssigner.waitingForCompletedSplits()) {
+                    // there is no available splits by now, skip assigning
+                    break;
+                } else {
+                    LOG.info(
+                            "No more splits available, signal no more splits to subtask {}",
+                            nextAwaiting);
+                    context.signalNoMoreSplits(nextAwaiting);
+                    awaitingReader.remove();
+                }
+            }
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSplitAssigner.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.IncrementalPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.split.CompletedSnapshotSplitInfo;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.relational.TableId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
+
+/** Assigner for incremental split. */
+public class IncrementalSplitAssigner<C extends SourceConfig> implements SplitAssigner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementalSplitAssigner.class);
+    protected static final String INCREMENTAL_SPLIT_ID = "incremental-split-%d";
+
+    private final SplitAssigner.Context<C> context;
+
+    private final int incrementalParallelism;
+
+    private final OffsetFactory offsetFactory;
+
+    /**
+     * Maximum watermark in SnapshotSplits per table. <br>
+     * Used to delete information in completedSnapshotSplitInfos, reducing state size. <br>
+     * Used to support Exactly-Once.
+     */
+    private final Map<TableId, Offset> tableWatermarks = new HashMap<>();
+
+    private boolean splitAssigned = false;
+
+    private final List<IncrementalSplit> remainingSplits = new ArrayList<>();
+
+    private final Map<String, IncrementalSplit> assignedSplits = new HashMap<>();
+
+    private boolean startWithSnapshotMinimumOffset = true;
+    private List<CatalogTable> checkpointTables;
+    private Map<TableId, byte[]> historyTableChanges;
+
+    public IncrementalSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int incrementalParallelism,
+            OffsetFactory offsetFactory) {
+        this.context = context;
+        this.incrementalParallelism = incrementalParallelism;
+        this.offsetFactory = offsetFactory;
+    }
+
+    @Override
+    public void open() {}
+
+    @Override
+    public Optional<SourceSplitBase> getNext() {
+        if (!remainingSplits.isEmpty()) {
+            // return remaining splits firstly
+            Iterator<IncrementalSplit> iterator = remainingSplits.iterator();
+            IncrementalSplit split = iterator.next();
+            iterator.remove();
+            assignedSplits.put(split.splitId(), split);
+            return Optional.of(split);
+        }
+        if (splitAssigned) {
+            return Optional.empty();
+        }
+        List<IncrementalSplit> incrementalSplits =
+                createIncrementalSplits(startWithSnapshotMinimumOffset);
+        remainingSplits.addAll(incrementalSplits);
+        splitAssigned = true;
+        return getNext();
+    }
+
+    /** Indicates there is no more splits available in this assigner. */
+    public boolean noMoreSplits() {
+        return getRemainingTables().isEmpty() && remainingSplits.isEmpty();
+    }
+
+    private Set<TableId> getRemainingTables() {
+        Set<TableId> allTables = new HashSet<>(context.getCapturedTables());
+        assignedSplits.values().forEach(split -> split.getTableIds().forEach(allTables::remove));
+        return allTables;
+    }
+
+    @Override
+    public boolean waitingForCompletedSplits() {
+        return false;
+    }
+
+    @Override
+    public void onCompletedSplits(List<SnapshotSplitWatermark> completedSplitWatermarks) {
+        // do nothing
+        completedSplitWatermarks.forEach(
+                watermark ->
+                        context.getSplitCompletedOffsets().put(watermark.getSplitId(), watermark));
+    }
+
+    @Override
+    public void addSplits(Collection<SourceSplitBase> splits) {
+        // we don't store the split, but will re-create incremental split later
+        splits.stream()
+                .map(SourceSplitBase::asIncrementalSplit)
+                .forEach(
+                        incrementalSplit -> {
+                            Offset startupOffset = incrementalSplit.getStartupOffset();
+                            List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos =
+                                    incrementalSplit.getCompletedSnapshotSplitInfos();
+                            for (CompletedSnapshotSplitInfo info : completedSnapshotSplitInfos) {
+                                if (!context.getCapturedTables().contains(info.getTableId())) {
+                                    continue;
+                                }
+                                context.getSplitCompletedOffsets()
+                                        .put(info.getSplitId(), info.getWatermark());
+                                context.getAssignedSnapshotSplit()
+                                        .put(info.getSplitId(), info.asSnapshotSplit());
+                            }
+                            for (TableId tableId : incrementalSplit.getTableIds()) {
+                                if (!context.getCapturedTables().contains(tableId)) {
+                                    continue;
+                                }
+                                tableWatermarks.put(tableId, startupOffset);
+                            }
+                            checkpointTables = incrementalSplit.getCheckpointTables();
+                            historyTableChanges = incrementalSplit.getHistoryTableChanges();
+                        });
+        if (!tableWatermarks.isEmpty()) {
+            this.startWithSnapshotMinimumOffset = false;
+        }
+    }
+
+    @Override
+    public IncrementalPhaseState snapshotState(long checkpointId) {
+        return new IncrementalPhaseState();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // nothing to do
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    public List<IncrementalSplit> createIncrementalSplits(boolean startWithSnapshotMinimumOffset) {
+        Set<TableId> allTables = new HashSet<>(context.getCapturedTables());
+        assignedSplits.values().forEach(split -> split.getTableIds().forEach(allTables::remove));
+        List<TableId>[] capturedTables = new List[incrementalParallelism];
+        int i = 0;
+        for (TableId tableId : allTables) {
+            int index = i % incrementalParallelism;
+            if (capturedTables[index] == null) {
+                capturedTables[index] = new ArrayList<>();
+            }
+            capturedTables[index].add(tableId);
+            i++;
+        }
+        i = 0;
+        List<IncrementalSplit> incrementalSplits = new ArrayList<>();
+        for (List<TableId> capturedTable : capturedTables) {
+            incrementalSplits.add(
+                    createIncrementalSplit(capturedTable, i++, startWithSnapshotMinimumOffset));
+        }
+        return incrementalSplits;
+    }
+
+    private IncrementalSplit createIncrementalSplit(
+            List<TableId> capturedTables, int index, boolean startWithSnapshotMinimumOffset) {
+        C sourceConfig = context.getSourceConfig();
+        final List<SnapshotSplit> assignedSnapshotSplit =
+                context.getAssignedSnapshotSplit().values().stream()
+                        .filter(split -> capturedTables.contains(split.getTableId()))
+                        .sorted(Comparator.comparing(SourceSplitBase::splitId))
+                        .collect(Collectors.toList());
+
+        Map<String, SnapshotSplitWatermark> splitCompletedOffsets =
+                context.getSplitCompletedOffsets();
+        final List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos = new ArrayList<>();
+        Offset minOffset = null;
+        for (SnapshotSplit split : assignedSnapshotSplit) {
+            SnapshotSplitWatermark splitWatermark = splitCompletedOffsets.get(split.splitId());
+            if (startWithSnapshotMinimumOffset) {
+                // find the min offset of change log
+                Offset splitOffset =
+                        sourceConfig.isExactlyOnce()
+                                ? splitWatermark.getHighWatermark()
+                                : splitWatermark.getLowWatermark();
+                if (minOffset == null || splitOffset.isBefore(minOffset)) {
+                    minOffset = splitOffset;
+                    LOG.debug(
+                            "Find the min offset {} of change log in split {}",
+                            splitOffset,
+                            splitWatermark);
+                }
+            }
+            completedSnapshotSplitInfos.add(
+                    new CompletedSnapshotSplitInfo(
+                            split.splitId(),
+                            split.getTableId(),
+                            split.getSplitKeyType(),
+                            split.getSplitStart(),
+                            split.getSplitEnd(),
+                            splitWatermark));
+        }
+        for (TableId tableId : capturedTables) {
+            Offset watermark = tableWatermarks.get(tableId);
+            if (minOffset == null || (watermark != null && watermark.isBefore(minOffset))) {
+                minOffset = watermark;
+                LOG.debug(
+                        "Find the min offset {} of change log in table-watermarks {}",
+                        watermark,
+                        tableId);
+            }
+        }
+        Offset incrementalSplitStartOffset =
+                minOffset != null
+                        ? minOffset
+                        : sourceConfig.getStartupConfig().getStartupOffset(offsetFactory);
+        return new IncrementalSplit(
+                String.format(INCREMENTAL_SPLIT_ID, index),
+                capturedTables,
+                incrementalSplitStartOffset,
+                sourceConfig.getStopConfig().getStopOffset(offsetFactory),
+                completedSnapshotSplitInfos,
+                checkpointTables,
+                historyTableChanges);
+    }
+
+    @VisibleForTesting
+    void setSplitAssigned(boolean assigned) {
+        this.splitAssigned = assigned;
+    }
+
+    public boolean completedSnapshotPhase(List<TableId> tableIds) {
+        checkArgument(splitAssigned && noMoreSplits());
+
+        for (String splitKey : new ArrayList<>(context.getAssignedSnapshotSplit().keySet())) {
+            SnapshotSplit assignedSplit = context.getAssignedSnapshotSplit().get(splitKey);
+            if (tableIds.contains(assignedSplit.getTableId())) {
+                context.getAssignedSnapshotSplit().remove(splitKey);
+                context.getSplitCompletedOffsets().remove(assignedSplit.splitId());
+            }
+        }
+        return context.getAssignedSnapshotSplit().isEmpty()
+                && context.getSplitCompletedOffsets().isEmpty();
+    }
+
+    public boolean waitingForAssignedSplits() {
+        return !(splitAssigned && noMoreSplits());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.SnapshotPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.relational.TableId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
+
+/** Assigner for snapshot split. */
+public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssigner {
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotSplitAssigner.class);
+
+    private final SplitAssigner.Context<C> context;
+
+    private final C sourceConfig;
+    private final List<TableId> alreadyProcessedTables;
+    private final Queue<SnapshotSplit> remainingSplits;
+    private final Map<String, SnapshotSplit> assignedSplits;
+    private final Map<String, SnapshotSplitWatermark> splitCompletedOffsets;
+    private boolean assignerCompleted;
+    private final int currentParallelism;
+    private final Deque<TableId> remainingTables;
+    private final boolean isRemainingTablesCheckpointed;
+
+    private ChunkSplitter chunkSplitter;
+    private boolean isTableIdCaseSensitive;
+
+    private Long checkpointIdToFinish;
+    private final DataSourceDialect<C> dialect;
+
+    SnapshotSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int currentParallelism,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            DataSourceDialect<C> dialect) {
+        this(
+                context,
+                currentParallelism,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new HashMap<>(),
+                new HashMap<>(),
+                false,
+                remainingTables,
+                isTableIdCaseSensitive,
+                true,
+                dialect);
+    }
+
+    SnapshotSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int currentParallelism,
+            SnapshotPhaseState checkpoint,
+            DataSourceDialect<C> dialect) {
+        this(
+                context,
+                currentParallelism,
+                checkpoint.getAlreadyProcessedTables(),
+                checkpoint.getRemainingSplits(),
+                checkpoint.getAssignedSplits(),
+                checkpoint.getSplitCompletedOffsets(),
+                checkpoint.isAssignerCompleted(),
+                checkpoint.getRemainingTables(),
+                checkpoint.isTableIdCaseSensitive(),
+                checkpoint.isRemainingTablesCheckpointed(),
+                dialect);
+    }
+
+    private SnapshotSplitAssigner(
+            SplitAssigner.Context<C> context,
+            int currentParallelism,
+            List<TableId> alreadyProcessedTables,
+            List<SnapshotSplit> remainingSplits,
+            Map<String, SnapshotSplit> assignedSplits,
+            Map<String, SnapshotSplitWatermark> splitCompletedOffsets,
+            boolean assignerCompleted,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            boolean isRemainingTablesCheckpointed,
+            DataSourceDialect<C> dialect) {
+        this.context = context;
+        this.sourceConfig = context.getSourceConfig();
+        this.currentParallelism = currentParallelism;
+        this.alreadyProcessedTables = Collections.synchronizedList(alreadyProcessedTables);
+        this.remainingSplits = new ConcurrentLinkedQueue(remainingSplits);
+        this.assignedSplits = new ConcurrentHashMap<>(assignedSplits);
+        this.splitCompletedOffsets = new ConcurrentHashMap<>(splitCompletedOffsets);
+        this.assignerCompleted = assignerCompleted;
+        this.remainingTables = new ConcurrentLinkedDeque<>(remainingTables);
+        this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
+        this.isTableIdCaseSensitive = isTableIdCaseSensitive;
+        this.dialect = dialect;
+
+        LOG.info("SnapshotSplitAssigner created with remaining tables: {}", this.remainingTables);
+        LOG.info(
+                "SnapshotSplitAssigner created with remaining splits: [{}]",
+                this.remainingSplits.stream()
+                        .map(SnapshotSplit::splitId)
+                        .collect(Collectors.joining(",")));
+        LOG.info(
+                "SnapshotSplitAssigner created with assigned splits: {}",
+                this.assignedSplits.keySet());
+    }
+
+    @Override
+    public void open() {
+        chunkSplitter = dialect.createChunkSplitter(sourceConfig);
+
+        // the legacy state didn't snapshot remaining tables, discovery remaining table here
+        if (!isRemainingTablesCheckpointed && !assignerCompleted) {
+            try {
+                final List<TableId> discoverTables = dialect.discoverDataCollections(sourceConfig);
+                context.getCapturedTables().addAll(discoverTables);
+                discoverTables.removeAll(alreadyProcessedTables);
+                this.remainingTables.addAll(discoverTables);
+                this.isTableIdCaseSensitive = dialect.isDataCollectionIdCaseSensitive(sourceConfig);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to discover remaining tables to capture", e);
+            }
+        }
+    }
+
+    @Override
+    public Optional<SourceSplitBase> getNext() {
+        if (chunkSplitter == null) {
+            return Optional.empty();
+        }
+        if (!remainingSplits.isEmpty()) {
+            // return remaining splits firstly
+            Iterator<SnapshotSplit> iterator = remainingSplits.iterator();
+            SnapshotSplit split = iterator.next();
+            iterator.remove();
+            assignedSplits.put(split.splitId(), split);
+            context.getAssignedSnapshotSplit().put(split.splitId(), split);
+            return Optional.of(split);
+        } else {
+            // it's turn for new table
+            TableId nextTable = remainingTables.pollFirst();
+            if (nextTable != null) {
+                // split the given table into chunks (snapshot splits)
+                Collection<SnapshotSplit> splits = chunkSplitter.generateSplits(nextTable);
+                remainingSplits.addAll(splits);
+                alreadyProcessedTables.add(nextTable);
+                return getNext();
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Override
+    public boolean waitingForCompletedSplits() {
+        return !allSplitsCompleted();
+    }
+
+    @Override
+    public void onCompletedSplits(List<SnapshotSplitWatermark> completedSplitWatermarks) {
+        completedSplitWatermarks.forEach(
+                watermark -> this.splitCompletedOffsets.put(watermark.getSplitId(), watermark));
+        if (allSplitsCompleted()) {
+            // Skip the waiting checkpoint when current parallelism is 1 which means we do not need
+            // to care about the global output data order of snapshot splits and incremental split.
+            if (currentParallelism == 1) {
+                assignerCompleted = true;
+                LOG.info(
+                        "Snapshot split assigner received all splits completed and the job parallelism is 1, snapshot split assigner is turn into completed status.");
+            } else {
+                LOG.info(
+                        "Snapshot split assigner received all splits completed, waiting for a complete checkpoint to mark the assigner completed.");
+            }
+        }
+    }
+
+    @Override
+    public void addSplits(Collection<SourceSplitBase> splits) {
+        for (SourceSplitBase split : splits) {
+            remainingSplits.add(split.asSnapshotSplit());
+            // we should remove the add-backed splits from the assigned list, because they are
+            // failed
+            assignedSplits.remove(split.splitId());
+            splitCompletedOffsets.remove(split.splitId());
+        }
+    }
+
+    @Override
+    public SnapshotPhaseState snapshotState(long checkpointId) {
+        SnapshotPhaseState state =
+                new SnapshotPhaseState(
+                        alreadyProcessedTables,
+                        remainingSplits.isEmpty()
+                                ? new ArrayList<>()
+                                : new ArrayList<>(remainingSplits),
+                        assignedSplits,
+                        splitCompletedOffsets,
+                        assignerCompleted,
+                        remainingTables.isEmpty()
+                                ? new ArrayList<>()
+                                : new ArrayList<>(remainingTables),
+                        isTableIdCaseSensitive,
+                        true);
+        // we need a complete checkpoint before mark this assigner to be completed, to wait for all
+        // records of snapshot splits are completely processed
+        if (checkpointIdToFinish == null && !assignerCompleted && allSplitsCompleted()) {
+            checkpointIdToFinish = checkpointId;
+        }
+        return state;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // we have waited for at-least one complete checkpoint after all snapshot-splits are
+        // completed, then we can mark snapshot assigner as completed.
+        if (checkpointIdToFinish != null && !assignerCompleted && allSplitsCompleted()) {
+            assignerCompleted = checkpointId >= checkpointIdToFinish;
+            LOG.info("Snapshot split assigner is turn into completed status.");
+        }
+    }
+
+    /** Indicates there is no more splits available in this assigner. */
+    public boolean noMoreSplits() {
+        return remainingTables.isEmpty() && remainingSplits.isEmpty();
+    }
+
+    /**
+     * Returns whether the snapshot split assigner is completed, which indicates there is no more
+     * splits and all records of splits have been completely processed in the pipeline.
+     */
+    public boolean isCompleted() {
+        return assignerCompleted;
+    }
+
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * Returns whether all splits are completed which means no more splits and all assigned splits
+     * are completed.
+     */
+    private boolean allSplitsCompleted() {
+        return noMoreSplits() && assignedSplits.size() == splitCompletedOffsets.size();
+    }
+
+    @VisibleForTesting
+    Map<String, SnapshotSplit> getAssignedSplits() {
+        return assignedSplits;
+    }
+
+    @VisibleForTesting
+    Map<String, SnapshotSplitWatermark> getSplitCompletedOffsets() {
+        return splitCompletedOffsets;
+    }
+
+    public boolean completedSnapshotPhase(List<TableId> tableIds) {
+        checkArgument(isCompleted() && allSplitsCompleted());
+
+        for (String splitKey : new ArrayList<>(assignedSplits.keySet())) {
+            SnapshotSplit assignedSplit = assignedSplits.get(splitKey);
+            if (tableIds.contains(assignedSplit.getTableId())) {
+                assignedSplits.remove(splitKey);
+                splitCompletedOffsets.remove(assignedSplit.splitId());
+            }
+        }
+
+        return assignedSplits.isEmpty() && splitCompletedOffsets.isEmpty();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SplitAssigner.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.api.state.CheckpointListener;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.PendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import io.debezium.relational.TableId;
+import lombok.Data;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The {@code SplitAssigner} is responsible for deciding what split should be processed. It
+ * determines split processing order.
+ */
+public interface SplitAssigner {
+
+    /**
+     * Called to open the assigner to acquire any resources, like threads or network connections.
+     */
+    void open();
+
+    /**
+     * Gets the next split.
+     *
+     * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
+     * be done and the source will finish once the readers completed their current splits.
+     */
+    Optional<SourceSplitBase> getNext();
+
+    /**
+     * Whether the split assigner is still waiting for callback of completed splits, i.e. {@link
+     * #onCompletedSplits}.
+     */
+    boolean waitingForCompletedSplits();
+
+    /**
+     * Callback to handle the completed splits with completed change log offset. This is useful for
+     * determine when to generate incremental split and what incremental split to generate.
+     */
+    void onCompletedSplits(List<SnapshotSplitWatermark> completedSplitWatermarks);
+
+    /**
+     * Adds a set of splits to this assigner. This happens for example when some split processing
+     * failed and the splits need to be re-added.
+     */
+    void addSplits(Collection<SourceSplitBase> splits);
+
+    /**
+     * Creates a snapshot of the state of this split assigner, to be stored in a checkpoint.
+     *
+     * <p>The snapshot should contain the latest state of the assigner: It should assume that all
+     * operations that happened before the snapshot have successfully completed. For example all
+     * splits assigned to readers via {@link #getNext()} don't need to be included in the snapshot
+     * anymore.
+     *
+     * <p>This method takes the ID of the checkpoint for which the state is snapshotted. Most
+     * implementations should be able to ignore this parameter, because for the contents of the
+     * snapshot, it doesn't matter for which checkpoint it gets created. This parameter can be
+     * interesting for source connectors with external systems where those systems are themselves
+     * aware of checkpoints; for example in cases where the enumerator notifies that system about a
+     * specific checkpoint being triggered.
+     *
+     * @param checkpointId The ID of the checkpoint for which the snapshot is created.
+     * @return an object containing the state of the split enumerator.
+     */
+    PendingSplitsState snapshotState(long checkpointId);
+
+    /**
+     * Notifies the listener that the checkpoint with the given {@code checkpointId} completed and
+     * was committed.
+     *
+     * @see CheckpointListener#notifyCheckpointComplete(long)
+     */
+    void notifyCheckpointComplete(long checkpointId);
+
+    /**
+     * Called to close the assigner, in case it holds on to any resources, like threads or network
+     * connections.
+     */
+    default void close() {}
+
+    @Data
+    final class Context<C extends SourceConfig> {
+        private final C sourceConfig;
+
+        private final Set<TableId> capturedTables;
+
+        private final Map<String, SnapshotSplit> assignedSnapshotSplit;
+
+        /** key: SnapshotSplit id */
+        private final Map<String, SnapshotSplitWatermark> splitCompletedOffsets;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter;
+
+import org.apache.seatunnel.api.table.catalog.ConstraintKey;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.utils.ObjectUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.math.BigDecimal.ROUND_CEILING;
+import static org.apache.seatunnel.connectors.cdc.base.utils.ObjectUtils.doubleCompare;
+
+@Slf4j
+public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunkSplitter {
+
+    private final JdbcSourceConfig sourceConfig;
+    private final JdbcDataSourceDialect dialect;
+
+    public AbstractJdbcSourceChunkSplitter(
+            JdbcSourceConfig sourceConfig, JdbcDataSourceDialect dialect) {
+        this.sourceConfig = sourceConfig;
+        this.dialect = dialect;
+    }
+
+    @Override
+    public Collection<SnapshotSplit> generateSplits(TableId tableId) {
+        try (JdbcConnection jdbc = dialect.openJdbcConnection(sourceConfig)) {
+            log.info("Start splitting table {} into chunks...", tableId);
+            long start = System.currentTimeMillis();
+
+            Column splitColumn = getSplitColumn(jdbc, dialect, tableId);
+            List<SnapshotSplit> splits = new ArrayList<>();
+            if (splitColumn == null) {
+                if (sourceConfig.isExactlyOnce()) {
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "Exactly once is enabled, but not found primary key or unique key for table %s",
+                                    tableId));
+                }
+                SnapshotSplit singleSplit = createSnapshotSplit(jdbc, tableId, 0, null, null, null);
+                splits.add(singleSplit);
+                log.warn(
+                        "No evenly split column found for table {}, use single split {}",
+                        tableId,
+                        singleSplit);
+            } else {
+                final List<ChunkRange> chunks;
+                try {
+                    chunks = splitTableIntoChunks(jdbc, tableId, splitColumn);
+                } catch (SQLException e) {
+                    throw new RuntimeException("Failed to split chunks for table " + tableId, e);
+                }
+
+                // convert chunks into splits
+                SeaTunnelRowType splitType = getSplitType(splitColumn);
+                for (int i = 0; i < chunks.size(); i++) {
+                    ChunkRange chunk = chunks.get(i);
+                    SnapshotSplit split =
+                            createSnapshotSplit(
+                                    jdbc,
+                                    tableId,
+                                    i,
+                                    splitType,
+                                    chunk.getChunkStart(),
+                                    chunk.getChunkEnd());
+                    splits.add(split);
+                }
+            }
+
+            long end = System.currentTimeMillis();
+            log.info(
+                    "Split table {} into {} chunks, time cost: {}ms.",
+                    tableId,
+                    splits.size(),
+                    end - start);
+            return splits;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format("Generate Splits for table %s error", tableId), e);
+        }
+    }
+
+    private List<ChunkRange> splitTableIntoChunks(
+            JdbcConnection jdbc, TableId tableId, Column splitColumn) throws Exception {
+        final String splitColumnName = splitColumn.name();
+        final Object[] minMax = queryMinMax(jdbc, tableId, splitColumn);
+        final Object min = minMax[0];
+        final Object max = minMax[1];
+        if (min == null || max == null || min.equals(max)) {
+            // empty table, or only one row, return full table scan as a chunk
+            return Collections.singletonList(ChunkRange.all());
+        }
+
+        final int chunkSize = sourceConfig.getSplitSize();
+        final double distributionFactorUpper = sourceConfig.getDistributionFactorUpper();
+        final double distributionFactorLower = sourceConfig.getDistributionFactorLower();
+        final int sampleShardingThreshold = sourceConfig.getSampleShardingThreshold();
+
+        log.info(
+                "Splitting table {} into chunks, split column: {}, min: {}, max: {}, chunk size: {}, "
+                        + "distribution factor upper: {}, distribution factor lower: {}, sample sharding threshold: {}",
+                tableId,
+                splitColumnName,
+                min,
+                max,
+                chunkSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                sampleShardingThreshold);
+
+        if (isEvenlySplitColumn(splitColumn)) {
+            long approximateRowCnt = queryApproximateRowCnt(jdbc, tableId);
+            double distributionFactor =
+                    calculateDistributionFactor(tableId, min, max, approximateRowCnt);
+
+            boolean dataIsEvenlyDistributed =
+                    doubleCompare(distributionFactor, distributionFactorLower) >= 0
+                            && doubleCompare(distributionFactor, distributionFactorUpper) <= 0;
+
+            if (dataIsEvenlyDistributed) {
+                // the minimum dynamic chunk size is at least 1
+                final int dynamicChunkSize = Math.max((int) (distributionFactor * chunkSize), 1);
+                return splitEvenlySizedChunks(
+                        tableId, min, max, approximateRowCnt, chunkSize, dynamicChunkSize);
+            } else {
+                int shardCount = (int) (approximateRowCnt / chunkSize);
+                int inverseSamplingRate = sourceConfig.getInverseSamplingRate();
+                if (sampleShardingThreshold < shardCount) {
+                    // It is necessary to ensure that the number of data rows sampled by the
+                    // sampling rate is greater than the number of shards.
+                    // Otherwise, if the sampling rate is too low, it may result in an insufficient
+                    // number of data rows for the shards, leading to an inadequate number of
+                    // shards.
+                    // Therefore, inverseSamplingRate should be less than chunkSize
+                    if (inverseSamplingRate > chunkSize) {
+                        log.warn(
+                                "The inverseSamplingRate is {}, which is greater than chunkSize {}, so we set inverseSamplingRate to chunkSize",
+                                inverseSamplingRate,
+                                chunkSize);
+                        inverseSamplingRate = chunkSize;
+                    }
+                    log.info(
+                            "Use sampling sharding for table {}, the sampling rate is {}",
+                            tableId,
+                            inverseSamplingRate);
+                    Object[] sample =
+                            sampleDataFromColumn(jdbc, tableId, splitColumn, inverseSamplingRate);
+                    log.info(
+                            "Sample data from table {} end, the sample size is {}",
+                            tableId,
+                            sample.length);
+                    return efficientShardingThroughSampling(
+                            tableId, sample, approximateRowCnt, shardCount);
+                }
+                return splitUnevenlySizedChunks(jdbc, tableId, splitColumn, min, max, chunkSize);
+            }
+        } else {
+            return splitUnevenlySizedChunks(jdbc, tableId, splitColumn, min, max, chunkSize);
+        }
+    }
+
+    /** Split table into unevenly sized chunks by continuously calculating next chunk max value. */
+    protected List<ChunkRange> splitUnevenlySizedChunks(
+            JdbcConnection jdbc,
+            TableId tableId,
+            Column splitColumn,
+            Object min,
+            Object max,
+            int chunkSize)
+            throws SQLException {
+        log.info(
+                "Use unevenly-sized chunks for table {}, the chunk size is {}", tableId, chunkSize);
+        final List<ChunkRange> splits = new ArrayList<>();
+        Object chunkStart = null;
+        Object chunkEnd = nextChunkEnd(jdbc, min, tableId, splitColumn, max, chunkSize);
+        int count = 0;
+        while (chunkEnd != null && ObjectCompare(chunkEnd, max) <= 0) {
+            // we start from [null, min + chunk_size) and avoid [null, min)
+            splits.add(ChunkRange.of(chunkStart, chunkEnd));
+            // may sleep a while to avoid DDOS on MySQL server
+            maySleep(count++, tableId);
+            chunkStart = chunkEnd;
+            chunkEnd = nextChunkEnd(jdbc, chunkEnd, tableId, splitColumn, max, chunkSize);
+        }
+        // add the ending split
+        splits.add(ChunkRange.of(chunkStart, null));
+        return splits;
+    }
+
+    protected Object nextChunkEnd(
+            JdbcConnection jdbc,
+            Object previousChunkEnd,
+            TableId tableId,
+            Column splitColumn,
+            Object max,
+            int chunkSize)
+            throws SQLException {
+        // chunk end might be null when max values are removed
+        Object chunkEnd =
+                queryNextChunkMax(jdbc, tableId, splitColumn, chunkSize, previousChunkEnd);
+        if (Objects.equals(previousChunkEnd, chunkEnd)) {
+            // we don't allow equal chunk start and end,
+            // should query the next one larger than chunkEnd
+            chunkEnd = queryMin(jdbc, tableId, splitColumn, chunkEnd);
+        }
+        if (ObjectCompare(chunkEnd, max) >= 0) {
+            return null;
+        } else {
+            return chunkEnd;
+        }
+    }
+
+    protected List<ChunkRange> efficientShardingThroughSampling(
+            TableId tableId, Object[] sampleData, long approximateRowCnt, int shardCount) {
+        log.info(
+                "Use efficient sharding through sampling optimization for table {}, the approximate row count is {}, the shardCount is {}",
+                tableId,
+                approximateRowCnt,
+                shardCount);
+
+        final List<ChunkRange> splits = new ArrayList<>();
+
+        if (shardCount == 0) {
+            splits.add(ChunkRange.of(null, null));
+            return splits;
+        }
+
+        double approxSamplePerShard = (double) sampleData.length / shardCount;
+
+        Object lastEnd = null;
+        if (approxSamplePerShard <= 1) {
+            splits.add(ChunkRange.of(null, sampleData[0]));
+            lastEnd = sampleData[0];
+            for (int i = 1; i < sampleData.length; i++) {
+                // avoid split duplicate data
+                if (!sampleData[i].equals(lastEnd)) {
+                    splits.add(ChunkRange.of(lastEnd, sampleData[i]));
+                    lastEnd = sampleData[i];
+                }
+            }
+
+            splits.add(ChunkRange.of(lastEnd, null));
+
+        } else {
+            for (int i = 0; i < shardCount; i++) {
+                Object chunkStart = lastEnd;
+                Object chunkEnd =
+                        (i < shardCount - 1)
+                                ? sampleData[(int) ((i + 1) * approxSamplePerShard)]
+                                : null;
+                // avoid split duplicate data
+                if (i == 0 || i == shardCount - 1 || !Objects.equals(chunkEnd, chunkStart)) {
+                    splits.add(ChunkRange.of(chunkStart, chunkEnd));
+                    lastEnd = chunkEnd;
+                }
+            }
+        }
+        return splits;
+    }
+
+    /**
+     * Split table into evenly sized chunks based on the numeric min and max value of split column,
+     * and tumble chunks in step size.
+     */
+    protected List<ChunkRange> splitEvenlySizedChunks(
+            TableId tableId,
+            Object min,
+            Object max,
+            long approximateRowCnt,
+            int chunkSize,
+            int dynamicChunkSize) {
+        log.info(
+                "Use evenly-sized chunk optimization for table {}, the approximate row count is {}, the chunk size is {}, the dynamic chunk size is {}",
+                tableId,
+                approximateRowCnt,
+                chunkSize,
+                dynamicChunkSize);
+        if (approximateRowCnt <= chunkSize) {
+            // there is no more than one chunk, return full table as a chunk
+            return Collections.singletonList(ChunkRange.all());
+        }
+
+        final List<ChunkRange> splits = new ArrayList<>();
+        Object chunkStart = null;
+        Object chunkEnd = ObjectUtils.plus(min, dynamicChunkSize);
+        while (ObjectCompare(chunkEnd, max) <= 0) {
+            splits.add(ChunkRange.of(chunkStart, chunkEnd));
+            chunkStart = chunkEnd;
+            try {
+                chunkEnd = ObjectUtils.plus(chunkEnd, dynamicChunkSize);
+            } catch (ArithmeticException e) {
+                // Stop chunk split to avoid dead loop when number overflows.
+                break;
+            }
+        }
+        // add the ending split
+        splits.add(ChunkRange.of(chunkStart, null));
+        return splits;
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    /** Returns the distribution factor of the given table. */
+    @SuppressWarnings("MagicNumber")
+    protected double calculateDistributionFactor(
+            TableId tableId, Object min, Object max, long approximateRowCnt) {
+
+        if (!min.getClass().equals(max.getClass())) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unsupported operation type, the MIN value type %s is different with MAX value type %s.",
+                            min.getClass().getSimpleName(), max.getClass().getSimpleName()));
+        }
+        if (approximateRowCnt == 0) {
+            return Double.MAX_VALUE;
+        }
+        BigDecimal difference = ObjectUtils.minus(max, min);
+        // factor = (max - min + 1) / rowCount
+        final BigDecimal subRowCnt = difference.add(BigDecimal.valueOf(1));
+        double distributionFactor =
+                subRowCnt.divide(new BigDecimal(approximateRowCnt), 4, ROUND_CEILING).doubleValue();
+        log.info(
+                "The distribution factor of table {} is {} according to the min split key {}, max split key {} and approximate row count {}",
+                tableId,
+                distributionFactor,
+                min,
+                max,
+                approximateRowCnt);
+        return distributionFactor;
+    }
+
+    protected SnapshotSplit createSnapshotSplit(
+            JdbcConnection jdbc,
+            TableId tableId,
+            int chunkId,
+            SeaTunnelRowType splitKeyType,
+            Object chunkStart,
+            Object chunkEnd) {
+        // currently, we only support single split column
+        Object[] splitStart = chunkStart == null ? null : new Object[] {chunkStart};
+        Object[] splitEnd = chunkEnd == null ? null : new Object[] {chunkEnd};
+        return new SnapshotSplit(
+                splitId(tableId, chunkId), tableId, splitKeyType, splitStart, splitEnd);
+    }
+
+    protected Column getSplitColumn(
+            JdbcConnection jdbc, JdbcDataSourceDialect dialect, TableId tableId)
+            throws SQLException {
+        Column splitColumn = null;
+        Table table = dialect.queryTableSchema(jdbc, tableId).getTable();
+
+        // first , compare user defined split column is in the primary key or unique key
+        Map<String, String> splitColumnsConfig = new HashMap<>();
+        try {
+            splitColumnsConfig = sourceConfig.getSplitColumn();
+        } catch (Exception e) {
+            log.error("Config snapshotSplitColumn get exception in {}:{}", tableId, e);
+        }
+        String tableSc =
+                splitColumnsConfig.getOrDefault(tableId.catalog() + "." + tableId.table(), null);
+
+        if (StringUtils.isNotEmpty(tableSc)) {
+            // Is tableSc（table split column） the unique key
+            AtomicBoolean isUniqueKey = new AtomicBoolean(false);
+            dialect.getUniqueKeys(jdbc, tableId)
+                    .forEach(
+                            ck ->
+                                    ck.getColumnNames()
+                                            .forEach(
+                                                    ckc -> {
+                                                        if (tableSc.equals(ckc.getColumnName())) {
+                                                            isUniqueKey.set(true);
+                                                        }
+                                                    }));
+
+            if (isUniqueKey.get()) {
+                Column column = table.columnWithName(tableSc);
+                if (isEvenlySplitColumn(column)) {
+                    return column;
+                } else {
+                    log.warn(
+                            "Config snapshotSplitColumn type in {} is not TINYINT、SMALLINT、INT、BIGINT、DECIMAL、STRING",
+                            tableId);
+                }
+            } else {
+                log.warn("Config snapshotSplitColumn not unique key for table {}", tableId);
+            }
+        } else {
+            log.info("Config snapshotSplitColumn not exists for table {}", tableId);
+        }
+
+        Optional<PrimaryKey> primaryKey = dialect.getPrimaryKey(jdbc, tableId);
+        if (primaryKey.isPresent()) {
+            List<String> pkColumns = primaryKey.get().getColumnNames();
+
+            for (String pkColumn : pkColumns) {
+                Column column = table.columnWithName(pkColumn);
+                if (isEvenlySplitColumn(column)) {
+                    splitColumn = columnComparable(splitColumn, column);
+                    if (sqlTypePriority(splitColumn) == 1) {
+                        return splitColumn;
+                    }
+                }
+            }
+        } else {
+            log.warn("No primary key found for table {}", tableId);
+        }
+
+        List<ConstraintKey> uniqueKeys = dialect.getUniqueKeys(jdbc, tableId);
+        if (!uniqueKeys.isEmpty()) {
+            for (ConstraintKey uniqueKey : uniqueKeys) {
+                List<ConstraintKey.ConstraintKeyColumn> uniqueKeyColumns =
+                        uniqueKey.getColumnNames();
+                for (ConstraintKey.ConstraintKeyColumn uniqueKeyColumn : uniqueKeyColumns) {
+                    Column column = table.columnWithName(uniqueKeyColumn.getColumnName());
+                    if (isEvenlySplitColumn(column)) {
+                        splitColumn = columnComparable(splitColumn, column);
+                        if (sqlTypePriority(splitColumn) == 1) {
+                            return splitColumn;
+                        }
+                    }
+                }
+            }
+        } else {
+            log.warn("No unique key found for table {}", tableId);
+        }
+        if (splitColumn != null) {
+            return splitColumn;
+        }
+
+        log.warn("No evenly split column found for table {}", tableId);
+        return null;
+    }
+
+    protected String splitId(TableId tableId, int chunkId) {
+        return tableId.toString() + ":" + chunkId;
+    }
+
+    protected int ObjectCompare(Object obj1, Object obj2) {
+        return ObjectUtils.compare(obj1, obj2);
+    }
+
+    @SuppressWarnings("MagicNumber")
+    private static void maySleep(int count, TableId tableId) {
+        // every 100 queries to sleep 1s
+        if (count % 10 == 0) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // nothing to do
+            }
+            log.info("JdbcSourceChunkSplitter has split {} chunks for table {}", count, tableId);
+        }
+    }
+
+    private int sqlTypePriority(Column splitColumn) {
+        switch (fromDbzColumn(splitColumn).getSqlType()) {
+            case TINYINT:
+                return 1;
+            case SMALLINT:
+                return 2;
+            case INT:
+                return 3;
+            case BIGINT:
+                return 4;
+            case DECIMAL:
+                return 5;
+            case STRING:
+                return 6;
+            default:
+                return Integer.MAX_VALUE;
+        }
+    }
+
+    private Column columnComparable(Column then, Column other) {
+        if (then == null) {
+            return other;
+        }
+        if (sqlTypePriority(then) > sqlTypePriority(other)) {
+            return other;
+        }
+        return then;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/ChunkRange.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/ChunkRange.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Objects;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * An internal structure describes a chunk range with a chunk start (inclusive) and chunk end
+ * (exclusive). Note that {@code null} represents unbounded chunk start/end.
+ */
+@Getter
+@EqualsAndHashCode
+public class ChunkRange {
+    private final Object chunkStart;
+    private final Object chunkEnd;
+
+    /**
+     * Returns a {@link ChunkRange} which represents a full table scan with unbounded chunk start
+     * and chunk end.
+     */
+    public static ChunkRange all() {
+        return new ChunkRange(null, null);
+    }
+
+    /** Returns a {@link ChunkRange} with the given chunk start and chunk end. */
+    public static ChunkRange of(Object chunkStart, Object chunkEnd) {
+        return new ChunkRange(chunkStart, chunkEnd);
+    }
+
+    private ChunkRange(Object chunkStart, Object chunkEnd) {
+        if (chunkStart != null || chunkEnd != null) {
+            checkArgument(
+                    !Objects.equals(chunkStart, chunkEnd),
+                    "Chunk start %s shouldn't be equal to chunk end %s",
+                    chunkStart,
+                    chunkEnd);
+        }
+        this.chunkStart = chunkStart;
+        this.chunkEnd = chunkEnd;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/ChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/ChunkSplitter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter;
+
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import io.debezium.relational.TableId;
+
+import java.util.Collection;
+
+/** The splitter used to split collection into a set of chunks. */
+public interface ChunkSplitter {
+
+    /** Generates all snapshot splits (chunks) for the give data collection. */
+    Collection<SnapshotSplit> generateSplits(TableId tableId);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/JdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/JdbcSourceChunkSplitter.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+import java.sql.SQLException;
+import java.util.Collection;
+
+/** The {@code ChunkSplitter} used to split table into a set of chunks for JDBC data source. */
+public interface JdbcSourceChunkSplitter extends ChunkSplitter {
+
+    /** Generates all snapshot splits (chunks) for the give table path. */
+    @Override
+    Collection<SnapshotSplit> generateSplits(TableId tableId);
+
+    /** @deprecated instead by {@link this#queryMinMax(JdbcConnection, TableId, Column)} */
+    @Deprecated
+    Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+            throws SQLException;
+
+    /**
+     * Query the maximum and minimum value of the column in the table. e.g. query string <code>
+     * SELECT MIN(%s) FROM %s WHERE %s > ?</code>
+     *
+     * @param jdbc JDBC connection.
+     * @param tableId table identity.
+     * @param column column.
+     * @return maximum and minimum value.
+     */
+    default Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, Column column)
+            throws SQLException {
+        return queryMinMax(jdbc, tableId, column.name());
+    }
+
+    /** @deprecated instead by {@link this#queryMin(JdbcConnection, TableId, Column, Object)} */
+    @Deprecated
+    Object queryMin(
+            JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+            throws SQLException;
+
+    /**
+     * Query the minimum value of the column in the table, and the minimum value must greater than
+     * the excludedLowerBound value. e.g. prepare query string <code>
+     * SELECT MIN(%s) FROM %s WHERE %s > ?</code>
+     *
+     * @param jdbc JDBC connection.
+     * @param tableId table identity.
+     * @param column column.
+     * @param excludedLowerBound the minimum value should be greater than this value.
+     * @return minimum value.
+     */
+    default Object queryMin(
+            JdbcConnection jdbc, TableId tableId, Column column, Object excludedLowerBound)
+            throws SQLException {
+        return queryMin(jdbc, tableId, column.name(), excludedLowerBound);
+    }
+
+    @Deprecated
+    Object[] sampleDataFromColumn(
+            JdbcConnection jdbc, TableId tableId, String columnName, int samplingRate)
+            throws Exception;
+
+    /**
+     * Performs a sampling operation on the specified column of a table in a JDBC-connected
+     * database.
+     *
+     * @param jdbc The JDBC connection object used to connect to the database.
+     * @param tableId The ID of the table in which the column resides.
+     * @param column The column to be sampled.
+     * @param samplingRate samplingRate The inverse of the fraction of the data to be sampled from
+     *     the column. For example, a value of 1000 would mean 1/1000 of the data will be sampled.
+     * @return Returns a List of sampled data from the specified column.
+     * @throws SQLException If an SQL error occurs during the sampling operation.
+     */
+    default Object[] sampleDataFromColumn(
+            JdbcConnection jdbc, TableId tableId, Column column, int samplingRate)
+            throws Exception {
+        return sampleDataFromColumn(jdbc, tableId, column.name(), samplingRate);
+    }
+
+    /**
+     * @deprecated instead by {@link this#queryNextChunkMax(JdbcConnection, TableId, Column, int,
+     *     Object)}
+     */
+    @Deprecated
+    Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String columnName,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException;
+
+    /**
+     * Query the maximum value of the next chunk, and the next chunk must be greater than or equal
+     * to <code>includedLowerBound</code> value [min_1, max_1), [min_2, max_2),... [min_n, null).
+     * Each time this method is called it will return max1, max2...
+     *
+     * @param jdbc JDBC connection.
+     * @param tableId table identity.
+     * @param column column.
+     * @param chunkSize chunk size.
+     * @param includedLowerBound the previous chunk end value.
+     * @return next chunk end value.
+     */
+    default Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            Column column,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        return queryNextChunkMax(jdbc, tableId, column.name(), chunkSize, includedLowerBound);
+    }
+
+    /**
+     * Approximate total number of entries in the lookup table.
+     *
+     * @param jdbc JDBC connection.
+     * @param tableId table identity.
+     * @return approximate row count.
+     */
+    Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId) throws SQLException;
+
+    /**
+     * Build the scan query sql of the {@link SnapshotSplit}.
+     *
+     * @param table table.
+     * @param splitKeyType primary key type.
+     * @param isFirstSplit whether the first split.
+     * @param isLastSplit whether the last split.
+     * @return query sql.
+     */
+    String buildSplitScanQuery(
+            Table table, SeaTunnelRowType splitKeyType, boolean isFirstSplit, boolean isLastSplit);
+
+    /**
+     * Checks whether split column is evenly distributed across its range.
+     *
+     * @param splitColumn split column.
+     * @return true that means split column with type BIGINT, INT, DECIMAL.
+     */
+    default boolean isEvenlySplitColumn(Column splitColumn) {
+        // currently, we only support these types.
+        switch (fromDbzColumn(splitColumn).getSqlType()) {
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+            case DECIMAL:
+            case STRING:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Get a corresponding SeaTunnel data type from a debezium {@link Column}.
+     *
+     * @param splitColumn dbz split column.
+     * @return SeaTunnel data type
+     */
+    SeaTunnelDataType<?> fromDbzColumn(Column splitColumn);
+
+    /**
+     * convert dbz column to SeaTunnel row type.
+     *
+     * @param splitColumn split column.
+     * @return SeaTunnel row type.
+     */
+    default SeaTunnelRowType getSplitType(Column splitColumn) {
+        return new SeaTunnelRowType(
+                new String[] {splitColumn.name()},
+                new SeaTunnelDataType[] {fromDbzColumn(splitColumn)});
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/HybridPendingSplitsState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/HybridPendingSplitsState.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.state;
+
+import lombok.Data;
+
+/** A {@link PendingSplitsState} for pending hybrid (snapshot & incremental) splits. */
+@Data
+public class HybridPendingSplitsState implements PendingSplitsState {
+    private final SnapshotPhaseState snapshotPhaseState;
+    private final IncrementalPhaseState incrementalPhaseState;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/IncrementalPhaseState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/IncrementalPhaseState.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.state;
+
+import lombok.Data;
+
+/** A {@link PendingSplitsState} for pending incremental splits. */
+@Data
+public class IncrementalPhaseState implements PendingSplitsState {}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/PendingSplitsState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/PendingSplitsState.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.state;
+
+import java.io.Serializable;
+
+/**
+ * A checkpoint of the current state of the containing the currently pending splits that are not yet
+ * assigned.
+ */
+public interface PendingSplitsState extends Serializable {}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/SnapshotPhaseState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/state/SnapshotPhaseState.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.state;
+
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.IncrementalSourceSplitReader;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import io.debezium.relational.TableId;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Map;
+
+/** A {@link PendingSplitsState} for pending snapshot splits. */
+@Getter
+@ToString
+@EqualsAndHashCode
+public class SnapshotPhaseState implements PendingSplitsState {
+
+    /** The tables in the checkpoint. */
+    private final List<TableId> remainingTables;
+
+    /**
+     * The paths that are no longer in the enumerator checkpoint, but have been processed before and
+     * should this be ignored. Relevant only for sources in continuous monitoring mode.
+     */
+    private final List<TableId> alreadyProcessedTables;
+
+    /** The splits in the checkpoint. */
+    private final List<SnapshotSplit> remainingSplits;
+
+    /**
+     * The snapshot splits that the {@link IncrementalSourceEnumerator} has assigned to {@link
+     * IncrementalSourceSplitReader}s.
+     */
+    private final Map<String, SnapshotSplit> assignedSplits;
+
+    /**
+     * The offsets of completed (snapshot) splits that the {@link IncrementalSourceEnumerator} has
+     * received from {@link IncrementalSourceSplitReader}s.
+     */
+    private final Map<String, SnapshotSplitWatermark> splitCompletedOffsets;
+
+    /**
+     * Whether the snapshot split assigner is completed, which indicates there is no more splits and
+     * all records of splits have been completely processed in the pipeline.
+     */
+    private final boolean isAssignerCompleted;
+
+    /** Whether the table identifier is case sensitive. */
+    private final boolean isTableIdCaseSensitive;
+
+    /** Whether the remaining tables are keep when snapshot state. */
+    private final boolean isRemainingTablesCheckpointed;
+
+    public SnapshotPhaseState(
+            List<TableId> alreadyProcessedTables,
+            List<SnapshotSplit> remainingSplits,
+            Map<String, SnapshotSplit> assignedSplits,
+            Map<String, SnapshotSplitWatermark> splitCompletedOffsets,
+            boolean isAssignerCompleted,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            boolean isRemainingTablesCheckpointed) {
+        this.alreadyProcessedTables = alreadyProcessedTables;
+        this.remainingSplits = remainingSplits;
+        this.assignedSplits = assignedSplits;
+        this.splitCompletedOffsets = splitCompletedOffsets;
+        this.isAssignerCompleted = isAssignerCompleted;
+        this.remainingTables = remainingTables;
+        this.isTableIdCaseSensitive = isTableIdCaseSensitive;
+        this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotPhaseEvent.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotPhaseEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.event;
+
+import org.apache.seatunnel.api.source.SourceEvent;
+
+import io.debezium.relational.TableId;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class CompletedSnapshotPhaseEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
+
+    private List<TableId> tableIds;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotSplitsAckEvent.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotSplitsAckEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.event;
+
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.IncrementalSourceReader;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceEnumerator} sends to {@link
+ * IncrementalSourceReader} to notify the completed snapshot splits has been received, i.e.
+ * acknowledge for {@link CompletedSnapshotSplitsReportEvent}.
+ */
+@Data
+public class CompletedSnapshotSplitsAckEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> completedSplits;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotSplitsReportEvent.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/CompletedSnapshotSplitsReportEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.event;
+
+import org.apache.seatunnel.api.source.SourceEvent;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CompletedSnapshotSplitsReportEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
+    List<SnapshotSplitWatermark> completedSnapshotSplitWatermarks;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/SnapshotSplitWatermark.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/event/SnapshotSplitWatermark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.event;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class SnapshotSplitWatermark implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String splitId;
+    private final Offset lowWatermark;
+    private final Offset highWatermark;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/offset/Offset.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/offset/Offset.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.offset;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A structure describes a fine-grained offset in a change event including change log position.
+ *
+ * <p>This structure can also be used to deal the change event in transaction, a transaction may
+ * contain multiple change events, and each change event may contain multiple rows. When restart
+ * from a specific {@link Offset}, we need to skip the processed change events and the processed
+ * rows.
+ */
+public abstract class Offset implements Comparable<Offset>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Getter protected Map<String, String> offset;
+
+    protected long longOffsetValue(Map<String, ?> values, String key) {
+        Object obj = values.get(key);
+        if (obj == null) {
+            return 0L;
+        }
+        if (obj instanceof Number) {
+            return ((Number) obj).longValue();
+        }
+        try {
+            return Long.parseLong(obj.toString());
+        } catch (NumberFormatException e) {
+            throw new ConnectException(
+                    "Source offset '"
+                            + key
+                            + "' parameter value "
+                            + obj
+                            + " could not be converted to a long");
+        }
+    }
+
+    public boolean isAtOrBefore(Offset that) {
+        return this.compareTo(that) <= 0;
+    }
+
+    public boolean isBefore(Offset that) {
+        return this.compareTo(that) < 0;
+    }
+
+    public boolean isAtOrAfter(Offset that) {
+        return this.compareTo(that) >= 0;
+    }
+
+    public boolean isAfter(Offset that) {
+        return this.compareTo(that) > 0;
+    }
+
+    @Override
+    public String toString() {
+        return offset.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Offset)) {
+            return false;
+        }
+        Offset that = (Offset) o;
+        return offset.equals(that.offset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(offset);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/offset/OffsetFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/offset/OffsetFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.offset;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public abstract class OffsetFactory implements Serializable {
+    public OffsetFactory() {}
+
+    public abstract Offset earliest();
+
+    public abstract Offset neverStop();
+
+    public abstract Offset latest();
+
+    public abstract Offset specific(Map<String, String> offset);
+
+    public abstract Offset specific(String filename, Long position);
+
+    public abstract Offset timestamp(long timestamp);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/parser/SeatunnelDDLParser.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/parser/SeatunnelDDLParser.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.parser;
+
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.TableId;
+
+public interface SeatunnelDDLParser {
+
+    /**
+     * @param column The column to convert
+     * @return The converted column in SeaTunnel format which has full type information
+     */
+    default org.apache.seatunnel.api.table.catalog.Column toSeatunnelColumnWithFullTypeInfo(
+            Column column) {
+        org.apache.seatunnel.api.table.catalog.Column seatunnelColumn = toSeatunnelColumn(column);
+        String sourceColumnType = getSourceColumnTypeWithLengthScale(column);
+        return seatunnelColumn.reSourceType(sourceColumnType);
+    }
+
+    /**
+     * @param column The column to convert
+     * @return The converted column in SeaTunnel format
+     */
+    org.apache.seatunnel.api.table.catalog.Column toSeatunnelColumn(Column column);
+
+    /**
+     * @param column The column to convert
+     * @return The type with length and scale
+     */
+    default String getSourceColumnTypeWithLengthScale(Column column) {
+        StringBuilder sb = new StringBuilder(column.typeName());
+        if (column.length() >= 0) {
+            sb.append('(').append(column.length());
+            if (column.scale().isPresent()) {
+                sb.append(", ").append(column.scale().get());
+            }
+
+            sb.append(')');
+        }
+        return sb.toString();
+    }
+
+    default TableIdentifier toTableIdentifier(TableId tableId) {
+        return new TableIdentifier(
+                StringUtils.EMPTY, tableId.catalog(), tableId.schema(), tableId.table());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceReader.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceReader.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotPhaseEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotSplitsReportEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.IncrementalSplitState;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.SnapshotSplitState;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.SourceSplitStateBase;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordEmitter;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SourceReaderOptions;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.fetcher.SingleThreadFetcherManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkState;
+
+/**
+ * The multi-parallel source reader for table snapshot phase from {@link SnapshotSplit} and then
+ * single-parallel source reader for table stream phase from {@link IncrementalSplit}.
+ */
+@Slf4j
+public class IncrementalSourceReader<T, C extends SourceConfig>
+        extends SingleThreadMultiplexSourceReaderBase<
+                SourceRecords, T, SourceSplitBase, SourceSplitStateBase> {
+
+    private final Map<String, SnapshotSplit> finishedUnackedSplits;
+
+    private volatile boolean running = false;
+    private final int subtaskId;
+
+    private final C sourceConfig;
+    private final DebeziumDeserializationSchema<T> debeziumDeserializationSchema;
+
+    private final DataSourceDialect<C> dataSourceDialect;
+
+    private transient volatile Offset snapshotChangeLogOffset;
+
+    private final AtomicBoolean needSendSplitRequest = new AtomicBoolean(false);
+
+    public IncrementalSourceReader(
+            DataSourceDialect<C> dataSourceDialect,
+            BlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue,
+            Supplier<IncrementalSourceSplitReader<C>> splitReaderSupplier,
+            RecordEmitter<SourceRecords, T, SourceSplitStateBase> recordEmitter,
+            SourceReaderOptions options,
+            SourceReader.Context context,
+            C sourceConfig,
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema) {
+        super(
+                elementsQueue,
+                new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                recordEmitter,
+                options,
+                context);
+        this.dataSourceDialect = dataSourceDialect;
+        this.sourceConfig = sourceConfig;
+        this.finishedUnackedSplits = new HashMap<>();
+        this.subtaskId = context.getIndexOfSubtask();
+        this.debeziumDeserializationSchema = debeziumDeserializationSchema;
+    }
+
+    @Override
+    public void pollNext(Collector<T> output) throws Exception {
+        if (!running) {
+            if (getNumberOfCurrentlyAssignedSplits() == 0) {
+                context.sendSplitRequest();
+            }
+            running = true;
+        }
+        if (needSendSplitRequest.get()) {
+            context.sendSplitRequest();
+            needSendSplitRequest.compareAndSet(true, false);
+        }
+
+        if (isNoMoreSplitsAssignment() && isNoMoreElement()) {
+            log.info("Reader {} send NoMoreElement event", context.getIndexOfSubtask());
+            context.signalNoMoreElement();
+        } else {
+            super.pollNext(output);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        dataSourceDialect.commitChangeLogOffset(snapshotChangeLogOffset);
+    }
+
+    @Override
+    public void addSplits(List<SourceSplitBase> splits) {
+        // restore for finishedUnackedSplits
+        List<SourceSplitBase> unfinishedSplits = new ArrayList<>();
+        log.info(
+                "subtask {} add splits: {}",
+                subtaskId,
+                splits.stream().map(SourceSplitBase::splitId).collect(Collectors.joining(",")));
+        for (SourceSplitBase split : splits) {
+            if (split.isSnapshotSplit()) {
+                SnapshotSplit snapshotSplit = split.asSnapshotSplit();
+                if (snapshotSplit.isSnapshotReadFinished()) {
+                    finishedUnackedSplits.put(snapshotSplit.splitId(), snapshotSplit);
+                    log.info(
+                            "subtask {} add finished split: {}",
+                            subtaskId,
+                            snapshotSplit.splitId());
+                } else {
+                    unfinishedSplits.add(split);
+                }
+            } else {
+                unfinishedSplits.add(split.asIncrementalSplit());
+            }
+        }
+        // notify split enumerator again about the finished unacked snapshot splits
+        reportFinishedSnapshotSplitsIfNeed();
+        // add all un-finished splits (including incremental split) to SourceReaderBase
+        if (!unfinishedSplits.isEmpty()) {
+            super.addSplits(unfinishedSplits);
+        } else {
+            // If the split received is 'isSnapshotReadFinished', we will not run this split, hence
+            // we need to send the split request.
+            // We cannot directly execute context.sendSplitRequest() here, as it is a synchronous
+            // call and can lead to a deadlock.
+            needSendSplitRequest.set(true);
+        }
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, SourceSplitStateBase> finishedSplitIds) {
+        for (SourceSplitStateBase splitState : finishedSplitIds.values()) {
+            SourceSplitBase sourceSplit = splitState.toSourceSplit();
+            checkState(
+                    sourceSplit.isSnapshotSplit()
+                            && sourceSplit.asSnapshotSplit().isSnapshotReadFinished(),
+                    String.format(
+                            "Only snapshot split could finish, but the actual split is incremental split %s",
+                            sourceSplit));
+            finishedUnackedSplits.put(sourceSplit.splitId(), sourceSplit.asSnapshotSplit());
+        }
+        reportFinishedSnapshotSplitsIfNeed();
+        context.sendSplitRequest();
+    }
+
+    private void reportFinishedSnapshotSplitsIfNeed() {
+        if (!finishedUnackedSplits.isEmpty()) {
+            List<SnapshotSplitWatermark> completedSnapshotSplitWatermarks = new ArrayList<>();
+
+            for (SnapshotSplit split : finishedUnackedSplits.values()) {
+                completedSnapshotSplitWatermarks.add(
+                        new SnapshotSplitWatermark(
+                                split.splitId(),
+                                split.getLowWatermark(),
+                                split.getHighWatermark()));
+            }
+            CompletedSnapshotSplitsReportEvent reportEvent =
+                    new CompletedSnapshotSplitsReportEvent();
+            reportEvent.setCompletedSnapshotSplitWatermarks(completedSnapshotSplitWatermarks);
+            context.sendSourceEventToEnumerator(reportEvent);
+            // TODO need enumerator return ack
+            finishedUnackedSplits.clear();
+            log.debug(
+                    "The subtask {} reports offsets of finished snapshot splits {}.",
+                    subtaskId,
+                    completedSnapshotSplitWatermarks);
+        }
+    }
+
+    @Override
+    protected SourceSplitStateBase initializedState(SourceSplitBase split) {
+        if (split.isSnapshotSplit()) {
+            return new SnapshotSplitState(split.asSnapshotSplit());
+        } else {
+            IncrementalSplit incrementalSplit = split.asIncrementalSplit();
+            if (incrementalSplit.getCheckpointDataType() != null) {
+                log.info(
+                        "The incremental split[{}] has checkpoint datatype {} for restore.",
+                        incrementalSplit.splitId(),
+                        incrementalSplit.getCheckpointDataType());
+                debeziumDeserializationSchema.restoreCheckpointProducedType(
+                        incrementalSplit.getCheckpointTables());
+            }
+            IncrementalSplitState splitState = new IncrementalSplitState(incrementalSplit);
+            if (splitState.autoEnterPureIncrementPhaseIfAllowed()) {
+                log.info(
+                        "The incremental split[{}] startup position {} is equal the maxSnapshotSplitsHighWatermark {}, auto enter pure increment phase.",
+                        incrementalSplit.splitId(),
+                        splitState.getStartupOffset(),
+                        splitState.getMaxSnapshotSplitsHighWatermark());
+                log.info("Clean the IncrementalSplit#completedSnapshotSplitInfos to empty.");
+                CompletedSnapshotPhaseEvent event =
+                        new CompletedSnapshotPhaseEvent(splitState.getTableIds());
+                context.sendSourceEventToEnumerator(event);
+            }
+            return splitState;
+        }
+    }
+
+    @Override
+    public List<SourceSplitBase> snapshotState(long checkpointId) {
+        List<SourceSplitBase> stateSplits = super.snapshotState(checkpointId);
+
+        // unfinished splits
+        List<SourceSplitBase> unfinishedSplits =
+                stateSplits.stream()
+                        .filter(split -> !finishedUnackedSplits.containsKey(split.splitId()))
+                        .collect(Collectors.toList());
+
+        // add finished snapshot splits that didn't receive ack yet
+        unfinishedSplits.addAll(finishedUnackedSplits.values());
+
+        if (isIncrementalSplitPhase(unfinishedSplits)) {
+            IncrementalSplit incrementalSplit = unfinishedSplits.get(0).asIncrementalSplit();
+            snapshotChangeLogOffset = incrementalSplit.getStartupOffset();
+            return snapshotCheckpointDataType(incrementalSplit);
+        }
+
+        return unfinishedSplits;
+    }
+
+    @Override
+    protected SourceSplitBase toSplitType(String splitId, SourceSplitStateBase splitState) {
+        return splitState.toSourceSplit();
+    }
+
+    private boolean isIncrementalSplitPhase(List<SourceSplitBase> stateSplits) {
+        return stateSplits.size() == 1 && stateSplits.get(0).isIncrementalSplit();
+    }
+
+    private List<SourceSplitBase> snapshotCheckpointDataType(IncrementalSplit incrementalSplit) {
+        // Snapshot current table struct to checkpoint
+        List<CatalogTable> checkpointTables = debeziumDeserializationSchema.getProducedType();
+
+        // Snapshot current history table changes to checkpoint for debezium
+        IncrementalSplit newIncrementalSplit =
+                new IncrementalSplit(
+                        incrementalSplit,
+                        checkpointTables,
+                        debeziumDeserializationSchema.getHistoryTableChanges());
+        log.debug(
+                "Snapshot checkpoint datatype {} into split[{}] state.",
+                checkpointTables,
+                incrementalSplit.splitId());
+        return Arrays.asList(newIncrementalSplit);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader;
+
+import org.apache.seatunnel.api.common.metrics.Counter;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.event.MessageDelayedEvent;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotPhaseEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.IncrementalSplitState;
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.SourceSplitStateBase;
+import org.apache.seatunnel.connectors.cdc.base.utils.MessageDelayedEventLimiter;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordEmitter;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isLowWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isSchemaChangeAfterWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isSchemaChangeBeforeWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.getFetchTimestamp;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.getMessageTimestamp;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isDataChangeRecord;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isHeartbeatRecord;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link IncrementalSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
+ * emit records rather than emit the records directly.
+ */
+@Slf4j
+public class IncrementalSourceRecordEmitter<T>
+        implements RecordEmitter<SourceRecords, T, SourceSplitStateBase> {
+
+    private static final String CDC_RECORD_FETCH_DELAY = "CDCRecordFetchDelay";
+    private static final String CDC_RECORD_EMIT_DELAY = "CDCRecordEmitDelay";
+
+    protected final DebeziumDeserializationSchema<T> debeziumDeserializationSchema;
+    protected final OutputCollector<T> outputCollector;
+
+    protected final OffsetFactory offsetFactory;
+
+    protected final SourceReader.Context context;
+    protected final Counter recordFetchDelay;
+    protected final Counter recordEmitDelay;
+    protected final EventListener eventListener;
+    protected final MessageDelayedEventLimiter delayedEventLimiter =
+            new MessageDelayedEventLimiter(Duration.ofSeconds(1), 0.5d);
+
+    public IncrementalSourceRecordEmitter(
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
+            OffsetFactory offsetFactory,
+            SourceReader.Context context) {
+        this.debeziumDeserializationSchema = debeziumDeserializationSchema;
+        this.outputCollector = new OutputCollector<>();
+        this.offsetFactory = offsetFactory;
+        this.context = context;
+        this.recordFetchDelay = context.getMetricsContext().counter(CDC_RECORD_FETCH_DELAY);
+        this.recordEmitDelay = context.getMetricsContext().counter(CDC_RECORD_EMIT_DELAY);
+        this.eventListener = context.getEventListener();
+    }
+
+    @Override
+    public void emitRecord(
+            SourceRecords sourceRecords, Collector<T> collector, SourceSplitStateBase splitState)
+            throws Exception {
+        final Iterator<SourceRecord> elementIterator = sourceRecords.iterator();
+        while (elementIterator.hasNext()) {
+            SourceRecord next = elementIterator.next();
+            reportMetrics(next);
+            processElement(next, collector, splitState);
+            markEnterPureIncrementPhase(next, splitState);
+        }
+    }
+
+    protected void reportMetrics(SourceRecord element) {
+        long now = System.currentTimeMillis();
+        // record the latest process time
+        Long messageTimestamp = getMessageTimestamp(element);
+
+        if (messageTimestamp != null && messageTimestamp > 0L) {
+            // report fetch delay
+            Long fetchTimestamp = getFetchTimestamp(element);
+            if (fetchTimestamp != null) {
+                long fetchDelay = fetchTimestamp - messageTimestamp;
+                recordFetchDelay.set(fetchDelay > 0 ? fetchDelay : 0);
+            }
+            // report emit delay
+            long emitDelay = now - messageTimestamp;
+            recordEmitDelay.set(emitDelay > 0 ? emitDelay : 0);
+
+            // limit the emit event frequency
+            if (delayedEventLimiter.acquire(messageTimestamp)) {
+                eventListener.onEvent(new MessageDelayedEvent(emitDelay, element.toString()));
+            }
+        }
+    }
+
+    protected void processElement(
+            SourceRecord element, Collector<T> output, SourceSplitStateBase splitState)
+            throws Exception {
+        if (isWatermarkEvent(element)) {
+            Offset watermark = getWatermark(element);
+            if (isLowWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                splitState.asSnapshotSplitState().setLowWatermark(watermark);
+            } else if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            } else if ((isSchemaChangeBeforeWatermarkEvent(element)
+                            || isSchemaChangeAfterWatermarkEvent(element))
+                    && splitState.isIncrementalSplitState()) {
+                emitElement(element, output);
+            }
+        } else if (isSchemaChangeEvent(element) && splitState.isIncrementalSplitState()) {
+            Offset position = getOffsetPosition(element);
+            splitState.asIncrementalSplitState().setStartupOffset(position);
+            emitElement(element, output);
+        } else if (isDataChangeRecord(element) || isHeartbeatRecord(element)) {
+            if (splitState.isIncrementalSplitState()) {
+                Offset position = getOffsetPosition(element);
+                splitState.asIncrementalSplitState().setStartupOffset(position);
+            }
+            emitElement(element, output);
+        } else {
+            emitElement(element, output);
+        }
+    }
+
+    private void markEnterPureIncrementPhase(
+            SourceRecord element, SourceSplitStateBase splitState) {
+        if (splitState.isIncrementalSplitState()) {
+            IncrementalSplitState incrementalSplitState = splitState.asIncrementalSplitState();
+            if (incrementalSplitState.isEnterPureIncrementPhase()) {
+                return;
+            }
+            Offset position = getOffsetPosition(element);
+            if (incrementalSplitState.markEnterPureIncrementPhaseIfNeed(position)) {
+                log.info(
+                        "The current record position {} is after the maxSnapshotSplitsHighWatermark {}, "
+                                + "mark enter pure increment phase.",
+                        position,
+                        incrementalSplitState.getMaxSnapshotSplitsHighWatermark());
+                log.info("Clean the IncrementalSplit#completedSnapshotSplitInfos to empty.");
+
+                CompletedSnapshotPhaseEvent completedSnapshotPhaseEvent =
+                        new CompletedSnapshotPhaseEvent(incrementalSplitState.getTableIds());
+                context.sendSourceEventToEnumerator(completedSnapshotPhaseEvent);
+            }
+        }
+    }
+
+    private Offset getWatermark(SourceRecord watermarkEvent) {
+        return getOffsetPosition(watermarkEvent.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(SourceRecord dataRecord) {
+        return getOffsetPosition(dataRecord.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(Map<String, ?> offset) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offset.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+        return offsetFactory.specific(offsetStrMap);
+    }
+
+    protected void emitElement(SourceRecord element, Collector<T> output) throws Exception {
+        outputCollector.output = output;
+        debeziumDeserializationSchema.deserialize(element, outputCollector);
+    }
+
+    private class OutputCollector<T> implements Collector<T> {
+        private Collector<T> output;
+
+        @Override
+        public void collect(T record) {
+            output.collect(record);
+        }
+
+        @Override
+        public void collect(SchemaChangeEvent event) {
+            eventListener.onEvent(event);
+            output.collect(event);
+        }
+
+        @Override
+        public void markSchemaChangeBeforeCheckpoint() {
+            output.markSchemaChangeBeforeCheckpoint();
+        }
+
+        @Override
+        public void markSchemaChangeAfterCheckpoint() {
+            output.markSchemaChangeAfterCheckpoint();
+        }
+
+        @Override
+        public Object getCheckpointLock() {
+            return output.getCheckpointLock();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader;
+
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.Fetcher;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.IncrementalSourceScanFetcher;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.IncrementalSourceStreamFetcher;
+import org.apache.seatunnel.connectors.cdc.base.source.split.ChangeEventRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsAddition;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsChange;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.Queue;
+
+@Slf4j
+public class IncrementalSourceSplitReader<C extends SourceConfig>
+        implements SplitReader<SourceRecords, SourceSplitBase> {
+    private final Queue<SourceSplitBase> splits;
+    private final int subtaskId;
+
+    private Fetcher<SourceRecords, SourceSplitBase> currentFetcher;
+
+    private String currentSplitId;
+    private final DataSourceDialect<C> dataSourceDialect;
+    private final C sourceConfig;
+    private final SchemaChangeResolver schemaChangeResolver;
+
+    public IncrementalSourceSplitReader(
+            int subtaskId,
+            DataSourceDialect<C> dataSourceDialect,
+            C sourceConfig,
+            SchemaChangeResolver schemaChangeResolver) {
+        this.subtaskId = subtaskId;
+        this.splits = new ArrayDeque<>();
+        this.dataSourceDialect = dataSourceDialect;
+        this.sourceConfig = sourceConfig;
+        this.schemaChangeResolver = schemaChangeResolver;
+    }
+
+    @Override
+    public RecordsWithSplitIds<SourceRecords> fetch() throws IOException {
+
+        checkSplitOrStartNext();
+        checkNeedStopBinlogReader();
+        Iterator<SourceRecords> dataIt = null;
+        try {
+            dataIt = currentFetcher.pollSplitRecords();
+        } catch (InterruptedException | SeaTunnelException e) {
+            log.warn("fetch data failed.", e);
+            throw new IOException(e);
+        }
+        return dataIt == null
+                ? finishedSnapshotSplit()
+                : ChangeEventRecords.forRecords(currentSplitId, dataIt);
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<SourceSplitBase> splitsChanges) {
+        if (!(splitsChanges instanceof SplitsAddition)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SplitChange type of %s is not supported.",
+                            splitsChanges.getClass()));
+        }
+
+        log.debug("Handling split change {}", splitsChanges);
+        splits.addAll(splitsChanges.splits());
+    }
+
+    @Override
+    public void wakeUp() {}
+
+    @Override
+    public void close() throws Exception {
+        if (currentFetcher != null) {
+            log.info("Close current fetcher {}", currentFetcher.getClass().getCanonicalName());
+            currentFetcher.close();
+            currentSplitId = null;
+        }
+    }
+
+    private void checkNeedStopBinlogReader() {
+        // TODO Currently not supported
+    }
+
+    protected void checkSplitOrStartNext() throws IOException {
+        // the stream fetcher should keep alive
+        if (currentFetcher instanceof IncrementalSourceStreamFetcher) {
+            return;
+        }
+
+        if (canAssignNextSplit()) {
+            final SourceSplitBase nextSplit = splits.poll();
+            if (nextSplit == null) {
+                throw new IOException("Cannot fetch from another split - no split remaining.");
+            }
+            currentSplitId = nextSplit.splitId();
+
+            if (nextSplit.isSnapshotSplit()) {
+                if (currentFetcher == null) {
+                    final FetchTask.Context taskContext =
+                            dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig);
+                    currentFetcher = new IncrementalSourceScanFetcher(taskContext, subtaskId);
+                }
+            } else {
+                // point from snapshot split to incremental split
+                if (currentFetcher != null) {
+                    log.info(
+                            "It's turn to read incremental split, close current snapshot fetcher.");
+                    currentFetcher.close();
+                }
+                final FetchTask.Context taskContext =
+                        dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig);
+                currentFetcher =
+                        new IncrementalSourceStreamFetcher(
+                                taskContext, subtaskId, schemaChangeResolver);
+                log.info("Stream fetcher is created.");
+            }
+            currentFetcher.submitTask(dataSourceDialect.createFetchTask(nextSplit));
+        }
+    }
+
+    public boolean canAssignNextSplit() {
+        return currentFetcher == null || currentFetcher.isFinished();
+    }
+
+    private ChangeEventRecords finishedSnapshotSplit() {
+        final ChangeEventRecords finishedRecords =
+                ChangeEventRecords.forFinishedSplit(currentSplitId);
+        currentSplitId = null;
+        return finishedRecords;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/FetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/FetchTask.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/** The task to fetching data of a Split. */
+public interface FetchTask<Split> {
+
+    /** Execute current task. */
+    void execute(Context context) throws Exception;
+
+    /** Returns current task is running or not. */
+    boolean isRunning();
+
+    /** Close this task */
+    void shutdown();
+
+    /** Returns the split that the task used. */
+    Split getSplit();
+
+    /** Base context used in the execution of fetch task. */
+    interface Context {
+        void configure(SourceSplitBase sourceSplitBase);
+
+        ChangeEventQueue<DataChangeEvent> getQueue();
+
+        TableId getTableId(SourceRecord record);
+
+        Tables.TableFilter getTableFilter();
+
+        boolean isExactlyOnce();
+
+        Offset getStreamOffset(SourceRecord record);
+
+        boolean isDataChangeRecord(SourceRecord record);
+
+        boolean isRecordBetween(SourceRecord record, Object[] splitStart, Object[] splitEnd);
+
+        void rewriteOutputBuffer(Map<Struct, SourceRecord> outputBuffer, SourceRecord changeRecord);
+
+        List<SourceRecord> formatMessageTimestamp(Collection<SourceRecord> snapshotRecords);
+
+        void close();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/Fetcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/Fetcher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import java.util.Iterator;
+
+/**
+ * Fetcher to fetch data of a table split, the split is either snapshot split {@link SnapshotSplit}
+ * or incremental split {@link IncrementalSplit}.
+ */
+public interface Fetcher<T, Split> {
+
+    /** Add to task to fetch, this should call only when the reader is idle. */
+    void submitTask(FetchTask<Split> fetchTask);
+
+    /**
+     * Fetched records from data source. The method should return null when reaching the end of the
+     * split, the empty {@link Iterator} will be returned if the data of split is on pulling.
+     */
+    Iterator<T> pollSplitRecords() throws InterruptedException, SeaTunnelException;
+
+    /** Return the current fetch task is finished or not. */
+    boolean isFinished();
+
+    /** Close the client and releases all resources. */
+    void close();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceScanFetcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceScanFetcher.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.shade.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isEndWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isLowWatermarkEvent;
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkState;
+
+/**
+ * Fetcher to fetch data from table split, the split is the snapshot split {@link SnapshotSplit}.
+ */
+@Slf4j
+public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, SourceSplitBase> {
+
+    public AtomicBoolean hasNextElement;
+    public AtomicBoolean reachEnd;
+
+    private final FetchTask.Context taskContext;
+    private final ExecutorService executorService;
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile Throwable readException;
+
+    // task to read snapshot for current split
+    private FetchTask<SourceSplitBase> snapshotSplitReadTask;
+    private SnapshotSplit currentSnapshotSplit;
+
+    private static final long READER_CLOSE_TIMEOUT_SECONDS = 30L;
+
+    public IncrementalSourceScanFetcher(FetchTask.Context taskContext, int subtaskId) {
+        this.taskContext = taskContext;
+        ThreadFactory threadFactory =
+                new ThreadFactoryBuilder()
+                        .setNameFormat("debezium-snapshot-reader-" + subtaskId)
+                        .build();
+        this.executorService = Executors.newSingleThreadExecutor(threadFactory);
+        this.hasNextElement = new AtomicBoolean(false);
+        this.reachEnd = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void submitTask(FetchTask<SourceSplitBase> fetchTask) {
+        this.snapshotSplitReadTask = fetchTask;
+        this.currentSnapshotSplit = fetchTask.getSplit().asSnapshotSplit();
+        taskContext.configure(currentSnapshotSplit);
+        this.queue = taskContext.getQueue();
+        this.hasNextElement.set(true);
+        this.reachEnd.set(false);
+        executorService.submit(
+                () -> {
+                    try {
+                        log.info(
+                                "Start snapshot read task for snapshot split: {} exactly-once: {}",
+                                currentSnapshotSplit,
+                                taskContext.isExactlyOnce());
+                        snapshotSplitReadTask.execute(taskContext);
+                    } catch (Throwable e) {
+                        log.error(
+                                String.format(
+                                        "Execute snapshot read task for snapshot split %s fail",
+                                        currentSnapshotSplit),
+                                e);
+                        readException = e;
+                    }
+                });
+    }
+
+    @Override
+    public boolean isFinished() {
+        return currentSnapshotSplit == null
+                || !snapshotSplitReadTask.isRunning() && !hasNextElement.get() && reachEnd.get();
+    }
+
+    @Override
+    public Iterator<SourceRecords> pollSplitRecords()
+            throws InterruptedException, SeaTunnelException {
+        checkReadException();
+
+        if (hasNextElement.get()) {
+            if (taskContext.isExactlyOnce()) {
+                return pollSplitRecordsIfExactlyOnce();
+            }
+            return pollSplitRecordsIfNotExactlyOnce();
+        }
+        // the data has been polled, no more data
+        reachEnd.compareAndSet(false, true);
+        return null;
+    }
+
+    public Iterator<SourceRecords> pollSplitRecordsIfNotExactlyOnce() throws InterruptedException {
+        // eg:
+        // data input: [low watermark event][snapshot events][high watermark event]
+        List<SourceRecord> sendRecords = new ArrayList<>();
+        List<DataChangeEvent> batch = queue.poll();
+        for (DataChangeEvent event : batch) {
+            SourceRecord record = event.getRecord();
+            sendRecords.add(record);
+            if (isHighWatermarkEvent(record)) {
+                hasNextElement.set(false);
+            }
+        }
+        // snapshot split return its data once
+        final List<SourceRecords> sourceRecordsSet = new ArrayList<>();
+        sourceRecordsSet.add(new SourceRecords(sendRecords));
+        return sourceRecordsSet.iterator();
+    }
+
+    public Iterator<SourceRecords> pollSplitRecordsIfExactlyOnce() throws InterruptedException {
+        // eg:
+        // data input: [low watermark event][snapshot events][high watermark event][change
+        // events][end watermark event]
+        // data output: [low watermark event][normalized events][high watermark event]
+        boolean reachChangeLogStart = false;
+        boolean reachChangeLogEnd = false;
+        SourceRecord lowWatermark = null;
+        SourceRecord highWatermark = null;
+        Map<Struct, SourceRecord> outputBuffer = new LinkedHashMap<>();
+        while (!reachChangeLogEnd) {
+            checkReadException();
+            List<DataChangeEvent> batch = queue.poll();
+            for (DataChangeEvent event : batch) {
+                SourceRecord record = event.getRecord();
+                if (lowWatermark == null) {
+                    lowWatermark = record;
+                    assertLowWatermark(lowWatermark);
+                    continue;
+                }
+
+                if (highWatermark == null && isHighWatermarkEvent(record)) {
+                    highWatermark = record;
+                    // begin to capture binlog events
+                    reachChangeLogStart = true;
+                    continue;
+                }
+
+                if (reachChangeLogStart && isEndWatermarkEvent(record)) {
+                    // capture to end watermark events, stop the loop
+                    reachChangeLogEnd = true;
+                    break;
+                }
+
+                if (!reachChangeLogStart) {
+                    outputBuffer.put((Struct) record.key(), record);
+                } else {
+                    if (isChangeRecordInChunkRange(record)) {
+                        // rewrite overlapping snapshot records through the record key
+                        taskContext.rewriteOutputBuffer(outputBuffer, record);
+                    }
+                }
+            }
+        }
+        // snapshot split return its data once
+        hasNextElement.set(false);
+
+        final List<SourceRecord> normalizedRecords = new ArrayList<>();
+        normalizedRecords.add(lowWatermark);
+        normalizedRecords.addAll(taskContext.formatMessageTimestamp(outputBuffer.values()));
+        normalizedRecords.add(highWatermark);
+
+        final List<SourceRecords> sourceRecordsSet = new ArrayList<>();
+        sourceRecordsSet.add(new SourceRecords(normalizedRecords));
+        return sourceRecordsSet.iterator();
+    }
+
+    private void assertLowWatermark(SourceRecord lowWatermark) {
+        checkState(
+                isLowWatermarkEvent(lowWatermark),
+                String.format(
+                        "The first record should be low watermark signal event, but actual is %s",
+                        lowWatermark));
+    }
+
+    private void checkReadException() {
+        if (readException != null) {
+            throw new SeaTunnelException(
+                    String.format(
+                            "Read split %s error due to %s.",
+                            currentSnapshotSplit, readException.getMessage()),
+                    readException);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            // 1. try close the split task
+            if (snapshotSplitReadTask != null) {
+                try {
+                    snapshotSplitReadTask.shutdown();
+                } catch (Exception e) {
+                    log.error("Close snapshot split read task error", e);
+                }
+            }
+            // 2. close the fetcher thread
+            if (executorService != null) {
+                executorService.shutdown();
+                if (!executorService.awaitTermination(
+                        READER_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    log.warn(
+                            "Failed to close the scan fetcher in {} seconds. Service will execute force close(ExecutorService.shutdownNow)",
+                            READER_CLOSE_TIMEOUT_SECONDS);
+                    executorService.shutdownNow();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Close scan fetcher error", e);
+        } finally {
+            // 3. close the task context
+            if (taskContext != null) {
+                taskContext.close();
+            }
+        }
+    }
+
+    private boolean isChangeRecordInChunkRange(SourceRecord record) {
+        if (taskContext.isDataChangeRecord(record)) {
+            // fix the between condition
+            return taskContext.isRecordBetween(
+                    record,
+                    currentSnapshotSplit.getSplitStart(),
+                    currentSnapshotSplit.getSplitEnd());
+        }
+        return false;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.shade.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.CompletedSnapshotSplitInfo;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.getTableId;
+
+/**
+ * Fetcher to fetch data from table split, the split is the incremental split {@link
+ * IncrementalSplit}.
+ */
+@Slf4j
+public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, SourceSplitBase> {
+    private final FetchTask.Context taskContext;
+    private final SchemaChangeResolver schemaChangeResolver;
+    private final ExecutorService executorService;
+    // has entered pure binlog mode
+    private final Set<TableId> pureBinlogPhaseTables;
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile Throwable readException;
+
+    private FetchTask<SourceSplitBase> streamFetchTask;
+
+    private IncrementalSplit currentIncrementalSplit;
+
+    private Offset splitStartWatermark;
+
+    // maximum watermark for each table
+    private Map<TableId, Offset> maxSplitHighWatermarkMap;
+    // finished spilt info
+    private Map<TableId, List<CompletedSnapshotSplitInfo>> finishedSplitsInfo;
+
+    private static final long READER_CLOSE_TIMEOUT_SECONDS = 30L;
+
+    public IncrementalSourceStreamFetcher(
+            FetchTask.Context taskContext,
+            int subTaskId,
+            SchemaChangeResolver schemaChangeResolver) {
+        this.taskContext = taskContext;
+        this.schemaChangeResolver = schemaChangeResolver;
+        ThreadFactory threadFactory =
+                new ThreadFactoryBuilder().setNameFormat("debezium-reader-" + subTaskId).build();
+        this.executorService = Executors.newSingleThreadExecutor(threadFactory);
+        this.pureBinlogPhaseTables = new HashSet<>();
+    }
+
+    @Override
+    public void submitTask(FetchTask<SourceSplitBase> fetchTask) {
+        this.streamFetchTask = fetchTask;
+        this.currentIncrementalSplit = fetchTask.getSplit().asIncrementalSplit();
+        configureFilter();
+        taskContext.configure(currentIncrementalSplit);
+        this.queue = taskContext.getQueue();
+        executorService.submit(
+                () -> {
+                    try {
+                        log.info(
+                                "Start incremental read task for incremental split: {} exactly-once: {}",
+                                currentIncrementalSplit,
+                                taskContext.isExactlyOnce());
+                        streamFetchTask.execute(taskContext);
+                    } catch (Throwable e) {
+                        log.error(
+                                String.format(
+                                        "Execute stream read task for incremental split %s fail",
+                                        currentIncrementalSplit),
+                                e);
+                        readException = e;
+                    }
+                });
+    }
+
+    @Override
+    public boolean isFinished() {
+        return currentIncrementalSplit == null || !streamFetchTask.isRunning();
+    }
+
+    @Override
+    public Iterator<SourceRecords> pollSplitRecords()
+            throws InterruptedException, SeaTunnelException {
+        checkReadException();
+
+        Iterator<SourceRecords> sourceRecordsIterator = Collections.emptyIterator();
+        if (streamFetchTask.isRunning()) {
+            List<DataChangeEvent> batch = queue.poll();
+            if (!batch.isEmpty()) {
+                if (schemaChangeResolver != null) {
+                    sourceRecordsIterator = splitSchemaChangeStream(batch);
+                } else {
+                    sourceRecordsIterator = splitNormalStream(batch);
+                }
+            }
+        }
+        return sourceRecordsIterator;
+    }
+
+    private Iterator<SourceRecords> splitNormalStream(List<DataChangeEvent> batchEvents) {
+        List<SourceRecord> sourceRecords = new ArrayList<>();
+        if (streamFetchTask.isRunning()) {
+            for (DataChangeEvent event : batchEvents) {
+                if (shouldEmit(event.getRecord())) {
+                    sourceRecords.add(event.getRecord());
+                }
+            }
+        }
+        List<SourceRecords> sourceRecordsSet = new ArrayList<>();
+        sourceRecordsSet.add(new SourceRecords(sourceRecords));
+        return sourceRecordsSet.iterator();
+    }
+
+    /**
+     * Split schema change stream.
+     *
+     * <p>For example 1:
+     *
+     * <p>Before event batch: [a, b, c, SchemaChangeEvent-1, SchemaChangeEvent-2, d, e]
+     *
+     * <p>After event batch: [a, b, c, checkpoint-before] [SchemaChangeEvent-1, SchemaChangeEvent-2,
+     * checkpoint-after] [d, e]
+     *
+     * <p>For example 2:
+     *
+     * <p>Before event batch: [SchemaChangeEvent-1, SchemaChangeEvent-2, a, b, c, d, e]
+     *
+     * <p>After event batch: [checkpoint-before] [SchemaChangeEvent-1, SchemaChangeEvent-2,
+     * checkpoint-after] [a, b, c, d, e]
+     */
+    Iterator<SourceRecords> splitSchemaChangeStream(List<DataChangeEvent> batchEvents) {
+        return new SchemaChangeStreamSplitter().split(batchEvents);
+    }
+
+    private void checkReadException() {
+        if (readException != null) {
+            throw new SeaTunnelException(
+                    String.format(
+                            "Read split %s error due to %s.",
+                            currentIncrementalSplit, readException.getMessage()),
+                    readException);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            // 1. try close the split task
+            if (streamFetchTask != null) {
+                try {
+                    streamFetchTask.shutdown();
+                } catch (Exception e) {
+                    log.error("Close stream split read task error", e);
+                }
+            }
+            // 2. close the fetcher thread
+            if (executorService != null) {
+                executorService.shutdown();
+                if (!executorService.awaitTermination(
+                        READER_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    log.warn(
+                            "Failed to close the stream fetcher in {} seconds. Service will execute force close(ExecutorService.shutdownNow)",
+                            READER_CLOSE_TIMEOUT_SECONDS);
+                    executorService.shutdownNow();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Close stream fetcher error", e);
+        } finally {
+            // 3. close the task context
+            if (taskContext != null) {
+                taskContext.close();
+            }
+        }
+    }
+
+    /** Returns the record should emit or not. */
+    boolean shouldEmit(SourceRecord sourceRecord) {
+        if (taskContext.isDataChangeRecord(sourceRecord)) {
+            Offset position = taskContext.getStreamOffset(sourceRecord);
+            TableId tableId = getTableId(sourceRecord);
+            if (!taskContext.isExactlyOnce()) {
+                log.trace(
+                        "The table {} is not support exactly-once, so ignore the watermark check",
+                        tableId);
+                return position.isAfter(splitStartWatermark);
+            }
+            // check whether the pure binlog mode has been entered
+            if (hasEnterPureBinlogPhase(tableId, position)) {
+                return true;
+            }
+            // not enter pure binlog mode and need to check whether the current record meets the
+            // emitting conditions.
+            if (finishedSplitsInfo.containsKey(tableId)) {
+                for (CompletedSnapshotSplitInfo splitInfo : finishedSplitsInfo.get(tableId)) {
+                    if (taskContext.isRecordBetween(
+                                    sourceRecord,
+                                    splitInfo.getSplitStart(),
+                                    splitInfo.getSplitEnd())
+                            && position.isAfter(splitInfo.getWatermark().getHighWatermark())) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasEnterPureBinlogPhase(TableId tableId, Offset position) {
+        // only the table who captured snapshot splits need to filter
+        if (pureBinlogPhaseTables.contains(tableId)) {
+            return true;
+        }
+        // the existed tables those have finished snapshot reading
+        if (maxSplitHighWatermarkMap.containsKey(tableId)
+                && position.isAtOrAfter(maxSplitHighWatermarkMap.get(tableId))) {
+            pureBinlogPhaseTables.add(tableId);
+            return true;
+        }
+        return false;
+    }
+
+    private void configureFilter() {
+        splitStartWatermark = currentIncrementalSplit.getStartupOffset();
+        Map<TableId, List<CompletedSnapshotSplitInfo>> splitsInfoMap = new HashMap<>();
+        Map<TableId, Offset> tableIdBinlogPositionMap = new HashMap<>();
+        List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos =
+                currentIncrementalSplit.getCompletedSnapshotSplitInfos();
+
+        // latest-offset mode
+        if (completedSnapshotSplitInfos.isEmpty()) {
+            for (TableId tableId : currentIncrementalSplit.getTableIds()) {
+                tableIdBinlogPositionMap.put(tableId, currentIncrementalSplit.getStartupOffset());
+            }
+        }
+
+        // calculate the max high watermark of every table
+        for (CompletedSnapshotSplitInfo finishedSplitInfo : completedSnapshotSplitInfos) {
+            TableId tableId = finishedSplitInfo.getTableId();
+            List<CompletedSnapshotSplitInfo> list =
+                    splitsInfoMap.getOrDefault(tableId, new ArrayList<>());
+            list.add(finishedSplitInfo);
+            splitsInfoMap.put(tableId, list);
+
+            Offset highWatermark = finishedSplitInfo.getWatermark().getHighWatermark();
+            Offset maxHighWatermark = tableIdBinlogPositionMap.get(tableId);
+            if (maxHighWatermark == null || highWatermark.isAfter(maxHighWatermark)) {
+                tableIdBinlogPositionMap.put(tableId, highWatermark);
+            }
+        }
+        this.finishedSplitsInfo = splitsInfoMap;
+        this.maxSplitHighWatermarkMap = tableIdBinlogPositionMap;
+        this.pureBinlogPhaseTables.clear();
+    }
+
+    class SchemaChangeStreamSplitter {
+        private List<SourceRecords> blockSet;
+        private List<SourceRecord> currentBlock;
+        private SourceRecord previousRecord;
+
+        public SchemaChangeStreamSplitter() {
+            blockSet = new ArrayList<>();
+            currentBlock = new ArrayList<>();
+            previousRecord = null;
+        }
+
+        public Iterator<SourceRecords> split(List<DataChangeEvent> batchEvents) {
+            for (int i = 0; i < batchEvents.size(); i++) {
+                DataChangeEvent event = batchEvents.get(i);
+                SourceRecord currentRecord = event.getRecord();
+                if (!shouldEmit(currentRecord)) {
+                    continue;
+                }
+
+                if (SourceRecordUtils.isSchemaChangeEvent(currentRecord)) {
+                    if (!schemaChangeResolver.support(currentRecord)) {
+                        continue;
+                    }
+
+                    if (previousRecord == null) {
+                        // add schema-change-before to first
+                        currentBlock.add(
+                                WatermarkEvent.createSchemaChangeBeforeWatermark(currentRecord));
+                        flipBlock();
+
+                        currentBlock.add(currentRecord);
+                    } else if (SourceRecordUtils.isSchemaChangeEvent(previousRecord)) {
+                        currentBlock.add(currentRecord);
+                    } else {
+                        currentBlock.add(
+                                WatermarkEvent.createSchemaChangeBeforeWatermark(currentRecord));
+                        flipBlock();
+
+                        currentBlock.add(currentRecord);
+                    }
+                } else if (SourceRecordUtils.isDataChangeRecord(currentRecord)
+                        || SourceRecordUtils.isHeartbeatRecord(currentRecord)) {
+                    if (previousRecord == null
+                            || SourceRecordUtils.isDataChangeRecord(previousRecord)
+                            || SourceRecordUtils.isHeartbeatRecord(previousRecord)) {
+                        currentBlock.add(currentRecord);
+                    } else {
+                        endBlock(previousRecord);
+                        flipBlock();
+
+                        currentBlock.add(currentRecord);
+                    }
+                }
+
+                previousRecord = currentRecord;
+                if (i == batchEvents.size() - 1) {
+                    endBlock(currentRecord);
+                    flipBlock();
+                }
+            }
+
+            endLastBlock(previousRecord);
+
+            if (blockSet.size() > 1) {
+                log.debug(
+                        "Split events stream into {} batches and mark schema change checkpoint",
+                        blockSet.size());
+            }
+
+            return blockSet.iterator();
+        }
+
+        void flipBlock() {
+            if (!currentBlock.isEmpty()) {
+                blockSet.add(new SourceRecords(currentBlock));
+                currentBlock = new ArrayList<>();
+            }
+        }
+
+        void endBlock(SourceRecord lastRecord) {
+            if (!currentBlock.isEmpty()) {
+                if (SourceRecordUtils.isSchemaChangeEvent(lastRecord)) {
+                    currentBlock.add(WatermarkEvent.createSchemaChangeAfterWatermark(lastRecord));
+                }
+            }
+        }
+
+        void endLastBlock(SourceRecord lastRecord) {
+            endBlock(lastRecord);
+            flipBlock();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/JdbcSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/JdbcSourceFetchTaskContext.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+import org.apache.seatunnel.connectors.cdc.debezium.ConnectTableChangeSerializer;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.data.Envelope;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.RelationalDatabaseSchema;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** The context for fetch task that fetching data of snapshot split from JDBC data source. */
+public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
+
+    protected final JdbcSourceConfig sourceConfig;
+    protected final JdbcDataSourceDialect dataSourceDialect;
+    protected final CommonConnectorConfig dbzConnectorConfig;
+    protected final SchemaNameAdjuster schemaNameAdjuster;
+    protected final ConnectTableChangeSerializer tableChangeSerializer =
+            new ConnectTableChangeSerializer();
+    protected final JsonConverter jsonConverter;
+
+    public JdbcSourceFetchTaskContext(
+            JdbcSourceConfig sourceConfig, JdbcDataSourceDialect dataSourceDialect) {
+        this.sourceConfig = sourceConfig;
+        this.dataSourceDialect = dataSourceDialect;
+        this.dbzConnectorConfig = sourceConfig.getDbzConnectorConfig();
+        this.schemaNameAdjuster = SchemaNameAdjuster.create();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", true), false);
+    }
+
+    @Override
+    public TableId getTableId(SourceRecord record) {
+        return SourceRecordUtils.getTableId(record);
+    }
+
+    @Override
+    public boolean isDataChangeRecord(SourceRecord record) {
+        return SourceRecordUtils.isDataChangeRecord(record);
+    }
+
+    @Override
+    public boolean isRecordBetween(SourceRecord record, Object[] splitStart, Object[] splitEnd) {
+        SeaTunnelRowType splitKeyType =
+                getSplitType(getDatabaseSchema().tableFor(getTableId(record)));
+        Object[] key = SourceRecordUtils.getSplitKey(splitKeyType, record, getSchemaNameAdjuster());
+        return SourceRecordUtils.splitKeyRangeContains(key, splitStart, splitEnd);
+    }
+
+    @Override
+    public void rewriteOutputBuffer(
+            Map<Struct, SourceRecord> outputBuffer, SourceRecord changeRecord) {
+        Struct key = (Struct) changeRecord.key();
+        Struct value = (Struct) changeRecord.value();
+        if (value != null) {
+            Envelope.Operation operation =
+                    Envelope.Operation.forCode(value.getString(Envelope.FieldName.OPERATION));
+            switch (operation) {
+                case CREATE:
+                case UPDATE:
+                    Envelope envelope = Envelope.fromSchema(changeRecord.valueSchema());
+                    Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                    Struct after = value.getStruct(Envelope.FieldName.AFTER);
+                    Instant fetchTs =
+                            Instant.ofEpochMilli((Long) source.get(Envelope.FieldName.TIMESTAMP));
+                    SourceRecord record =
+                            new SourceRecord(
+                                    changeRecord.sourcePartition(),
+                                    changeRecord.sourceOffset(),
+                                    changeRecord.topic(),
+                                    changeRecord.kafkaPartition(),
+                                    changeRecord.keySchema(),
+                                    changeRecord.key(),
+                                    changeRecord.valueSchema(),
+                                    envelope.read(after, source, fetchTs));
+                    outputBuffer.put(key, record);
+                    break;
+                case DELETE:
+                    outputBuffer.remove(key);
+                    break;
+                case READ:
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Data change record shouldn't use READ operation, the the record is %s.",
+                                    changeRecord));
+            }
+        }
+    }
+
+    @Override
+    public List<SourceRecord> formatMessageTimestamp(Collection<SourceRecord> snapshotRecords) {
+        return snapshotRecords.stream()
+                .map(
+                        record -> {
+                            Envelope envelope = Envelope.fromSchema(record.valueSchema());
+                            Struct value = (Struct) record.value();
+                            Struct updateAfter = value.getStruct(Envelope.FieldName.AFTER);
+                            // set message timestamp (source.ts_ms) to 0L
+                            Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                            source.put(Envelope.FieldName.TIMESTAMP, 0L);
+                            // extend the fetch timestamp(ts_ms)
+                            Instant fetchTs =
+                                    Instant.ofEpochMilli(
+                                            value.getInt64(Envelope.FieldName.TIMESTAMP));
+                            SourceRecord sourceRecord =
+                                    new SourceRecord(
+                                            record.sourcePartition(),
+                                            record.sourceOffset(),
+                                            record.topic(),
+                                            record.kafkaPartition(),
+                                            record.keySchema(),
+                                            record.key(),
+                                            record.valueSchema(),
+                                            envelope.read(updateAfter, source, fetchTs));
+                            return sourceRecord;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    protected void registerDatabaseHistory(
+            SourceSplitBase sourceSplitBase, JdbcConnection connection) {
+        List<TableChanges.TableChange> engineHistory = new ArrayList<>();
+        // TODO: support save table schema
+        if (sourceSplitBase instanceof SnapshotSplit) {
+            SnapshotSplit snapshotSplit = (SnapshotSplit) sourceSplitBase;
+            engineHistory.add(
+                    dataSourceDialect.queryTableSchema(connection, snapshotSplit.getTableId()));
+        } else {
+            IncrementalSplit incrementalSplit = (IncrementalSplit) sourceSplitBase;
+            Map<TableId, byte[]> historyTableChanges = incrementalSplit.getHistoryTableChanges();
+            for (TableId tableId : incrementalSplit.getTableIds()) {
+                if (historyTableChanges != null && historyTableChanges.containsKey(tableId)) {
+                    SchemaAndValue schemaAndValue =
+                            jsonConverter.toConnectData("topic", historyTableChanges.get(tableId));
+                    Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+                    TableChanges tableChanges =
+                            tableChangeSerializer.deserialize(
+                                    Collections.singletonList(deserializedStruct), false);
+
+                    Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+                    TableChanges.TableChange tableChange = null;
+                    while (iterator.hasNext()) {
+                        if (tableChange != null) {
+                            throw new IllegalStateException(
+                                    "The table changes should only have one element");
+                        }
+                        tableChange = iterator.next();
+                    }
+                    engineHistory.add(tableChange);
+                    continue;
+                }
+                engineHistory.add(dataSourceDialect.queryTableSchema(connection, tableId));
+            }
+        }
+
+        EmbeddedDatabaseHistory.registerHistory(
+                sourceConfig
+                        .getDbzConfiguration()
+                        .getString(EmbeddedDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME),
+                engineHistory);
+    }
+
+    public SourceConfig getSourceConfig() {
+        return sourceConfig;
+    }
+
+    @Override
+    public boolean isExactlyOnce() {
+        return sourceConfig.isExactlyOnce();
+    }
+
+    public JdbcDataSourceDialect getDataSourceDialect() {
+        return dataSourceDialect;
+    }
+
+    public CommonConnectorConfig getDbzConnectorConfig() {
+        return dbzConnectorConfig;
+    }
+
+    public SchemaNameAdjuster getSchemaNameAdjuster() {
+        return schemaNameAdjuster;
+    }
+
+    public abstract RelationalDatabaseSchema getDatabaseSchema();
+
+    public abstract SeaTunnelRowType getSplitType(Table table);
+
+    public abstract ErrorHandler getErrorHandler();
+
+    public abstract JdbcSourceEventDispatcher getDispatcher();
+
+    public abstract OffsetContext getOffsetContext();
+
+    public abstract Partition getPartition();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * An implementation of {@link RecordsWithSplitIds} which contains the records of one table split.
+ */
+public final class ChangeEventRecords implements RecordsWithSplitIds<SourceRecords> {
+    private String splitId;
+    private Iterator<SourceRecords> recordsForCurrentSplit;
+    private final Iterator<SourceRecords> recordsForSplit;
+    private final Set<String> finishedSnapshotSplits;
+
+    public ChangeEventRecords(
+            String splitId, Iterator recordsForSplit, Set<String> finishedSnapshotSplits) {
+        this.splitId = splitId;
+        this.recordsForSplit = recordsForSplit;
+        this.finishedSnapshotSplits = finishedSnapshotSplits;
+    }
+
+    @Override
+    public String nextSplit() {
+        // move the split one (from current value to null)
+        final String nextSplit = this.splitId;
+        this.splitId = null;
+
+        // move the iterator, from null to value (if first move) or to null (if second move)
+        this.recordsForCurrentSplit = nextSplit != null ? this.recordsForSplit : null;
+        return nextSplit;
+    }
+
+    @Override
+    public SourceRecords nextRecordFromSplit() {
+        final Iterator<SourceRecords> recordsForSplit = this.recordsForCurrentSplit;
+        if (recordsForSplit != null) {
+            if (recordsForSplit.hasNext()) {
+                return recordsForSplit.next();
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public Set<String> finishedSplits() {
+        return finishedSnapshotSplits;
+    }
+
+    public static ChangeEventRecords forRecords(
+            final String splitId, final Iterator<SourceRecords> recordsForSplit) {
+        return new ChangeEventRecords(splitId, recordsForSplit, Collections.emptySet());
+    }
+
+    public static ChangeEventRecords forFinishedSplit(final String splitId) {
+        return new ChangeEventRecords(null, null, Collections.singleton(splitId));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/CompletedSnapshotSplitInfo.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/CompletedSnapshotSplitInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+
+import io.debezium.relational.TableId;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class CompletedSnapshotSplitInfo implements Serializable {
+    private final String splitId;
+    private final TableId tableId;
+    private final SeaTunnelRowType splitKeyType;
+    private final Object[] splitStart;
+    private final Object[] splitEnd;
+    private final SnapshotSplitWatermark watermark;
+
+    public CompletedSnapshotSplitInfo(
+            String splitId,
+            TableId tableId,
+            SeaTunnelRowType splitKeyType,
+            Object[] splitStart,
+            Object[] splitEnd,
+            SnapshotSplitWatermark watermark) {
+        this.splitId = splitId;
+        this.tableId = tableId;
+        this.splitKeyType = splitKeyType;
+        this.splitStart = splitStart;
+        this.splitEnd = splitEnd;
+        this.watermark = watermark;
+    }
+
+    public SnapshotSplit asSnapshotSplit() {
+        return new SnapshotSplit(
+                splitId,
+                tableId,
+                splitKeyType,
+                splitStart,
+                splitEnd,
+                watermark.getLowWatermark(),
+                watermark.getHighWatermark());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/IncrementalSplit.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/IncrementalSplit.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+
+import io.debezium.relational.TableId;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ToString
+@Getter
+public class IncrementalSplit extends SourceSplitBase {
+    private static final long serialVersionUID = 1L;
+
+    /** All the tables that this incremental split needs to capture. */
+    private final List<TableId> tableIds;
+
+    /** Minimum watermark for SnapshotSplits for all tables in this IncrementalSplit */
+    private final Offset startupOffset;
+
+    /** Obtained by configuration, may not end */
+    private final Offset stopOffset;
+
+    /**
+     * SnapshotSplit information for all tables in this IncrementalSplit. <br>
+     * Used to support Exactly-Once.
+     */
+    private final List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos;
+
+    // Remove in the next version
+    @Deprecated private SeaTunnelDataType checkpointDataType;
+    private List<CatalogTable> checkpointTables;
+
+    // debezium history table changes
+    private final Map<TableId, byte[]> historyTableChanges;
+
+    public IncrementalSplit(
+            String splitId,
+            List<TableId> capturedTables,
+            Offset startupOffset,
+            Offset stopOffset,
+            List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos) {
+        this(
+                splitId,
+                capturedTables,
+                startupOffset,
+                stopOffset,
+                completedSnapshotSplitInfos,
+                new ArrayList<>(),
+                new HashMap<>());
+    }
+
+    @Deprecated
+    public IncrementalSplit(IncrementalSplit split, SeaTunnelDataType checkpointDataType) {
+        this(
+                split.splitId(),
+                split.getTableIds(),
+                split.getStartupOffset(),
+                split.getStopOffset(),
+                split.getCompletedSnapshotSplitInfos(),
+                checkpointDataType);
+    }
+
+    public IncrementalSplit(
+            IncrementalSplit split,
+            List<CatalogTable> tables,
+            Map<TableId, byte[]> historyTableChanges) {
+        this(
+                split.splitId(),
+                split.getTableIds(),
+                split.getStartupOffset(),
+                split.getStopOffset(),
+                split.getCompletedSnapshotSplitInfos(),
+                tables,
+                historyTableChanges);
+    }
+
+    @Deprecated
+    public IncrementalSplit(
+            String splitId,
+            List<TableId> capturedTables,
+            Offset startupOffset,
+            Offset stopOffset,
+            List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos,
+            SeaTunnelDataType checkpointDataType) {
+        super(splitId);
+        this.tableIds = capturedTables;
+        this.startupOffset = startupOffset;
+        this.stopOffset = stopOffset;
+        this.completedSnapshotSplitInfos = completedSnapshotSplitInfos;
+        this.checkpointDataType = checkpointDataType;
+        this.historyTableChanges = new HashMap<>();
+    }
+
+    public IncrementalSplit(
+            String splitId,
+            List<TableId> capturedTables,
+            Offset startupOffset,
+            Offset stopOffset,
+            List<CompletedSnapshotSplitInfo> completedSnapshotSplitInfos,
+            List<CatalogTable> checkpointTables,
+            Map<TableId, byte[]> historyTableChanges) {
+        super(splitId);
+        this.tableIds = capturedTables;
+        this.startupOffset = startupOffset;
+        this.stopOffset = stopOffset;
+        this.completedSnapshotSplitInfos = completedSnapshotSplitInfos;
+        this.checkpointTables = checkpointTables;
+        this.historyTableChanges = historyTableChanges;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SnapshotSplit.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SnapshotSplit.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+
+import io.debezium.relational.TableId;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class SnapshotSplit extends SourceSplitBase {
+    private static final long serialVersionUID = 1L;
+    private final TableId tableId;
+    private final SeaTunnelRowType splitKeyType;
+    private final Object[] splitStart;
+    private final Object[] splitEnd;
+
+    private final Offset lowWatermark;
+    private final Offset highWatermark;
+
+    public SnapshotSplit(
+            String splitId,
+            TableId tableId,
+            SeaTunnelRowType splitKeyType,
+            Object[] splitStart,
+            Object[] splitEnd) {
+        this(splitId, tableId, splitKeyType, splitStart, splitEnd, null, null);
+    }
+
+    public SnapshotSplit(
+            String splitId,
+            TableId tableId,
+            SeaTunnelRowType splitKeyType,
+            Object[] splitStart,
+            Object[] splitEnd,
+            Offset lowWatermark,
+            Offset highWatermark) {
+        super(splitId);
+        this.tableId = tableId;
+        this.splitKeyType = splitKeyType;
+        this.splitStart = splitStart;
+        this.splitEnd = splitEnd;
+        this.lowWatermark = lowWatermark;
+        this.highWatermark = highWatermark;
+    }
+
+    @Override
+    public String splitId() {
+        return this.splitId;
+    }
+
+    public boolean isSnapshotReadFinished() {
+        return lowWatermark != null && highWatermark != null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SourceRecords.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SourceRecords.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** Data structure to describe a set of {@link SourceRecord}. */
+public final class SourceRecords {
+
+    private final List<SourceRecord> sourceRecords;
+
+    public SourceRecords(List<SourceRecord> sourceRecords) {
+        this.sourceRecords = sourceRecords;
+    }
+
+    public List<SourceRecord> getSourceRecordList() {
+        return sourceRecords;
+    }
+
+    public Iterator<SourceRecord> iterator() {
+        return sourceRecords.iterator();
+    }
+
+    public static SourceRecords fromSingleRecord(SourceRecord record) {
+        final List<SourceRecord> records = new ArrayList<>();
+        records.add(record);
+        return new SourceRecords(records);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SourceSplitBase.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/SourceSplitBase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+
+import java.util.Objects;
+
+/** The split of table comes from a Table that splits by primary key. */
+public abstract class SourceSplitBase implements SourceSplit {
+
+    protected final String splitId;
+
+    public SourceSplitBase(String splitId) {
+        this.splitId = splitId;
+    }
+
+    /** Checks whether this split is a snapshot split. */
+    public final boolean isSnapshotSplit() {
+        return getClass() == SnapshotSplit.class;
+    }
+
+    /** Checks whether this split is an incremental split. */
+    public final boolean isIncrementalSplit() {
+        return getClass() == IncrementalSplit.class;
+    }
+
+    /** Casts this split into a {@link SnapshotSplit}. */
+    public final SnapshotSplit asSnapshotSplit() {
+        return (SnapshotSplit) this;
+    }
+
+    /** Casts this split into a {@link IncrementalSplit}. */
+    public final IncrementalSplit asIncrementalSplit() {
+        return (IncrementalSplit) this;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SourceSplitBase that = (SourceSplitBase) o;
+        return Objects.equals(splitId, that.splitId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(splitId);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/IncrementalSplitState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/IncrementalSplitState.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.state;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+
+import io.debezium.relational.TableId;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Comparator;
+import java.util.List;
+
+/** The state of split to describe the change log of table(s). */
+@Getter
+@Setter
+public class IncrementalSplitState extends SourceSplitStateBase {
+
+    private List<TableId> tableIds;
+
+    /** Minimum watermark for SnapshotSplits for all tables in this IncrementalSplit */
+    private Offset startupOffset;
+
+    /** Obtained by configuration, may not end */
+    private Offset stopOffset;
+
+    private Offset maxSnapshotSplitsHighWatermark;
+    private volatile boolean enterPureIncrementPhase;
+
+    public IncrementalSplitState(IncrementalSplit split) {
+        super(split);
+        this.tableIds = split.getTableIds();
+        this.startupOffset = split.getStartupOffset();
+        this.stopOffset = split.getStopOffset();
+
+        if (split.getCompletedSnapshotSplitInfos().isEmpty()) {
+            this.maxSnapshotSplitsHighWatermark = null;
+            this.enterPureIncrementPhase = true;
+        } else {
+            this.maxSnapshotSplitsHighWatermark =
+                    split.getCompletedSnapshotSplitInfos().stream()
+                            .filter(e -> e.getWatermark() != null)
+                            .max(Comparator.comparing(o -> o.getWatermark().getHighWatermark()))
+                            .map(e -> e.getWatermark().getHighWatermark())
+                            .get();
+            this.enterPureIncrementPhase = false;
+        }
+    }
+
+    @Override
+    public IncrementalSplit toSourceSplit() {
+        final IncrementalSplit incrementalSplit = split.asIncrementalSplit();
+        return new IncrementalSplit(
+                incrementalSplit.splitId(),
+                getTableIds(),
+                getStartupOffset(),
+                getStopOffset(),
+                incrementalSplit.getCompletedSnapshotSplitInfos());
+    }
+
+    public synchronized boolean markEnterPureIncrementPhaseIfNeed(Offset currentRecordPosition) {
+        if (enterPureIncrementPhase) {
+            return false;
+        }
+
+        if (currentRecordPosition.isAtOrAfter(maxSnapshotSplitsHighWatermark)) {
+            split.asIncrementalSplit().getCompletedSnapshotSplitInfos().clear();
+            this.enterPureIncrementPhase = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    public synchronized boolean autoEnterPureIncrementPhaseIfAllowed() {
+        if (!enterPureIncrementPhase
+                && maxSnapshotSplitsHighWatermark.compareTo(startupOffset) == 0) {
+            split.asIncrementalSplit().getCompletedSnapshotSplitInfos().clear();
+            enterPureIncrementPhase = true;
+            return true;
+        }
+        return false;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/SnapshotSplitState.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/SnapshotSplitState.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.state;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/** The state of split to describe the snapshot of table(s). */
+@Getter
+@Setter
+public class SnapshotSplitState extends SourceSplitStateBase {
+
+    private Offset lowWatermark;
+    private Offset highWatermark;
+
+    public SnapshotSplitState(SnapshotSplit split) {
+        super(split);
+    }
+
+    @Override
+    public SnapshotSplit toSourceSplit() {
+        final SnapshotSplit snapshotSplit = split.asSnapshotSplit();
+        return new SnapshotSplit(
+                snapshotSplit.splitId(),
+                snapshotSplit.getTableId(),
+                snapshotSplit.getSplitKeyType(),
+                snapshotSplit.getSplitStart(),
+                snapshotSplit.getSplitEnd(),
+                getLowWatermark(),
+                getHighWatermark());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/SourceSplitStateBase.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/SourceSplitStateBase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.state;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+/** State of the reader, essentially a mutable version of the {@link SourceSplit}. */
+public abstract class SourceSplitStateBase {
+
+    protected final SourceSplitBase split;
+
+    public SourceSplitStateBase(SourceSplitBase split) {
+        this.split = split;
+    }
+
+    /** Checks whether this split state is a snapshot split state. */
+    public final boolean isSnapshotSplitState() {
+        return getClass() == SnapshotSplitState.class;
+    }
+
+    /** Checks whether this split state is a incremental split state. */
+    public final boolean isIncrementalSplitState() {
+        return getClass() == IncrementalSplitState.class;
+    }
+
+    /** Casts this split state into a {@link SnapshotSplitState}. */
+    public final SnapshotSplitState asSnapshotSplitState() {
+        return (SnapshotSplitState) this;
+    }
+
+    /** Casts this split state into a {@link IncrementalSplitState}. */
+    public final IncrementalSplitState asIncrementalSplitState() {
+        return (IncrementalSplitState) this;
+    }
+
+    /** Use the current split state to create a new SourceSplit. */
+    public abstract SourceSplitBase toSourceSplit();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/wartermark/WatermarkEvent.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/wartermark/WatermarkEvent.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.wartermark;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** Utility class to deal Watermark event. */
+public class WatermarkEvent {
+
+    public static final String WATERMARK_SIGNAL = "_split_watermark_signal_";
+    public static final String SPLIT_ID_KEY = "split_id";
+    public static final String WATERMARK_KIND = "watermark_kind";
+    public static final String SIGNAL_EVENT_KEY_SCHEMA_NAME =
+            "io.debezium.connector.seatunnel.cdc.embedded.watermark.key";
+    public static final String SIGNAL_EVENT_VALUE_SCHEMA_NAME =
+            "io.debezium.connector.seatunnel.cdc.embedded.watermark.value";
+
+    private static final SchemaNameAdjuster SCHEMA_NAME_ADJUSTER = SchemaNameAdjuster.create();
+
+    private static final Schema SIGNAL_EVENT_KEY_SCHEMA =
+            SchemaBuilder.struct()
+                    .name(SCHEMA_NAME_ADJUSTER.adjust(SIGNAL_EVENT_KEY_SCHEMA_NAME))
+                    .field(SPLIT_ID_KEY, Schema.STRING_SCHEMA)
+                    .field(WATERMARK_SIGNAL, Schema.BOOLEAN_SCHEMA)
+                    .build();
+
+    private static final Schema SIGNAL_EVENT_VALUE_SCHEMA =
+            SchemaBuilder.struct()
+                    .name(SCHEMA_NAME_ADJUSTER.adjust(SIGNAL_EVENT_VALUE_SCHEMA_NAME))
+                    .field(SPLIT_ID_KEY, Schema.STRING_SCHEMA)
+                    .field(WATERMARK_KIND, Schema.STRING_SCHEMA)
+                    .build();
+
+    public static SourceRecord create(
+            Map<String, ?> sourcePartition,
+            String topic,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset watermark) {
+        return new SourceRecord(
+                sourcePartition,
+                watermark.getOffset(),
+                topic,
+                SIGNAL_EVENT_KEY_SCHEMA,
+                signalRecordKey(splitId),
+                SIGNAL_EVENT_VALUE_SCHEMA,
+                signalRecordValue(splitId, watermarkKind));
+    }
+
+    public static SourceRecord createSchemaChangeBeforeWatermark(SourceRecord record) {
+        return new SourceRecord(
+                record.sourcePartition(),
+                record.sourceOffset(),
+                record.topic(),
+                SIGNAL_EVENT_KEY_SCHEMA,
+                signalRecordKey("schema-change-before"),
+                SIGNAL_EVENT_VALUE_SCHEMA,
+                signalRecordValue("schema-change-before", WatermarkKind.SCHEMA_CHANGE_BEFORE));
+    }
+
+    public static SourceRecord createSchemaChangeAfterWatermark(SourceRecord record) {
+        return new SourceRecord(
+                record.sourcePartition(),
+                record.sourceOffset(),
+                record.topic(),
+                SIGNAL_EVENT_KEY_SCHEMA,
+                signalRecordKey("schema-change-after"),
+                SIGNAL_EVENT_VALUE_SCHEMA,
+                signalRecordValue("schema-change-after", WatermarkKind.SCHEMA_CHANGE_AFTER));
+    }
+
+    public static boolean isWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent();
+    }
+
+    public static boolean isLowWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent() && watermarkKind.get() == WatermarkKind.LOW;
+    }
+
+    public static boolean isHighWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent() && watermarkKind.get() == WatermarkKind.HIGH;
+    }
+
+    public static boolean isEndWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent() && watermarkKind.get() == WatermarkKind.END;
+    }
+
+    public static boolean isSchemaChangeBeforeWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent()
+                && watermarkKind.get() == WatermarkKind.SCHEMA_CHANGE_BEFORE;
+    }
+
+    public static boolean isSchemaChangeAfterWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        return watermarkKind.isPresent()
+                && watermarkKind.get() == WatermarkKind.SCHEMA_CHANGE_AFTER;
+    }
+
+    private static Optional<WatermarkKind> getWatermarkKind(SourceRecord record) {
+        if (record.valueSchema() != null
+                && SIGNAL_EVENT_VALUE_SCHEMA_NAME.equals(record.valueSchema().name())) {
+            Struct value = (Struct) record.value();
+            return Optional.of(WatermarkKind.valueOf(value.getString(WATERMARK_KIND)));
+        }
+        return Optional.empty();
+    }
+
+    private static Struct signalRecordKey(String splitId) {
+        Struct result = new Struct(SIGNAL_EVENT_KEY_SCHEMA);
+        result.put(SPLIT_ID_KEY, splitId);
+        result.put(WATERMARK_SIGNAL, true);
+        return result;
+    }
+
+    private static Struct signalRecordValue(String splitId, WatermarkKind watermarkKind) {
+        Struct result = new Struct(SIGNAL_EVENT_VALUE_SCHEMA);
+        result.put(SPLIT_ID_KEY, splitId);
+        result.put(WATERMARK_KIND, watermarkKind.toString());
+        return result;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/wartermark/WatermarkKind.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/wartermark/WatermarkKind.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.wartermark;
+
+/** The watermark kind. */
+public enum WatermarkKind {
+    LOW,
+    HIGH,
+    SCHEMA_CHANGE_BEFORE,
+    SCHEMA_CHANGE_AFTER,
+    END;
+
+    public WatermarkKind fromString(String kindString) {
+        if (LOW.name().equalsIgnoreCase(kindString)) {
+            return LOW;
+        } else if (HIGH.name().equalsIgnoreCase(kindString)) {
+            return HIGH;
+        } else if (SCHEMA_CHANGE_BEFORE.name().equalsIgnoreCase(kindString)) {
+            return SCHEMA_CHANGE_BEFORE;
+        } else if (SCHEMA_CHANGE_AFTER.name().equalsIgnoreCase(kindString)) {
+            return SCHEMA_CHANGE_AFTER;
+        } else {
+            return END;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/CatalogTableUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/CatalogTableUtils.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceTableConfig;
+
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class CatalogTableUtils {
+
+    public static List<CatalogTable> mergeCatalogTableConfig(
+            List<CatalogTable> tables,
+            List<JdbcSourceTableConfig> tableConfigs,
+            Function<String, TablePath> parser) {
+        Map<TablePath, CatalogTable> catalogTableMap =
+                tables.stream()
+                        .collect(Collectors.toMap(t -> t.getTableId().toTablePath(), t -> t));
+        for (JdbcSourceTableConfig catalogTableConfig : tableConfigs) {
+            TablePath tablePath = parser.apply(catalogTableConfig.getTable());
+            CatalogTable catalogTable = catalogTableMap.get(tablePath);
+            if (catalogTable != null) {
+                catalogTable = mergeCatalogTableConfig(catalogTable, catalogTableConfig);
+                catalogTableMap.put(tablePath, catalogTable);
+                log.info(
+                        "Override primary key({}) for catalog table {}",
+                        catalogTableConfig.getPrimaryKeys(),
+                        catalogTableConfig.getTable());
+            } else {
+                log.warn(
+                        "Table {} is not found in catalog tables, skip to merge config",
+                        catalogTableConfig.getTable());
+            }
+        }
+        return new ArrayList<>(catalogTableMap.values());
+    }
+
+    public static CatalogTable mergeCatalogTableConfig(
+            final CatalogTable table, JdbcSourceTableConfig config) {
+        List<String> columnNames =
+                table.getTableSchema().getColumns().stream()
+                        .map(c -> c.getName())
+                        .collect(Collectors.toList());
+        for (String pk : config.getPrimaryKeys()) {
+            if (!columnNames.contains(pk)) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Primary key(%s) is not in table(%s) columns(%s)",
+                                pk, table.getTablePath(), columnNames));
+            }
+        }
+        PrimaryKey primaryKeys =
+                PrimaryKey.of(
+                        "pk" + (config.getPrimaryKeys().hashCode() & Integer.MAX_VALUE),
+                        config.getPrimaryKeys());
+        List<Column> columns =
+                table.getTableSchema().getColumns().stream()
+                        .map(
+                                column -> {
+                                    if (config.getPrimaryKeys().contains(column.getName())
+                                            && column.isNullable()) {
+                                        log.warn(
+                                                "Primary key({}) is nullable for catalog table {}",
+                                                column.getName(),
+                                                table.getTablePath());
+                                        return PhysicalColumn.of(
+                                                column.getName(),
+                                                column.getDataType(),
+                                                column.getColumnLength(),
+                                                false,
+                                                column.getDefaultValue(),
+                                                column.getComment());
+                                    }
+                                    return column;
+                                })
+                        .collect(Collectors.toList());
+
+        return CatalogTable.of(
+                table.getTableId(),
+                TableSchema.builder()
+                        .primaryKey(primaryKeys)
+                        .columns(columns)
+                        .constraintKey(table.getTableSchema().getConstraintKeys())
+                        .build(),
+                table.getOptions(),
+                table.getPartitionKeys(),
+                table.getComment());
+    }
+
+    public static Table mergeCatalogTableConfig(Table debeziumTable, CatalogTable catalogTable) {
+        PrimaryKey pk = catalogTable.getTableSchema().getPrimaryKey();
+        if (pk != null) {
+            debeziumTable = debeziumTable.edit().setPrimaryKeyNames(pk.getColumnNames()).create();
+            log.info(
+                    "Override primary key({}) for catalog table {}",
+                    pk.getColumnNames(),
+                    debeziumTable.id());
+        }
+        return debeziumTable;
+    }
+
+    public static Map<TableId, CatalogTable> convertTables(List<CatalogTable> catalogTables) {
+        Map<TableId, CatalogTable> tableMap =
+                catalogTables.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        e ->
+                                                new TableId(
+                                                        e.getTableId().getDatabaseName(),
+                                                        e.getTableId().getSchemaName(),
+                                                        e.getTableId().getTableName()),
+                                        e -> e));
+        return Collections.unmodifiableMap(tableMap);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/MessageDelayedEventLimiter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/MessageDelayedEventLimiter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import org.apache.seatunnel.shade.com.google.common.util.concurrent.RateLimiter;
+
+import lombok.AllArgsConstructor;
+
+import java.time.Duration;
+
+@AllArgsConstructor
+public class MessageDelayedEventLimiter {
+    private final long delayMs;
+    private final RateLimiter eventRateLimiter;
+
+    public MessageDelayedEventLimiter(Duration delayThreshold) {
+        this(delayThreshold, 1);
+    }
+
+    public MessageDelayedEventLimiter(Duration delayThreshold, double permitsPerSecond) {
+        this.delayMs = delayThreshold.toMillis();
+        this.eventRateLimiter = RateLimiter.create(permitsPerSecond);
+    }
+
+    public boolean acquire(long messageCreateTime) {
+        if (isDelayed(messageCreateTime)) {
+            return eventRateLimiter.tryAcquire();
+        }
+        return false;
+    }
+
+    private boolean isDelayed(long messageCreateTime) {
+        return delayMs != 0 && System.currentTimeMillis() - messageCreateTime >= delayMs;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/** Utilities for operation on {@link Object}. */
+public class ObjectUtils {
+
+    /**
+     * Returns a number {@code Object} whose value is {@code (number + augend)}, Note: This method
+     * will throw {@link ArithmeticException} if number overflows.
+     */
+    public static Object plus(Object number, int augend) throws ArithmeticException {
+        if (number instanceof Integer) {
+            return Math.addExact((Integer) number, augend);
+        } else if (number instanceof Long) {
+            return Math.addExact((Long) number, augend);
+        } else if (number instanceof BigInteger) {
+            return ((BigInteger) number).add(BigInteger.valueOf(augend));
+        } else if (number instanceof BigDecimal) {
+            return ((BigDecimal) number).add(BigDecimal.valueOf(augend));
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Unsupported type %s for numeric plus.",
+                            number.getClass().getSimpleName()));
+        }
+    }
+
+    /** Returns the difference {@code BigDecimal} whose value is {@code (minuend - subtrahend)}. */
+    public static BigDecimal minus(Object minuend, Object subtrahend) {
+        if (!minuend.getClass().equals(subtrahend.getClass())) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unsupported operand type, the minuend type %s is different with subtrahend type %s.",
+                            minuend.getClass().getSimpleName(),
+                            subtrahend.getClass().getSimpleName()));
+        }
+        if (minuend instanceof Integer) {
+            return BigDecimal.valueOf((int) minuend).subtract(BigDecimal.valueOf((int) subtrahend));
+        } else if (minuend instanceof Short) {
+            return BigDecimal.valueOf((short) minuend)
+                    .subtract(BigDecimal.valueOf((short) subtrahend));
+        } else if (minuend instanceof Byte) {
+            return BigDecimal.valueOf((byte) minuend)
+                    .subtract(BigDecimal.valueOf((byte) subtrahend));
+        } else if (minuend instanceof Long) {
+            return BigDecimal.valueOf((long) minuend)
+                    .subtract(BigDecimal.valueOf((long) subtrahend));
+        } else if (minuend instanceof BigInteger) {
+            return new BigDecimal(
+                    ((BigInteger) minuend).subtract((BigInteger) subtrahend).toString());
+        } else if (minuend instanceof BigDecimal) {
+            return ((BigDecimal) minuend).subtract((BigDecimal) subtrahend);
+        } else if (minuend instanceof String) {
+            return BigDecimal.valueOf(Long.MAX_VALUE);
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Unsupported type %s for numeric minus.",
+                            minuend.getClass().getSimpleName()));
+        }
+    }
+
+    /**
+     * Compares two comparable objects.
+     *
+     * @return The value {@code 0} if {@code num1} is equal to the {@code num2}; a value less than
+     *     {@code 0} if the {@code num1} is numerically less than the {@code num2}; and a value
+     *     greater than {@code 0} if the {@code num1} is numerically greater than the {@code num2}.
+     * @throws ClassCastException if the compared objects are not instance of {@link Comparable} or
+     *     not <i>mutually comparable</i> (for example, strings and integers).
+     */
+    @SuppressWarnings("unchecked")
+    public static int compare(Object obj1, Object obj2) {
+        Comparable<Object> c1 = (Comparable<Object>) obj1;
+        Comparable<Object> c2 = (Comparable<Object>) obj2;
+        return c1.compareTo(c2);
+    }
+
+    /**
+     * Compares two Double numeric object.
+     *
+     * @return -1, 0, or 1 as this {@code arg1} is numerically less than, equal to, or greater than
+     *     {@code arg2}.
+     */
+    public static int doubleCompare(double arg1, double arg2) {
+        BigDecimal bigDecimal1 = BigDecimal.valueOf(arg1);
+        BigDecimal bigDecimal2 = BigDecimal.valueOf(arg2);
+        return bigDecimal1.compareTo(bigDecimal2);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourceRecordUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourceRecordUtils.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.document.DocumentReader;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.debezium.connector.AbstractSourceInfo.DATABASE_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
+
+/** Utility class to deal record. */
+public class SourceRecordUtils {
+
+    private SourceRecordUtils() {}
+
+    /** Todo: Support more schema change event key name, currently only support MySQL and Oracle. */
+    public static final List<String> SUPPORT_SCHEMA_CHANGE_EVENT_KEY_NAME =
+            Arrays.asList(
+                    "io.debezium.connector.mysql.SchemaChangeKey",
+                    "io.debezium.connector.oracle.SchemaChangeKey");
+
+    public static final String HEARTBEAT_VALUE_SCHEMA_KEY_NAME =
+            "io.debezium.connector.common.Heartbeat";
+    private static final DocumentReader DOCUMENT_READER = DocumentReader.defaultReader();
+
+    /** Converts a {@link ResultSet} row to an array of Objects. */
+    public static Object[] rowToArray(ResultSet rs, int size) throws SQLException {
+        final Object[] row = new Object[size];
+        for (int i = 0; i < size; i++) {
+            row[i] = rs.getObject(i + 1);
+        }
+        return row;
+    }
+
+    /**
+     * In the source object, ts_ms indicates the time that the change was made in the database. By
+     * comparing the value for payload.source.ts_ms with the value for payload.ts_ms, you can
+     * determine the lag between the source database update and Debezium.
+     */
+    public static Long getMessageTimestamp(SourceRecord record) {
+        Schema schema = record.valueSchema();
+        Struct value = (Struct) record.value();
+        if (schema == null || schema.field(Envelope.FieldName.SOURCE) == null) {
+            return null;
+        }
+
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        if (source.schema().field(Envelope.FieldName.TIMESTAMP) == null) {
+            return null;
+        }
+
+        return source.getInt64(Envelope.FieldName.TIMESTAMP);
+    }
+
+    /**
+     * The field `ts_ms` in {@link SourceRecord} data struct is the time when the record fetched by
+     * debezium reader, use it as the process time in Source.
+     */
+    public static Long getFetchTimestamp(SourceRecord record) {
+        Schema schema = record.valueSchema();
+        Struct value = (Struct) record.value();
+        if (schema.field(Envelope.FieldName.TIMESTAMP) == null) {
+            return null;
+        }
+        return value.getInt64(Envelope.FieldName.TIMESTAMP);
+    }
+
+    public static boolean isSchemaChangeEvent(SourceRecord sourceRecord) {
+        Schema keySchema = sourceRecord.keySchema();
+        return keySchema != null
+                && SUPPORT_SCHEMA_CHANGE_EVENT_KEY_NAME.stream()
+                        .anyMatch(name -> name.equalsIgnoreCase(keySchema.name()));
+    }
+
+    public static boolean isDataChangeRecord(SourceRecord record) {
+        Schema valueSchema = record.valueSchema();
+        Struct value = (Struct) record.value();
+        return valueSchema != null
+                && valueSchema.field(Envelope.FieldName.OPERATION) != null
+                && value.getString(Envelope.FieldName.OPERATION) != null;
+    }
+
+    public static boolean isHeartbeatRecord(SourceRecord record) {
+        Schema valueSchema = record.valueSchema();
+        return valueSchema != null && valueSchema.name().equals(HEARTBEAT_VALUE_SCHEMA_KEY_NAME);
+    }
+
+    public static TableId getTableId(SourceRecord dataRecord) {
+        Struct value = (Struct) dataRecord.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String dbName = source.getString(DATABASE_NAME_KEY);
+        // Oracle need schemaName
+        String schemaName = getSchemaName(source);
+        String tableName = source.getString(TABLE_NAME_KEY);
+        return new TableId(dbName, schemaName, tableName);
+    }
+
+    public static String getSchemaName(Struct source) {
+        if (source.schema().fields().stream().anyMatch(r -> SCHEMA_NAME_KEY.equals(r.name()))) {
+            return source.getString(SCHEMA_NAME_KEY);
+        }
+        return null;
+    }
+
+    public static Object[] getSplitKey(
+            SeaTunnelRowType splitBoundaryType,
+            SourceRecord dataRecord,
+            SchemaNameAdjuster nameAdjuster) {
+        // the split key field contains single field now
+        String splitFieldName = nameAdjuster.adjust(splitBoundaryType.getFieldNames()[0]);
+        Struct key = (Struct) dataRecord.key();
+        return new Object[] {key.get(splitFieldName)};
+    }
+
+    /** Returns the specific key contains in the split key range or not. */
+    public static boolean splitKeyRangeContains(
+            Object[] key, Object[] splitKeyStart, Object[] splitKeyEnd) {
+        // for all range
+        if (splitKeyStart == null && splitKeyEnd == null) {
+            return true;
+        }
+        // first split
+        if (splitKeyStart == null) {
+            int[] upperBoundRes = new int[key.length];
+            for (int i = 0; i < key.length; i++) {
+                upperBoundRes[i] = compareObjects(key[i], splitKeyEnd[i]);
+            }
+            return Arrays.stream(upperBoundRes).anyMatch(value -> value < 0)
+                    && Arrays.stream(upperBoundRes).allMatch(value -> value <= 0);
+        }
+        // last split
+        else if (splitKeyEnd == null) {
+            int[] lowerBoundRes = new int[key.length];
+            for (int i = 0; i < key.length; i++) {
+                lowerBoundRes[i] = compareObjects(key[i], splitKeyStart[i]);
+            }
+            return Arrays.stream(lowerBoundRes).allMatch(value -> value >= 0);
+        }
+        // other split
+        else {
+            int[] lowerBoundRes = new int[key.length];
+            int[] upperBoundRes = new int[key.length];
+            for (int i = 0; i < key.length; i++) {
+                lowerBoundRes[i] = compareObjects(key[i], splitKeyStart[i]);
+                upperBoundRes[i] = compareObjects(key[i], splitKeyEnd[i]);
+            }
+            return Arrays.stream(lowerBoundRes).anyMatch(value -> value >= 0)
+                    && Arrays.stream(upperBoundRes).anyMatch(value -> value < 0)
+                    && Arrays.stream(upperBoundRes).allMatch(value -> value <= 0);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int compareObjects(Object o1, Object o2) {
+        if (o1 instanceof Comparable && o1.getClass().equals(o2.getClass())) {
+            return ((Comparable) o1).compareTo(o2);
+        } else if (isNumericObject(o1) && isNumericObject(o2)) {
+            return toBigDecimal(o1).compareTo(toBigDecimal(o2));
+        } else {
+            return o1.toString().compareTo(o2.toString());
+        }
+    }
+
+    private static boolean isNumericObject(Object obj) {
+        return obj instanceof Byte
+                || obj instanceof Short
+                || obj instanceof Integer
+                || obj instanceof Long
+                || obj instanceof Float
+                || obj instanceof Double
+                || obj instanceof BigInteger
+                || obj instanceof BigDecimal;
+    }
+
+    private static BigDecimal toBigDecimal(Object numericObj) {
+        return new BigDecimal(numericObj.toString());
+    }
+
+    public static TablePath getTablePath(SourceRecord record) {
+        Struct messageStruct = (Struct) record.value();
+        Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
+        String databaseName = sourceStruct.getString(AbstractSourceInfo.DATABASE_NAME_KEY);
+        String tableName = sourceStruct.getString(AbstractSourceInfo.TABLE_NAME_KEY);
+        String schemaName = null;
+        if (sourceStruct.schema().field(AbstractSourceInfo.SCHEMA_NAME_KEY) != null) {
+            schemaName = sourceStruct.getString(AbstractSourceInfo.SCHEMA_NAME_KEY);
+        }
+        return TablePath.of(databaseName, schemaName, tableName);
+    }
+
+    public static String getDdl(SourceRecord record) {
+        Struct schemaChangeStruct = (Struct) record.value();
+        return schemaChangeStruct.getString(HistoryRecord.Fields.DDL_STATEMENTS);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/AbstractDebeziumDeserializationSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/AbstractDebeziumDeserializationSchema.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.seatunnel.api.source.Collector;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.HistoryRecord;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+
+/**
+ * Abstract class for Debezium deserialization schema.
+ *
+ * <p>It provides the basic functionality to serialize the table changes struct and history table
+ * changes.
+ *
+ * @param <T>
+ */
+public abstract class AbstractDebeziumDeserializationSchema<T>
+        implements DebeziumDeserializationSchema<T> {
+
+    protected final Map<TableId, byte[]> tableChangesStructMap = new HashMap<>();
+    protected transient JsonConverter converter;
+
+    public AbstractDebeziumDeserializationSchema(Map<TableId, Struct> tableIdTableChangeMap) {
+        this.tableChangesStructMap.putAll(
+                tableIdTableChangeMap.entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        entry -> serializeStruct(entry.getValue()))));
+    }
+
+    @Override
+    public Map<TableId, byte[]> getHistoryTableChanges() {
+        return new HashMap<>(tableChangesStructMap);
+    }
+
+    public void deserialize(SourceRecord record, Collector<T> out) throws Exception {
+        if (isSchemaChangeEvent(record)) {
+            Struct recordValue = (Struct) record.value();
+            List<Struct> tableChangesStruct =
+                    (List<Struct>) recordValue.get(HistoryRecord.Fields.TABLE_CHANGES);
+            tableChangesStruct.forEach(
+                    tableChangeStruct -> {
+                        tableChangesStructMap.put(
+                                TableId.parse(tableChangeStruct.getString("id")),
+                                serializeStruct(tableChangeStruct));
+                    });
+        }
+    }
+
+    private byte[] serializeStruct(Struct struct) {
+        if (converter == null) {
+            converter = new JsonConverter();
+            Map<String, ?> configs = Collections.singletonMap("schemas.enable", true);
+            converter.configure(configs, false);
+        }
+        return converter.fromConnectData("topic", struct.schema(), struct);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/ConnectTableChangeSerializer.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/ConnectTableChangeSerializer.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.util.SchemaNameAdjuster;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static io.debezium.relational.history.ConnectTableChangeSerializer.AUTO_INCREMENTED_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.CHARSET_NAME_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.COLUMNS_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.COMMENT_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.DEFAULT_CHARSET_NAME_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.GENERATED_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.ID_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.JDBC_TYPE_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.LENGTH_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.NAME_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.NATIVE_TYPE_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.OPTIONAL_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.POSITION_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.PRIMARY_KEY_COLUMN_NAMES_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.SCALE_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.TABLE_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.TYPE_EXPRESSION_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.TYPE_KEY;
+import static io.debezium.relational.history.ConnectTableChangeSerializer.TYPE_NAME_KEY;
+
+/**
+ * A serializer for {@link TableChanges} that deserialize the table list of {@link Struct} into a
+ * {@link TableChanges}. This class is used to deserialize the checkpoint data into {@link
+ * TableChanges}.
+ */
+@Slf4j
+public class ConnectTableChangeSerializer
+        implements TableChanges.TableChangesSerializer<List<Struct>>, Serializable {
+    private static final String ENUM_VALUES_KEY = "enumValues";
+    private static final SchemaNameAdjuster SCHEMA_NAME_ADJUSTER = SchemaNameAdjuster.create();
+
+    private static final Schema COLUMN_SCHEMA =
+            SchemaBuilder.struct()
+                    .name(SCHEMA_NAME_ADJUSTER.adjust("io.debezium.connector.schema.Column"))
+                    .field(NAME_KEY, Schema.STRING_SCHEMA)
+                    .field(JDBC_TYPE_KEY, Schema.INT32_SCHEMA)
+                    .field(NATIVE_TYPE_KEY, Schema.OPTIONAL_INT32_SCHEMA)
+                    .field(TYPE_NAME_KEY, Schema.STRING_SCHEMA)
+                    .field(TYPE_EXPRESSION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                    .field(CHARSET_NAME_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                    .field(LENGTH_KEY, Schema.OPTIONAL_INT32_SCHEMA)
+                    .field(SCALE_KEY, Schema.OPTIONAL_INT32_SCHEMA)
+                    .field(POSITION_KEY, Schema.INT32_SCHEMA)
+                    .field(OPTIONAL_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                    .field(AUTO_INCREMENTED_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                    .field(GENERATED_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                    .field(COMMENT_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                    .field(
+                            ENUM_VALUES_KEY,
+                            SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                    .build();
+
+    public static final Schema TABLE_SCHEMA =
+            SchemaBuilder.struct()
+                    .name(SCHEMA_NAME_ADJUSTER.adjust("io.debezium.connector.schema.Table"))
+                    .field(DEFAULT_CHARSET_NAME_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                    .field(
+                            PRIMARY_KEY_COLUMN_NAMES_KEY,
+                            SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                    .field(COLUMNS_KEY, SchemaBuilder.array(COLUMN_SCHEMA).build())
+                    .field(COMMENT_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                    .build();
+
+    public static final Schema CHANGE_SCHEMA =
+            SchemaBuilder.struct()
+                    .name(SCHEMA_NAME_ADJUSTER.adjust("io.debezium.connector.schema.Change"))
+                    .field(TYPE_KEY, Schema.STRING_SCHEMA)
+                    .field(ID_KEY, Schema.STRING_SCHEMA)
+                    .field(TABLE_KEY, TABLE_SCHEMA)
+                    .build();
+
+    @Override
+    public List<Struct> serialize(TableChanges tableChanges) {
+        return StreamSupport.stream(tableChanges.spliterator(), false)
+                .map(this::toStruct)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public TableChanges deserialize(List<Struct> data, boolean useCatalogBeforeSchema) {
+        TableChanges tableChanges = new TableChanges();
+        for (Struct struct : data) {
+            String tableId = struct.getString(ID_KEY);
+            TableChanges.TableChangeType changeType =
+                    TableChanges.TableChangeType.valueOf(struct.getString(TYPE_KEY));
+            Table table = toTable(struct.getStruct(TABLE_KEY), TableId.parse(tableId));
+            switch (changeType) {
+                case CREATE:
+                    tableChanges.create(table);
+                    break;
+                case DROP:
+                    tableChanges.drop(table);
+                    break;
+                case ALTER:
+                    tableChanges.alter(table);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown table change type: " + changeType);
+            }
+        }
+        return tableChanges;
+    }
+
+    public Table toTable(Struct struct, TableId tableId) {
+        return Table.editor()
+                .tableId(tableId)
+                .setDefaultCharsetName(struct.getString(DEFAULT_CHARSET_NAME_KEY))
+                .setPrimaryKeyNames(struct.getArray(PRIMARY_KEY_COLUMN_NAMES_KEY))
+                .setColumns(
+                        struct.getArray(COLUMNS_KEY).stream()
+                                .map(Struct.class::cast)
+                                .map(this::toColumn)
+                                .collect(Collectors.toList()))
+                .create();
+    }
+
+    private Column toColumn(Struct struct) {
+        ColumnEditor editor =
+                Column.editor()
+                        .name(struct.getString(NAME_KEY))
+                        .jdbcType(struct.getInt32(JDBC_TYPE_KEY))
+                        .type(
+                                struct.getString(TYPE_NAME_KEY),
+                                struct.getString(TYPE_EXPRESSION_KEY))
+                        .charsetName(struct.getString(CHARSET_NAME_KEY))
+                        .position(struct.getInt32(POSITION_KEY))
+                        .optional(struct.getBoolean(OPTIONAL_KEY))
+                        .autoIncremented(struct.getBoolean(AUTO_INCREMENTED_KEY))
+                        .generated(struct.getBoolean(GENERATED_KEY));
+        if (struct.get(NATIVE_TYPE_KEY) != null) {
+            editor.nativeType(struct.getInt32(NATIVE_TYPE_KEY));
+        }
+        if (struct.get(LENGTH_KEY) != null) {
+            editor.length(struct.getInt32(LENGTH_KEY));
+        }
+        if (struct.get(SCALE_KEY) != null) {
+            editor.scale(struct.getInt32(SCALE_KEY));
+        }
+        if (struct.get(COMMENT_KEY) != null) {
+            editor.comment(struct.getString(COMMENT_KEY));
+        }
+        if (struct.schema().field(ENUM_VALUES_KEY) != null) {
+            editor.enumValues(struct.getArray(ENUM_VALUES_KEY));
+        }
+        return editor.create();
+    }
+
+    public Struct toStruct(TableChanges.TableChange tableChange) {
+        final Struct struct = new Struct(CHANGE_SCHEMA);
+
+        struct.put(TYPE_KEY, tableChange.getType().name());
+        struct.put(ID_KEY, tableChange.getId().toDoubleQuotedString());
+        struct.put(TABLE_KEY, toStruct(tableChange.getTable()));
+        return struct;
+    }
+
+    private Struct toStruct(Table table) {
+        final Struct struct = new Struct(TABLE_SCHEMA);
+
+        struct.put(DEFAULT_CHARSET_NAME_KEY, table.defaultCharsetName());
+        struct.put(PRIMARY_KEY_COLUMN_NAMES_KEY, table.primaryKeyColumnNames());
+
+        final List<Struct> columns =
+                table.columns().stream().map(this::toStruct).collect(Collectors.toList());
+
+        struct.put(COLUMNS_KEY, columns);
+        return struct;
+    }
+
+    private Struct toStruct(Column column) {
+        final Struct struct = new Struct(COLUMN_SCHEMA);
+
+        struct.put(NAME_KEY, column.name());
+        struct.put(JDBC_TYPE_KEY, column.jdbcType());
+
+        if (column.nativeType() != Column.UNSET_INT_VALUE) {
+            struct.put(NATIVE_TYPE_KEY, column.nativeType());
+        }
+
+        struct.put(TYPE_NAME_KEY, column.typeName());
+        struct.put(TYPE_EXPRESSION_KEY, column.typeExpression());
+        struct.put(CHARSET_NAME_KEY, column.charsetName());
+
+        if (column.length() != Column.UNSET_INT_VALUE) {
+            struct.put(LENGTH_KEY, column.length());
+        }
+
+        column.scale().ifPresent(s -> struct.put(SCALE_KEY, s));
+
+        struct.put(POSITION_KEY, column.position());
+        struct.put(OPTIONAL_KEY, column.isOptional());
+        struct.put(AUTO_INCREMENTED_KEY, column.isAutoIncremented());
+        struct.put(GENERATED_KEY, column.isGenerated());
+        struct.put(COMMENT_KEY, column.comment());
+        struct.put(ENUM_VALUES_KEY, column.enumValues());
+
+        return struct;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationConverter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.io.Serializable;
+
+/** Runtime converter that converts objects of Debezium into objects of internal data structures. */
+@FunctionalInterface
+public interface DebeziumDeserializationConverter extends Serializable {
+    Object convert(Object dbzObj, Schema schema) throws Exception;
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationConverterFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationConverterFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+
+import java.io.Serializable;
+import java.time.ZoneId;
+import java.util.Optional;
+
+/**
+ * Factory to create {@link DebeziumDeserializationConverter} according to {@link
+ * SeaTunnelDataType}. It's usually used to create a user-defined {@link
+ * DebeziumDeserializationConverter} which has a higher resolve order than default converter.
+ */
+public interface DebeziumDeserializationConverterFactory extends Serializable {
+
+    /** A user-defined converter factory which always fallback to default converters. */
+    DebeziumDeserializationConverterFactory DEFAULT =
+            (logicalType, serverTimeZone) -> Optional.empty();
+
+    /**
+     * Returns an optional {@link DebeziumDeserializationConverter}. Returns {@link
+     * Optional#empty()} if fallback to default converter.
+     *
+     * @param type the SeaTunnel datatype to be converted from objects of Debezium
+     * @param serverTimeZone TimeZone used to convert data with timestamp type
+     */
+    Optional<DebeziumDeserializationConverter> createUserDefinedConverter(
+            SeaTunnelDataType<?> type, ZoneId serverTimeZone);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DebeziumDeserializationSchema.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.relational.TableId;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The deserialization schema describes how to turn the Debezium SourceRecord into data types
+ * (Java/Scala objects) that are processed by engine.
+ *
+ * @param <T> The type created by the deserialization schema.
+ */
+public interface DebeziumDeserializationSchema<T> extends Serializable {
+
+    /** Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}. */
+    void deserialize(SourceRecord record, Collector<T> out) throws Exception;
+
+    List<CatalogTable> getProducedType();
+
+    default void restoreCheckpointProducedType(List<CatalogTable> checkpointDataType) {}
+
+    default SchemaChangeResolver getSchemaChangeResolver() {
+        return null;
+    }
+
+    Map<TableId, byte[]> getHistoryTableChanges();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DeserializeFormat.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/DeserializeFormat.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.seatunnel.format.compatible.debezium.json.CompatibleDebeziumJsonDeserializationSchema;
+
+public enum DeserializeFormat {
+    DEFAULT("default"),
+    COMPATIBLE_DEBEZIUM_JSON(CompatibleDebeziumJsonDeserializationSchema.IDENTIFIER);
+
+    private String name;
+
+    DeserializeFormat(String name) {
+        this.name = name;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/EmbeddedDatabaseHistory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/EmbeddedDatabaseHistory.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.seatunnel.connectors.cdc.base.source.split.state.SourceSplitStateBase;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.relational.history.DatabaseHistoryException;
+import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.relational.history.TableChanges.TableChange;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A {@link DatabaseHistory} implementation which store the latest table schema in Flink state.
+ *
+ * <p>It stores/recovers history using data offered by {@link SourceSplitStateBase}.
+ */
+public class EmbeddedDatabaseHistory implements DatabaseHistory {
+
+    public static final String DATABASE_HISTORY_INSTANCE_NAME = "database.history.instance.name";
+
+    public static final ConcurrentMap<String, Collection<TableChange>> TABLE_SCHEMAS =
+            new ConcurrentHashMap<>();
+
+    private Map<TableId, TableChange> tableSchemas;
+    private DatabaseHistoryListener listener;
+    private boolean storeOnlyMonitoredTablesDdl;
+    private boolean skipUnparseableDDL;
+
+    @Override
+    public void configure(
+            Configuration config,
+            HistoryRecordComparator comparator,
+            DatabaseHistoryListener listener,
+            boolean useCatalogBeforeSchema) {
+        this.listener = listener;
+        this.storeOnlyMonitoredTablesDdl = config.getBoolean(STORE_ONLY_MONITORED_TABLES_DDL);
+        this.skipUnparseableDDL = config.getBoolean(SKIP_UNPARSEABLE_DDL_STATEMENTS);
+
+        // recover
+        String instanceName = config.getString(DATABASE_HISTORY_INSTANCE_NAME);
+        this.tableSchemas = new HashMap<>();
+        for (TableChange tableChange : removeHistory(instanceName)) {
+            tableSchemas.put(tableChange.getId(), tableChange);
+        }
+    }
+
+    @Override
+    public void start() {
+        listener.started();
+    }
+
+    @Override
+    public void record(
+            Map<String, ?> source, Map<String, ?> position, String databaseName, String ddl)
+            throws DatabaseHistoryException {
+        throw new UnsupportedOperationException("should not call here, error");
+    }
+
+    @Override
+    public void record(
+            Map<String, ?> source,
+            Map<String, ?> position,
+            String databaseName,
+            String schemaName,
+            String ddl,
+            TableChanges changes)
+            throws DatabaseHistoryException {
+        final HistoryRecord record =
+                new HistoryRecord(source, position, databaseName, schemaName, ddl, changes);
+        listener.onChangeApplied(record);
+    }
+
+    @Override
+    public void recover(
+            Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) {
+        listener.recoveryStarted();
+        for (TableChange tableChange : tableSchemas.values()) {
+            schema.overwriteTable(tableChange.getTable());
+        }
+        listener.recoveryStopped();
+    }
+
+    @Override
+    public void recover(
+            Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) {
+        offsets.forEach((source, position) -> recover(source, position, schema, ddlParser));
+    }
+
+    @Override
+    public void stop() {
+        listener.stopped();
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
+    public boolean storageExists() {
+        return true;
+    }
+
+    @Override
+    public void initializeStorage() {
+        // do nothing
+    }
+
+    @Override
+    public boolean storeOnlyCapturedTables() {
+        return storeOnlyMonitoredTablesDdl;
+    }
+
+    @Override
+    public boolean skipUnparseableDdlStatements() {
+        return skipUnparseableDDL;
+    }
+
+    public static void registerHistory(String engineName, Collection<TableChange> engineHistory) {
+        TABLE_SCHEMAS.put(engineName, engineHistory);
+    }
+
+    public static Collection<TableChange> removeHistory(String engineName) {
+        if (engineName == null) {
+            return Collections.emptyList();
+        }
+        Collection<TableChange> tableChanges = TABLE_SCHEMAS.remove(engineName);
+        return tableChanges != null ? tableChanges : Collections.emptyList();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/MetadataConverter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/MetadataConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.Serializable;
+
+/** {@link SourceRecord} metadata info converter. */
+@FunctionalInterface
+public interface MetadataConverter extends Serializable {
+    Object read(SourceRecord record);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/DebeziumJsonDeserializeSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/DebeziumJsonDeserializeSchema.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.row;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.cdc.debezium.AbstractDebeziumDeserializationSchema;
+import org.apache.seatunnel.format.compatible.debezium.json.CompatibleDebeziumJsonDeserializationSchema;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.relational.TableId;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isHeartbeatRecord;
+
+@Slf4j
+public class DebeziumJsonDeserializeSchema
+        extends AbstractDebeziumDeserializationSchema<SeaTunnelRow> {
+    private static final String KEY_SCHEMA_ENABLE = "key.converter.schemas.enable";
+    private static final String VALUE_SCHEMA_ENABLE = "value.converter.schemas.enable";
+
+    private final CompatibleDebeziumJsonDeserializationSchema deserializationSchema;
+
+    public DebeziumJsonDeserializeSchema(Map<String, String> debeziumConfig) {
+        this(debeziumConfig, new HashMap<>());
+    }
+
+    public DebeziumJsonDeserializeSchema(
+            Map<String, String> debeziumConfig, Map<TableId, Struct> tableIdTableChangeMap) {
+        super(tableIdTableChangeMap);
+        boolean keySchemaEnable =
+                Boolean.valueOf(debeziumConfig.getOrDefault(KEY_SCHEMA_ENABLE, "true"));
+        boolean valueSchemaEnable =
+                Boolean.valueOf(debeziumConfig.getOrDefault(VALUE_SCHEMA_ENABLE, "true"));
+        this.deserializationSchema =
+                new CompatibleDebeziumJsonDeserializationSchema(keySchemaEnable, valueSchemaEnable);
+    }
+
+    @Override
+    public void deserialize(SourceRecord record, Collector<SeaTunnelRow> out) throws Exception {
+        super.deserialize(record, out);
+        if (!isHeartbeatRecord(record)) {
+            SeaTunnelRow row = deserializationSchema.deserialize(record);
+            out.collect(row);
+            return;
+        }
+
+        log.debug("Unsupported record {}, just skip.", record);
+    }
+
+    @Override
+    public List<CatalogTable> getProducedType() {
+        return CatalogTableUtil.convertDataTypeToCatalogTables(
+                deserializationSchema.getProducedType(), "default.default");
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializationConverters.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializationConverters.java
@@ -1,0 +1,625 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.row;
+
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverter;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverterFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.MetadataConverter;
+import org.apache.seatunnel.connectors.cdc.debezium.utils.TemporalConversions;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.data.SpecialValueDecimal;
+import io.debezium.data.VariableScaleDecimal;
+import io.debezium.data.geometry.Geography;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.NanoTime;
+import io.debezium.time.NanoTimestamp;
+import io.debezium.time.Timestamp;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/** Deserialization schema from Debezium object to {@link SeaTunnelRow} */
+public class SeaTunnelRowDebeziumDeserializationConverters implements Serializable {
+    private static final long serialVersionUID = -897499476343410567L;
+    protected final DebeziumDeserializationConverter[] physicalConverters;
+    protected final MetadataConverter[] metadataConverters;
+    protected final String[] fieldNames;
+
+    public SeaTunnelRowDebeziumDeserializationConverters(
+            SeaTunnelRowType physicalDataType,
+            MetadataConverter[] metadataConverters,
+            ZoneId serverTimeZone,
+            DebeziumDeserializationConverterFactory userDefinedConverterFactory) {
+        this.metadataConverters = metadataConverters;
+
+        this.physicalConverters =
+                Arrays.stream(physicalDataType.getFieldTypes())
+                        .map(
+                                type ->
+                                        createConverter(
+                                                type, serverTimeZone, userDefinedConverterFactory))
+                        .toArray(DebeziumDeserializationConverter[]::new);
+        this.fieldNames = physicalDataType.getFieldNames();
+    }
+
+    public SeaTunnelRow convert(SourceRecord record, Struct struct, Schema schema)
+            throws Exception {
+        int arity = physicalConverters.length + metadataConverters.length;
+        SeaTunnelRow row = new SeaTunnelRow(arity);
+        // physical column
+        for (int i = 0; i < physicalConverters.length; i++) {
+            String fieldName = fieldNames[i];
+            Field field = schema.field(fieldName);
+            if (field == null) {
+                row.setField(i, null);
+            } else {
+                Object fieldValue = struct.getWithoutDefault(fieldName);
+                Schema fieldSchema = field.schema();
+                Object convertedField =
+                        SeaTunnelRowDebeziumDeserializationConverters.convertField(
+                                physicalConverters[i], fieldValue, fieldSchema);
+                row.setField(i, convertedField);
+            }
+        }
+        // metadata column
+        for (int i = 0; i < metadataConverters.length; i++) {
+            row.setField(i + physicalConverters.length, metadataConverters[i].read(record));
+        }
+        return row;
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Runtime Converters
+    // -------------------------------------------------------------------------------------
+
+    /** Creates a runtime converter which is null safe. */
+    private static DebeziumDeserializationConverter createConverter(
+            SeaTunnelDataType<?> type,
+            ZoneId serverTimeZone,
+            DebeziumDeserializationConverterFactory userDefinedConverterFactory) {
+        return wrapIntoNullableConverter(
+                createNotNullConverter(type, serverTimeZone, userDefinedConverterFactory));
+    }
+
+    // --------------------------------------------------------------------------------
+    // IMPORTANT! We use anonymous classes instead of lambdas for a reason here. It is
+    // necessary because the maven shade plugin cannot relocate classes in
+    // SerializedLambdas (MSHADE-260).
+    // --------------------------------------------------------------------------------
+
+    /** Creates a runtime converter which assuming input object is not null. */
+    private static DebeziumDeserializationConverter createNotNullConverter(
+            SeaTunnelDataType<?> type,
+            ZoneId serverTimeZone,
+            DebeziumDeserializationConverterFactory userDefinedConverterFactory) {
+
+        // user defined converter has a higher resolve order
+        Optional<DebeziumDeserializationConverter> converter =
+                userDefinedConverterFactory.createUserDefinedConverter(type, serverTimeZone);
+        if (converter.isPresent()) {
+            return converter.get();
+        }
+
+        // if no matched user defined converter, fallback to the default converter
+        switch (type.getSqlType()) {
+            case NULL:
+                return new DebeziumDeserializationConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(Object dbzObj, Schema schema) throws Exception {
+                        return null;
+                    }
+                };
+            case BOOLEAN:
+                return wrapNumericConverter(convertToBoolean());
+            case TINYINT:
+                return wrapNumericConverter(convertToByte());
+            case SMALLINT:
+                return wrapNumericConverter(convertToShort());
+            case INT:
+                return wrapNumericConverter(convertToInt());
+            case BIGINT:
+                return wrapNumericConverter(convertToLong());
+            case DATE:
+                return convertToDate();
+            case TIME:
+                return convertToTime();
+            case TIMESTAMP:
+                return convertToTimestamp(serverTimeZone);
+            case FLOAT:
+                return wrapNumericConverter(convertToFloat());
+            case DOUBLE:
+                return wrapNumericConverter(convertToDouble());
+            case STRING:
+                return convertToString();
+            case BYTES:
+                return convertToBinary();
+            case DECIMAL:
+                return wrapNumericConverter(createDecimalConverter());
+            case ROW:
+                return createRowConverter(
+                        (SeaTunnelRowType) type, serverTimeZone, userDefinedConverterFactory);
+            case ARRAY:
+                return createArrayConverter(type);
+            case MAP:
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    @VisibleForTesting
+    protected static DebeziumDeserializationConverter createArrayConverter(
+            SeaTunnelDataType<?> type) {
+        SeaTunnelDataType elementType = ((ArrayType) type).getElementType();
+        switch (elementType.getSqlType()) {
+            case BOOLEAN:
+                return (dbzObj, schema) ->
+                        convertListToArray((List<Boolean>) dbzObj, Boolean.class);
+            case SMALLINT:
+                return (dbzObj, schema) -> convertListToArray((List<Short>) dbzObj, Short.class);
+            case INT:
+                return (dbzObj, schema) ->
+                        convertListToArray((List<Integer>) dbzObj, Integer.class);
+            case BIGINT:
+                return (dbzObj, schema) -> convertListToArray((List<Long>) dbzObj, Long.class);
+            case FLOAT:
+                return (dbzObj, schema) -> convertListToArray((List<Float>) dbzObj, Float.class);
+            case DOUBLE:
+                return (dbzObj, schema) -> convertListToArray((List<Double>) dbzObj, Double.class);
+            case STRING:
+                return (dbzObj, schema) -> convertListToArray((List<String>) dbzObj, String.class);
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported SQL type: " + elementType.getSqlType());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T[] convertListToArray(List<T> list, Class<T> clazz) {
+        T[] array = (T[]) java.lang.reflect.Array.newInstance(clazz, list.size());
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = list.get(i);
+        }
+        return array;
+    }
+
+    private static DebeziumDeserializationConverter convertToBoolean() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Boolean) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Byte) {
+                    return (byte) dbzObj != 0;
+                } else if (dbzObj instanceof Short) {
+                    return (short) dbzObj != 0;
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).shortValue() != 0;
+                } else {
+                    return Boolean.parseBoolean(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToByte() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Byte) {
+                    return dbzObj;
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).byteValue();
+                } else if (dbzObj instanceof Boolean) {
+                    return Boolean.TRUE.equals(dbzObj) ? Byte.valueOf("1") : Byte.valueOf("0");
+                } else {
+                    return Byte.parseByte(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToShort() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Byte) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Short) {
+                    return dbzObj;
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).shortValue();
+                } else {
+                    return Short.parseShort(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToInt() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Integer) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Long) {
+                    return ((Long) dbzObj).intValue();
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).intValue();
+                } else {
+                    return Integer.parseInt(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToLong() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Integer) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Long) {
+                    return dbzObj;
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).longValue();
+                } else {
+                    return Long.parseLong(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToDouble() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Float) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Double) {
+                    return dbzObj;
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).doubleValue();
+                } else {
+                    return Double.parseDouble(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToFloat() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Float) {
+                    return dbzObj;
+                } else if (dbzObj instanceof Double) {
+                    return ((Double) dbzObj).floatValue();
+                } else if (dbzObj instanceof BigDecimal) {
+                    return ((BigDecimal) dbzObj).floatValue();
+                } else {
+                    return Float.parseFloat(dbzObj.toString());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToDate() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                return TemporalConversions.toLocalDate(dbzObj);
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToTime() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @SuppressWarnings("MagicNumber")
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Long) {
+                    switch (schema.name()) {
+                        case MicroTime.SCHEMA_NAME:
+                            return LocalTime.ofNanoOfDay((long) dbzObj * 1000L);
+                        case NanoTime.SCHEMA_NAME:
+                            return LocalTime.ofNanoOfDay((long) dbzObj);
+                        default:
+                    }
+                } else if (dbzObj instanceof Integer) {
+                    return LocalTime.ofNanoOfDay((Integer) dbzObj * 1000_000L);
+                }
+                // get number of milliseconds of the day
+                return TemporalConversions.toLocalTime(dbzObj);
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToTimestamp(ZoneId serverTimeZone) {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @SuppressWarnings("MagicNumber")
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof Long) {
+                    switch (schema.name()) {
+                        case Timestamp.SCHEMA_NAME:
+                            return toLocalDateTime((Long) dbzObj, 0);
+                        case MicroTimestamp.SCHEMA_NAME:
+                            long micro = (long) dbzObj;
+                            return toLocalDateTime(micro / 1000, (int) (micro % 1000 * 1000));
+                        case NanoTimestamp.SCHEMA_NAME:
+                            long nano = (long) dbzObj;
+                            return toLocalDateTime(nano / 1000_000, (int) (nano % 1000_000));
+                        default:
+                    }
+                }
+                return TemporalConversions.toLocalDateTime(dbzObj, serverTimeZone);
+            }
+        };
+    }
+
+    @SuppressWarnings("MagicNumber")
+    public static LocalDateTime toLocalDateTime(long millisecond, int nanoOfMillisecond) {
+        // 86400000 = 24 * 60 * 60 * 1000
+        int date = (int) (millisecond / 86400000);
+        int time = (int) (millisecond % 86400000);
+        if (time < 0) {
+            --date;
+            time += 86400000;
+        }
+        long nanoOfDay = time * 1_000_000L + nanoOfMillisecond;
+        LocalDate localDate = LocalDate.ofEpochDay(date);
+        LocalTime localTime = LocalTime.ofNanoOfDay(nanoOfDay);
+        return LocalDateTime.of(localDate, localTime);
+    }
+
+    private static DebeziumDeserializationConverter convertToLocalTimeZoneTimestamp(
+            ZoneId serverTimeZone) {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj instanceof String) {
+                    String str = (String) dbzObj;
+                    // TIMESTAMP type is encoded in string type
+                    Instant instant = Instant.parse(str);
+                    return LocalDateTime.ofInstant(instant, serverTimeZone);
+                }
+                throw new IllegalArgumentException(
+                        "Unable to convert to LocalDateTime from unexpected value '"
+                                + dbzObj
+                                + "' of type "
+                                + dbzObj.getClass().getName());
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter convertToString() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) {
+                if (dbzObj == null) {
+                    return null;
+                }
+
+                if (schema != null && schema.name() != null && dbzObj instanceof Struct) {
+                    String logicalName = schema.name();
+                    if (Geometry.LOGICAL_NAME.equals(logicalName)
+                            || Geography.LOGICAL_NAME.equals(logicalName)) {
+                        return convertGeometryStructToHexWkb((Struct) dbzObj);
+                    }
+                }
+
+                return dbzObj.toString();
+            }
+        };
+    }
+
+    private static String convertGeometryStructToHexWkb(Struct struct) {
+        Object wkbField = struct.get(Geometry.WKB_FIELD);
+        if (!(wkbField instanceof byte[])) {
+            // Fallback to default string representation if the expected field is not present.
+            return struct.toString();
+        }
+
+        byte[] wkb = (byte[]) wkbField;
+        StringBuilder sb = new StringBuilder(wkb.length * 2);
+        for (byte b : wkb) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+
+    private static DebeziumDeserializationConverter convertToBinary() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) throws Exception {
+                if (dbzObj instanceof byte[]) {
+                    return dbzObj;
+                } else if (dbzObj instanceof ByteBuffer) {
+                    ByteBuffer byteBuffer = (ByteBuffer) dbzObj;
+                    byte[] bytes = new byte[byteBuffer.remaining()];
+                    byteBuffer.get(bytes);
+                    return bytes;
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unsupported BYTES value type: " + dbzObj.getClass().getSimpleName());
+                }
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter createDecimalConverter() {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) throws Exception {
+                BigDecimal bigDecimal;
+                if (dbzObj instanceof byte[]) {
+                    // decimal.handling.mode=precise
+                    bigDecimal = Decimal.toLogical(schema, (byte[]) dbzObj);
+                } else if (dbzObj instanceof String) {
+                    // decimal.handling.mode=string
+                    bigDecimal = new BigDecimal((String) dbzObj);
+                } else if (dbzObj instanceof Double) {
+                    // decimal.handling.mode=double
+                    bigDecimal = BigDecimal.valueOf((Double) dbzObj);
+                } else if (dbzObj instanceof BigDecimal) {
+                    bigDecimal = (BigDecimal) dbzObj;
+                } else {
+                    // fallback to string
+                    bigDecimal = new BigDecimal(dbzObj.toString());
+                }
+
+                return bigDecimal;
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter createRowConverter(
+            SeaTunnelRowType rowType,
+            ZoneId serverTimeZone,
+            DebeziumDeserializationConverterFactory userDefinedConverterFactory) {
+        final DebeziumDeserializationConverter[] fieldConverters =
+                Arrays.stream(rowType.getFieldTypes())
+                        .map(
+                                type ->
+                                        createConverter(
+                                                type, serverTimeZone, userDefinedConverterFactory))
+                        .toArray(DebeziumDeserializationConverter[]::new);
+        final String[] fieldNames = rowType.getFieldNames();
+
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) throws Exception {
+                Struct struct = (Struct) dbzObj;
+                int arity = fieldNames.length;
+                SeaTunnelRow row = new SeaTunnelRow(arity);
+                for (int i = 0; i < arity; i++) {
+                    String fieldName = fieldNames[i];
+                    Field field = schema.field(fieldName);
+                    if (field == null) {
+                        row.setField(i, null);
+                    } else {
+                        Object fieldValue = struct.getWithoutDefault(fieldName);
+                        Schema fieldSchema = field.schema();
+                        Object convertedField =
+                                SeaTunnelRowDebeziumDeserializationConverters.convertField(
+                                        fieldConverters[i], fieldValue, fieldSchema);
+                        row.setField(i, convertedField);
+                    }
+                }
+                return row;
+            }
+        };
+    }
+
+    private static Object convertField(
+            DebeziumDeserializationConverter fieldConverter, Object fieldValue, Schema fieldSchema)
+            throws Exception {
+        if (fieldValue == null) {
+            return null;
+        } else {
+            return fieldConverter.convert(fieldValue, fieldSchema);
+        }
+    }
+
+    private static DebeziumDeserializationConverter wrapIntoNullableConverter(
+            DebeziumDeserializationConverter converter) {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) throws Exception {
+                if (dbzObj == null) {
+                    return null;
+                }
+                return converter.convert(dbzObj, schema);
+            }
+        };
+    }
+
+    private static DebeziumDeserializationConverter wrapNumericConverter(
+            DebeziumDeserializationConverter converter) {
+        return new DebeziumDeserializationConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object dbzObj, Schema schema) throws Exception {
+                if (VariableScaleDecimal.LOGICAL_NAME.equals(schema.name())) {
+                    SpecialValueDecimal decimal = VariableScaleDecimal.toLogical((Struct) dbzObj);
+                    return converter.convert(
+                            decimal.getDecimalValue().orElse(BigDecimal.ZERO), schema);
+                }
+                return converter.convert(dbzObj, schema);
+            }
+        };
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializeSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializeSchema.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.row;
+
+import org.apache.seatunnel.api.event.EventType;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.schema.event.AlterTableColumnEvent;
+import org.apache.seatunnel.api.table.schema.event.AlterTableColumnsEvent;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.schema.handler.TableSchemaChangeEventDispatcher;
+import org.apache.seatunnel.api.table.schema.handler.TableSchemaChangeEventHandler;
+import org.apache.seatunnel.api.table.type.MetadataUtil;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+import org.apache.seatunnel.connectors.cdc.debezium.AbstractDebeziumDeserializationSchema;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverterFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.MetadataConverter;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.data.Envelope;
+import io.debezium.relational.TableId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isSchemaChangeAfterWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent.isSchemaChangeBeforeWatermarkEvent;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isDataChangeRecord;
+import static org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
+
+/** Deserialization schema from Debezium object to {@link SeaTunnelRow}. */
+@Slf4j
+public final class SeaTunnelRowDebeziumDeserializeSchema
+        extends AbstractDebeziumDeserializationSchema<SeaTunnelRow> {
+    private static final long serialVersionUID = 1L;
+    private static final String DEFAULT_TABLE_NAME_KEY = null;
+
+    private final MetadataConverter[] metadataConverters;
+    private final ZoneId serverTimeZone;
+    private final DebeziumDeserializationConverterFactory userDefinedConverterFactory;
+    private final SchemaChangeResolver schemaChangeResolver;
+    private final TableSchemaChangeEventHandler tableSchemaChangeHandler;
+    private List<CatalogTable> tables;
+    private Map<String, SeaTunnelRowDebeziumDeserializationConverters> tableRowConverters;
+
+    SeaTunnelRowDebeziumDeserializeSchema(
+            MetadataConverter[] metadataConverters,
+            List<CatalogTable> tables,
+            ZoneId serverTimeZone,
+            DebeziumDeserializationConverterFactory userDefinedConverterFactory,
+            SchemaChangeResolver schemaChangeResolver,
+            Map<TableId, Struct> tableIdTableChangeMap) {
+        super(tableIdTableChangeMap);
+        this.metadataConverters = metadataConverters;
+        this.serverTimeZone = serverTimeZone;
+        this.userDefinedConverterFactory = userDefinedConverterFactory;
+        this.tables = checkNotNull(tables);
+        this.schemaChangeResolver = schemaChangeResolver;
+        this.tableSchemaChangeHandler = new TableSchemaChangeEventDispatcher();
+        this.tableRowConverters =
+                createTableRowConverters(
+                        tables, metadataConverters, serverTimeZone, userDefinedConverterFactory);
+    }
+
+    @Override
+    public void deserialize(SourceRecord record, Collector<SeaTunnelRow> collector)
+            throws Exception {
+        super.deserialize(record, collector);
+
+        if (isSchemaChangeBeforeWatermarkEvent(record)) {
+            collector.markSchemaChangeBeforeCheckpoint();
+            return;
+        }
+        if (isSchemaChangeAfterWatermarkEvent(record)) {
+            collector.markSchemaChangeAfterCheckpoint();
+            return;
+        }
+        if (isSchemaChangeEvent(record)) {
+            deserializeSchemaChangeRecord(record, collector);
+            return;
+        }
+
+        if (isDataChangeRecord(record)) {
+            deserializeDataChangeRecord(record, collector);
+            return;
+        }
+
+        log.debug("Unsupported record {}, just skip.", record);
+    }
+
+    private void deserializeSchemaChangeRecord(
+            SourceRecord record, Collector<SeaTunnelRow> collector) {
+        SchemaChangeEvent schemaChangeEvent = null;
+        try {
+            if (schemaChangeResolver != null) {
+                schemaChangeEvent = schemaChangeResolver.resolve(record, null);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve schemaChangeEvent, just skip.", e);
+            return;
+        }
+        if (schemaChangeEvent == null) {
+            log.warn("Unsupported resolve schemaChangeEvent {}, just skip.", record);
+            return;
+        }
+        boolean tableExist = false;
+        for (int i = 0; i < tables.size(); i++) {
+            CatalogTable changeBefore = tables.get(i);
+            if (!schemaChangeEvent.tablePath().equals(changeBefore.getTablePath())) {
+                continue;
+            }
+
+            tableExist = true;
+            log.debug(
+                    "Table[{}] change before: {}",
+                    schemaChangeEvent.tablePath(),
+                    changeBefore.getTableSchema());
+
+            CatalogTable changeAfter = null;
+            if (EventType.SCHEMA_CHANGE_UPDATE_COLUMNS.equals(schemaChangeEvent.getEventType())) {
+                AlterTableColumnsEvent alterTableColumnsEvent =
+                        (AlterTableColumnsEvent) schemaChangeEvent;
+                for (AlterTableColumnEvent event : alterTableColumnsEvent.getEvents()) {
+                    TableSchema changeAfterSchema =
+                            tableSchemaChangeHandler
+                                    .reset(changeBefore.getTableSchema())
+                                    .apply(event);
+                    changeAfter =
+                            CatalogTable.of(
+                                    changeBefore.getTableId(),
+                                    changeAfterSchema,
+                                    changeBefore.getOptions(),
+                                    changeBefore.getPartitionKeys(),
+                                    changeBefore.getComment());
+                    event.setChangeAfter(changeAfter);
+
+                    changeBefore = changeAfter;
+                }
+            } else {
+                TableSchema changeAfterSchema =
+                        tableSchemaChangeHandler
+                                .reset(changeBefore.getTableSchema())
+                                .apply(schemaChangeEvent);
+                changeAfter =
+                        CatalogTable.of(
+                                changeBefore.getTableId(),
+                                changeAfterSchema,
+                                changeBefore.getOptions(),
+                                changeBefore.getPartitionKeys(),
+                                changeBefore.getComment());
+            }
+            tables.set(i, changeAfter);
+            schemaChangeEvent.setChangeAfter(changeAfter);
+            log.debug(
+                    "Table[{}] change after: {}",
+                    schemaChangeEvent.tablePath(),
+                    changeAfter.getTableSchema());
+            break;
+        }
+        if (!tableExist) {
+            log.error(
+                    "Not found table {}, skip schema change event {}",
+                    schemaChangeEvent.tablePath());
+        }
+        tableRowConverters =
+                createTableRowConverters(
+                        tables, metadataConverters, serverTimeZone, userDefinedConverterFactory);
+        collector.collect(schemaChangeEvent);
+    }
+
+    private void deserializeDataChangeRecord(SourceRecord record, Collector<SeaTunnelRow> collector)
+            throws Exception {
+        Envelope.Operation operation = Envelope.operationFor(record);
+        Struct messageStruct = (Struct) record.value();
+        Schema valueSchema = record.valueSchema();
+        TablePath tablePath = SourceRecordUtils.getTablePath(record);
+        String tableId = tablePath.toString();
+        SeaTunnelRowDebeziumDeserializationConverters converters;
+        if (tables.size() > 1) {
+            converters = tableRowConverters.get(tableId);
+            if (converters == null) {
+                log.debug("Ignore newly added table {}", tableId);
+                return;
+            }
+        } else {
+            converters = tableRowConverters.get(DEFAULT_TABLE_NAME_KEY);
+        }
+        Long fetchTimestamp = SourceRecordUtils.getFetchTimestamp(record);
+        Long messageTimestamp = SourceRecordUtils.getMessageTimestamp(record);
+        long delay = -1L;
+        if (fetchTimestamp != null && messageTimestamp != null) {
+            delay = fetchTimestamp - messageTimestamp;
+        }
+        if (operation == Envelope.Operation.CREATE || operation == Envelope.Operation.READ) {
+            SeaTunnelRow insert = extractAfterRow(converters, record, messageStruct, valueSchema);
+            insert.setRowKind(RowKind.INSERT);
+            insert.setTableId(tableId);
+            MetadataUtil.setDelay(insert, delay);
+            MetadataUtil.setEventTime(insert, fetchTimestamp);
+            collector.collect(insert);
+        } else if (operation == Envelope.Operation.DELETE) {
+            SeaTunnelRow delete = extractBeforeRow(converters, record, messageStruct, valueSchema);
+            delete.setRowKind(RowKind.DELETE);
+            delete.setTableId(tableId);
+            MetadataUtil.setDelay(delete, delay);
+            MetadataUtil.setEventTime(delete, fetchTimestamp);
+            collector.collect(delete);
+        } else if (operation == Envelope.Operation.UPDATE) {
+            SeaTunnelRow before = extractBeforeRow(converters, record, messageStruct, valueSchema);
+            before.setRowKind(RowKind.UPDATE_BEFORE);
+            before.setTableId(tableId);
+            MetadataUtil.setDelay(before, delay);
+            MetadataUtil.setEventTime(before, fetchTimestamp);
+            collector.collect(before);
+
+            SeaTunnelRow after = extractAfterRow(converters, record, messageStruct, valueSchema);
+            after.setRowKind(RowKind.UPDATE_AFTER);
+            after.setTableId(tableId);
+            MetadataUtil.setDelay(after, delay);
+            MetadataUtil.setEventTime(after, fetchTimestamp);
+            collector.collect(after);
+        } else {
+            log.warn("Received {} operation, skip", operation);
+        }
+    }
+
+    private SeaTunnelRow extractAfterRow(
+            SeaTunnelRowDebeziumDeserializationConverters runtimeConverter,
+            SourceRecord record,
+            Struct value,
+            Schema valueSchema)
+            throws Exception {
+
+        Schema afterSchema = valueSchema.field(Envelope.FieldName.AFTER).schema();
+        Struct after = value.getStruct(Envelope.FieldName.AFTER);
+        return runtimeConverter.convert(record, after, afterSchema);
+    }
+
+    private SeaTunnelRow extractBeforeRow(
+            SeaTunnelRowDebeziumDeserializationConverters runtimeConverter,
+            SourceRecord record,
+            Struct value,
+            Schema valueSchema)
+            throws Exception {
+
+        Schema beforeSchema = valueSchema.field(Envelope.FieldName.BEFORE).schema();
+        Struct before = value.getStruct(Envelope.FieldName.BEFORE);
+        return runtimeConverter.convert(record, before, beforeSchema);
+    }
+
+    @Override
+    public List<CatalogTable> getProducedType() {
+        return tables;
+    }
+
+    @Override
+    public SchemaChangeResolver getSchemaChangeResolver() {
+        return schemaChangeResolver;
+    }
+
+    @Override
+    public void restoreCheckpointProducedType(List<CatalogTable> checkpointDataType) {
+        // If checkpointDataType is null, it indicates that DDL changes are not supported.
+        // Therefore, we need to use the latest table structure to ensure that data from newly added
+        // columns can be parsed correctly.
+        if (schemaChangeResolver == null) {
+            return;
+        }
+
+        Map<TablePath, CatalogTable> latestTableMap =
+                this.tables.stream().collect(Collectors.toMap(CatalogTable::getTablePath, t -> t));
+        Map<TablePath, CatalogTable> restoreTableMap =
+                checkpointDataType.stream()
+                        .collect(Collectors.toMap(CatalogTable::getTablePath, t -> t));
+        for (TablePath tablePath : restoreTableMap.keySet()) {
+            CatalogTable latestTable = latestTableMap.get(tablePath);
+            CatalogTable restoreTable = restoreTableMap.get(tablePath);
+            if (latestTable == null) {
+                log.info("Ignore restore table[{}] has been deleted.", tablePath);
+                continue;
+            }
+
+            log.info("Table[{}] restore before: {}", tablePath, latestTable.getSeaTunnelRowType());
+            latestTableMap.put(tablePath, restoreTable);
+            log.info("Table[{}] restore after: {}", tablePath, restoreTable.getSeaTunnelRowType());
+        }
+        this.tables = new ArrayList<>(latestTableMap.values());
+        this.tableRowConverters =
+                createTableRowConverters(
+                        tables, metadataConverters, serverTimeZone, userDefinedConverterFactory);
+    }
+
+    private static Map<String, SeaTunnelRowDebeziumDeserializationConverters>
+            createTableRowConverters(
+                    List<CatalogTable> tables,
+                    MetadataConverter[] metadataConverters,
+                    ZoneId serverTimeZone,
+                    DebeziumDeserializationConverterFactory userDefinedConverterFactory) {
+        Map<String, SeaTunnelRowDebeziumDeserializationConverters> tableRowConverters =
+                new HashMap<>();
+        if (tables.size() > 1) {
+            for (CatalogTable table : tables) {
+                SeaTunnelRowDebeziumDeserializationConverters itemRowConverter =
+                        new SeaTunnelRowDebeziumDeserializationConverters(
+                                table.getSeaTunnelRowType(),
+                                metadataConverters,
+                                serverTimeZone,
+                                userDefinedConverterFactory);
+                tableRowConverters.put(table.getTablePath().toString(), itemRowConverter);
+            }
+            return tableRowConverters;
+        }
+
+        SeaTunnelRowDebeziumDeserializationConverters tableRowConverter =
+                new SeaTunnelRowDebeziumDeserializationConverters(
+                        tables.get(0).getSeaTunnelRowType(),
+                        metadataConverters,
+                        serverTimeZone,
+                        userDefinedConverterFactory);
+        tableRowConverters.put(DEFAULT_TABLE_NAME_KEY, tableRowConverter);
+        return tableRowConverters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Setter
+    @Accessors(chain = true)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Builder {
+        private List<CatalogTable> tables;
+        private MetadataConverter[] metadataConverters = new MetadataConverter[0];
+        private ZoneId serverTimeZone = ZoneId.systemDefault();
+        private DebeziumDeserializationConverterFactory userDefinedConverterFactory =
+                DebeziumDeserializationConverterFactory.DEFAULT;
+        private Map<TableId, Struct> tableIdTableChangeMap = new HashMap<>();
+        private SchemaChangeResolver schemaChangeResolver;
+
+        public SeaTunnelRowDebeziumDeserializeSchema build() {
+            return new SeaTunnelRowDebeziumDeserializeSchema(
+                    metadataConverters,
+                    tables,
+                    serverTimeZone,
+                    userDefinedConverterFactory,
+                    schemaChangeResolver,
+                    tableIdTableChangeMap);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/utils/TemporalConversions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/utils/TemporalConversions.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.utils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.concurrent.TimeUnit;
+
+/** Temporal conversion constants. */
+public final class TemporalConversions {
+
+    static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+    static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
+    static final long MICROSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
+    static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+    static final long NANOSECONDS_PER_MICROSECOND = TimeUnit.MICROSECONDS.toNanos(1);
+    static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+    static final long NANOSECONDS_PER_DAY = TimeUnit.DAYS.toNanos(1);
+    static final long SECONDS_PER_DAY = TimeUnit.DAYS.toSeconds(1);
+    static final long MICROSECONDS_PER_DAY = TimeUnit.DAYS.toMicros(1);
+    static final LocalDate EPOCH = LocalDate.ofEpochDay(0);
+    static final DateTimeFormatter TIME_WITH_TIMEZONE_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendPattern("HH:mm:ss")
+                    .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                    .appendPattern("[XXX][XX][X]")
+                    .toFormatter();
+
+    private TemporalConversions() {}
+
+    @SuppressWarnings("MagicNumber")
+    public static LocalDate toLocalDate(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof LocalDate) {
+            return (LocalDate) obj;
+        }
+        if (obj instanceof LocalDateTime) {
+            return ((LocalDateTime) obj).toLocalDate();
+        }
+        if (obj instanceof java.sql.Date) {
+            return ((java.sql.Date) obj).toLocalDate();
+        }
+        if (obj instanceof java.sql.Time) {
+            throw new IllegalArgumentException(
+                    "Unable to convert to LocalDate from a java.sql.Time value '" + obj + "'");
+        }
+        if (obj instanceof java.util.Date) {
+            java.util.Date date = (java.util.Date) obj;
+            return LocalDate.of(date.getYear() + 1900, date.getMonth() + 1, date.getDate());
+        }
+        if (obj instanceof Long) {
+            if ((Long) obj > ChronoField.EPOCH_DAY.range().getMaximum()) {
+                return Instant.ofEpochMilli((Long) obj)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate();
+            }
+            // Assume the value is the epoch day number
+            return LocalDate.ofEpochDay((Long) obj);
+        }
+        if (obj instanceof Integer) {
+            // Assume the value is the epoch day number
+            return LocalDate.ofEpochDay((Integer) obj);
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to LocalDate from unexpected value '"
+                        + obj
+                        + "' of type "
+                        + obj.getClass().getName());
+    }
+
+    public static LocalTime toLocalTime(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof LocalTime) {
+            return (LocalTime) obj;
+        }
+        if (obj instanceof LocalDateTime) {
+            return ((LocalDateTime) obj).toLocalTime();
+        }
+        if (obj instanceof java.sql.Date) {
+            throw new IllegalArgumentException(
+                    "Unable to convert to LocalDate from a java.sql.Date value '" + obj + "'");
+        }
+        if (obj instanceof java.sql.Time) {
+            java.sql.Time time = (java.sql.Time) obj;
+            long millis = (int) (time.getTime() % MILLISECONDS_PER_SECOND);
+            int nanosOfSecond = (int) (millis * NANOSECONDS_PER_MILLISECOND);
+            return LocalTime.of(
+                    time.getHours(), time.getMinutes(), time.getSeconds(), nanosOfSecond);
+        }
+        if (obj instanceof java.sql.Timestamp) {
+            java.sql.Timestamp timestamp = (java.sql.Timestamp) obj;
+            return LocalTime.of(
+                    timestamp.getHours(),
+                    timestamp.getMinutes(),
+                    timestamp.getSeconds(),
+                    timestamp.getNanos());
+        }
+        if (obj instanceof java.util.Date) {
+            java.util.Date date = (java.util.Date) obj;
+            long millis = (int) (date.getTime() % MILLISECONDS_PER_SECOND);
+            int nanosOfSecond = (int) (millis * NANOSECONDS_PER_MILLISECOND);
+            return LocalTime.of(
+                    date.getHours(), date.getMinutes(), date.getSeconds(), nanosOfSecond);
+        }
+        if (obj instanceof Duration) {
+            Long value = ((Duration) obj).toNanos();
+            if (value >= 0 && value <= NANOSECONDS_PER_DAY) {
+                return LocalTime.ofNanoOfDay(value);
+            } else {
+                throw new IllegalArgumentException(
+                        "Time values must use number of milliseconds greater than 0 and less than 86400000000000");
+            }
+        }
+        if (obj instanceof String) {
+            // The TIMETZ column is returned as a String which we initially parse here
+            // The parsed offset-time potentially has a zone-offset from the data, shift it after to
+            // GMT.
+            final OffsetTime offsetTime =
+                    OffsetTime.parse((String) obj, TIME_WITH_TIMEZONE_FORMATTER);
+            return offsetTime.toLocalTime();
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to LocalTime from unexpected value '"
+                        + obj
+                        + "' of type "
+                        + obj.getClass().getName());
+    }
+
+    @SuppressWarnings("MagicNumber")
+    public static LocalDateTime toLocalDateTime(Object obj, ZoneId serverTimeZone) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof OffsetDateTime) {
+            return ((OffsetDateTime) obj).toLocalDateTime();
+        }
+        if (obj instanceof Instant) {
+            return ((Instant) obj).atOffset(ZoneOffset.UTC).toLocalDateTime();
+        }
+        if (obj instanceof LocalDateTime) {
+            return (LocalDateTime) obj;
+        }
+        if (obj instanceof LocalDate) {
+            LocalDate date = (LocalDate) obj;
+            return LocalDateTime.of(date, LocalTime.MIDNIGHT);
+        }
+        if (obj instanceof LocalTime) {
+            LocalTime time = (LocalTime) obj;
+            return LocalDateTime.of(EPOCH, time);
+        }
+        if (obj instanceof java.sql.Date) {
+            java.sql.Date sqlDate = (java.sql.Date) obj;
+            LocalDate date = sqlDate.toLocalDate();
+            return LocalDateTime.of(date, LocalTime.MIDNIGHT);
+        }
+        if (obj instanceof java.sql.Time) {
+            LocalTime localTime = toLocalTime(obj);
+            return LocalDateTime.of(EPOCH, localTime);
+        }
+        if (obj instanceof java.sql.Timestamp) {
+            java.sql.Timestamp timestamp = (java.sql.Timestamp) obj;
+            return LocalDateTime.of(
+                    timestamp.getYear() + 1900,
+                    timestamp.getMonth() + 1,
+                    timestamp.getDate(),
+                    timestamp.getHours(),
+                    timestamp.getMinutes(),
+                    timestamp.getSeconds(),
+                    timestamp.getNanos());
+        }
+        if (obj instanceof java.util.Date) {
+            java.util.Date date = (java.util.Date) obj;
+            long millis = (int) (date.getTime() % MILLISECONDS_PER_SECOND);
+            if (millis < 0) {
+                millis = MILLISECONDS_PER_SECOND + millis;
+            }
+            int nanosOfSecond = (int) (millis * NANOSECONDS_PER_MILLISECOND);
+            return LocalDateTime.of(
+                    date.getYear() + 1900,
+                    date.getMonth() + 1,
+                    date.getDate(),
+                    date.getHours(),
+                    date.getMinutes(),
+                    date.getSeconds(),
+                    nanosOfSecond);
+        }
+        if (obj instanceof String) {
+            String str = (String) obj;
+            // TIMESTAMP type is encoded in string type
+            Instant instant = Instant.parse(str);
+            return LocalDateTime.ofInstant(instant, serverTimeZone);
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to LocalDateTime from unexpected value '"
+                        + obj
+                        + "' of type "
+                        + obj.getClass().getName());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jdbc.source;
+
+import org.apache.seatunnel.api.table.catalog.ConstraintKey;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.relational.connection.JdbcConnectionPoolFactory;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.AbstractJdbcSourceChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class JdbcSourceChunkSplitterTest {
+
+    @Test
+    public void splitColumnTest() throws SQLException {
+        TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
+                new TestJdbcSourceChunkSplitter(null, new TestSourceDialect());
+        Column splitColumn =
+                testJdbcSourceChunkSplitter.getSplitColumn(
+                        null, new TestSourceDialect(), new TableId("", "", ""));
+        Assertions.assertEquals(splitColumn.typeName(), "tinyint");
+    }
+
+    private class TestJdbcSourceChunkSplitter extends AbstractJdbcSourceChunkSplitter {
+
+        public TestJdbcSourceChunkSplitter(
+                JdbcSourceConfig sourceConfig, JdbcDataSourceDialect dialect) {
+            super(sourceConfig, dialect);
+        }
+
+        @Override
+        public Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+                throws SQLException {
+            return new Object[0];
+        }
+
+        @Override
+        public Object queryMin(
+                JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Object[] sampleDataFromColumn(
+                JdbcConnection jdbc, TableId tableId, String columnName, int samplingRate)
+                throws Exception {
+            return new Object[0];
+        }
+
+        @Override
+        public Object queryNextChunkMax(
+                JdbcConnection jdbc,
+                TableId tableId,
+                String columnName,
+                int chunkSize,
+                Object includedLowerBound)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public String buildSplitScanQuery(
+                Table table,
+                SeaTunnelRowType splitKeyType,
+                boolean isFirstSplit,
+                boolean isLastSplit) {
+            return null;
+        }
+
+        @Override
+        public SeaTunnelDataType<?> fromDbzColumn(Column splitColumn) {
+            String typeName = splitColumn.typeName();
+            switch (typeName) {
+                case "varchar":
+                    return BasicType.STRING_TYPE;
+                case "tinyint":
+                    return BasicType.BYTE_TYPE;
+                case "smallint":
+                    return BasicType.SHORT_TYPE;
+                case "int":
+                    return BasicType.INT_TYPE;
+                case "bigint":
+                    return BasicType.LONG_TYPE;
+                case "decimal":
+                    return new DecimalType(20, 0);
+                default:
+                    return BasicType.STRING_TYPE;
+            }
+        }
+
+        @Override
+        public Column getSplitColumn(
+                JdbcConnection jdbc, JdbcDataSourceDialect dialect, TableId tableId)
+                throws SQLException {
+            return super.getSplitColumn(jdbc, dialect, tableId);
+        }
+    }
+
+    private class TestSourceDialect implements JdbcDataSourceDialect {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+            return false;
+        }
+
+        @Override
+        public ChunkSplitter createChunkSplitter(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public JdbcConnectionPoolFactory getPooledDataSourceFactory() {
+            return null;
+        }
+
+        @Override
+        public TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
+
+            Table table =
+                    Table.editor()
+                            .tableId(tableId)
+                            .addColumns(
+                                    Column.editor()
+                                            .name("string_col")
+                                            .jdbcType(Types.VARCHAR)
+                                            .type("varchar")
+                                            .create(),
+                                    Column.editor()
+                                            .name("smallint")
+                                            .jdbcType(Types.SMALLINT)
+                                            .type("smallint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("int")
+                                            .jdbcType(Types.INTEGER)
+                                            .type("int")
+                                            .create(),
+                                    Column.editor()
+                                            .name("decimal")
+                                            .jdbcType(Types.DECIMAL)
+                                            .type("decimal")
+                                            .create(),
+                                    Column.editor()
+                                            .name("tinyint_col")
+                                            .jdbcType(Types.TINYINT)
+                                            .type("tinyint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("bigint_col")
+                                            .jdbcType(Types.BIGINT)
+                                            .type("bigint")
+                                            .create())
+                            .create();
+            return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+        }
+
+        @Override
+        public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
+            return null;
+        }
+
+        @Override
+        public JdbcSourceFetchTaskContext createFetchTaskContext(
+                SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
+            return null;
+        }
+
+        @Override
+        public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            return Optional.of(
+                    PrimaryKey.of(
+                            "pkName",
+                            Arrays.asList(
+                                    "string_col",
+                                    "smallint",
+                                    "int",
+                                    "decimal",
+                                    "tinyint_col",
+                                    "bigint_col")));
+        }
+
+        @Override
+        public List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            return new ArrayList<ConstraintKey>();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/HybridSplitAssignerTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/HybridSplitAssignerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.HybridPendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.SnapshotPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class HybridSplitAssignerTest {
+    @Test
+    public void testCompletedSnapshotPhase() {
+        Map<String, SnapshotSplit> assignedSplits = createAssignedSplits();
+        Map<String, SnapshotSplitWatermark> splitCompletedOffsets = createSplitCompletedOffsets();
+        SnapshotPhaseState snapshotPhaseState =
+                new SnapshotPhaseState(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        assignedSplits,
+                        splitCompletedOffsets,
+                        true,
+                        Collections.emptyList(),
+                        false,
+                        false);
+        HybridPendingSplitsState checkpointState =
+                new HybridPendingSplitsState(snapshotPhaseState, null);
+        SplitAssigner.Context context =
+                new SplitAssigner.Context<>(
+                        null,
+                        Collections.emptySet(),
+                        checkpointState.getSnapshotPhaseState().getAssignedSplits(),
+                        checkpointState.getSnapshotPhaseState().getSplitCompletedOffsets());
+        HybridSplitAssigner splitAssigner =
+                new HybridSplitAssigner<>(context, 1, 1, checkpointState, null, null);
+        splitAssigner.getIncrementalSplitAssigner().setSplitAssigned(true);
+
+        Assertions.assertFalse(
+                splitAssigner.completedSnapshotPhase(Arrays.asList(TableId.parse("db1.table1"))));
+        Assertions.assertFalse(
+                splitAssigner.getSnapshotSplitAssigner().getAssignedSplits().isEmpty());
+        Assertions.assertFalse(
+                splitAssigner.getSnapshotSplitAssigner().getSplitCompletedOffsets().isEmpty());
+        Assertions.assertFalse(context.getAssignedSnapshotSplit().isEmpty());
+        Assertions.assertFalse(context.getSplitCompletedOffsets().isEmpty());
+
+        Assertions.assertTrue(
+                splitAssigner.completedSnapshotPhase(Arrays.asList(TableId.parse("db1.table2"))));
+        Assertions.assertTrue(
+                splitAssigner.getSnapshotSplitAssigner().getAssignedSplits().isEmpty());
+        Assertions.assertTrue(
+                splitAssigner.getSnapshotSplitAssigner().getSplitCompletedOffsets().isEmpty());
+        Assertions.assertTrue(context.getAssignedSnapshotSplit().isEmpty());
+        Assertions.assertTrue(context.getSplitCompletedOffsets().isEmpty());
+    }
+
+    private static Map<String, SnapshotSplit> createAssignedSplits() {
+        return Stream.of(
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table1.1",
+                                new SnapshotSplit(
+                                        "db1.table1.1",
+                                        TableId.parse("db1.table1"),
+                                        null,
+                                        null,
+                                        null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table1.2",
+                                new SnapshotSplit(
+                                        "db1.table1.2",
+                                        TableId.parse("db1.table1"),
+                                        null,
+                                        null,
+                                        null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table2.1",
+                                new SnapshotSplit(
+                                        "db1.table2.1",
+                                        TableId.parse("db1.table2"),
+                                        null,
+                                        null,
+                                        null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table2.2",
+                                new SnapshotSplit(
+                                        "db1.table2.2",
+                                        TableId.parse("db1.table2"),
+                                        null,
+                                        null,
+                                        null)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map<String, SnapshotSplitWatermark> createSplitCompletedOffsets() {
+        return Stream.of(
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table1.1", new SnapshotSplitWatermark(null, null, null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table1.2", new SnapshotSplitWatermark(null, null, null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table2.1", new SnapshotSplitWatermark(null, null, null)),
+                        new AbstractMap.SimpleEntry<>(
+                                "db1.table2.2", new SnapshotSplitWatermark(null, null, null)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitterTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractJdbcSourceChunkSplitterTest {
+
+    @Test
+    public void testEfficientShardingThroughSampling() throws NoSuchMethodException {
+
+        UtJdbcSourceChunkSplitter utJdbcSourceChunkSplitter = new UtJdbcSourceChunkSplitter();
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1}, 1000, 2),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1}, 1000, 1),
+                Arrays.asList(ChunkRange.of(null, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1}, 1000, 10),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2}, 1000, 10),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, 2), ChunkRange.of(2, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2}, 1000, 1),
+                Arrays.asList(ChunkRange.of(null, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2}, 1000, 2),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1}, 1000, 1),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1}, 1000, 2),
+                Arrays.asList(ChunkRange.of(null, 1), ChunkRange.of(1, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3}, 1000, 2),
+                Arrays.asList(ChunkRange.of(null, 2), ChunkRange.of(2, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3}, 1000, 1),
+                Arrays.asList(ChunkRange.of(null, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3}, 1000, 3),
+                Arrays.asList(
+                        ChunkRange.of(null, 1),
+                        ChunkRange.of(1, 2),
+                        ChunkRange.of(2, 3),
+                        ChunkRange.of(3, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5}, 1000, 3),
+                Arrays.asList(ChunkRange.of(null, 2), ChunkRange.of(2, 4), ChunkRange.of(4, null)));
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5}, 1000, 2),
+                Arrays.asList(ChunkRange.of(null, 3), ChunkRange.of(3, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5, 6}, 1000, 1),
+                Arrays.asList(ChunkRange.of(null, null)));
+
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5, 6}, 1000, 3),
+                Arrays.asList(ChunkRange.of(null, 3), ChunkRange.of(3, 5), ChunkRange.of(5, null)));
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5, 6}, 1000, 4),
+                Arrays.asList(
+                        ChunkRange.of(null, 2),
+                        ChunkRange.of(2, 4),
+                        ChunkRange.of(4, 5),
+                        ChunkRange.of(5, null)));
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5, 6}, 1000, 5),
+                Arrays.asList(
+                        ChunkRange.of(null, 2),
+                        ChunkRange.of(2, 3),
+                        ChunkRange.of(3, 4),
+                        ChunkRange.of(4, 5),
+                        ChunkRange.of(5, null)));
+        check(
+                utJdbcSourceChunkSplitter.efficientShardingThroughSampling(
+                        null, new Object[] {1, 2, 3, 4, 5, 6}, 1000, 6),
+                Arrays.asList(
+                        ChunkRange.of(null, 1),
+                        ChunkRange.of(1, 2),
+                        ChunkRange.of(2, 3),
+                        ChunkRange.of(3, 4),
+                        ChunkRange.of(4, 5),
+                        ChunkRange.of(5, 6),
+                        ChunkRange.of(6, null)));
+    }
+
+    private void check(List<ChunkRange> a, List<ChunkRange> b) {
+        checkRule(b);
+        assertEquals(a, b);
+    }
+
+    private void checkRule(List<ChunkRange> a) {
+        for (int i = 0; i < a.size(); i++) {
+            if (i == 0) {
+                assertNull(a.get(i).getChunkStart());
+            }
+            if (i == a.size() - 1) {
+                assertNull(a.get(i).getChunkEnd());
+            }
+            // current chunk start should be equal to previous chunk end
+            if (i > 0) {
+                assertEquals(a.get(i - 1).getChunkEnd(), a.get(i).getChunkStart());
+            }
+            if (i > 0 && i < a.size() - 1) {
+                // current chunk end should be greater than current chunk start
+                assertTrue((int) a.get(i).getChunkEnd() > (int) a.get(i).getChunkStart());
+            }
+        }
+    }
+
+    public static class UtJdbcSourceChunkSplitter extends AbstractJdbcSourceChunkSplitter {
+
+        public UtJdbcSourceChunkSplitter() {
+            super(null, null);
+        }
+
+        @Override
+        public Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+                throws SQLException {
+            return new Object[0];
+        }
+
+        @Override
+        public Object queryMin(
+                JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Object[] sampleDataFromColumn(
+                JdbcConnection jdbc, TableId tableId, String columnName, int samplingRate)
+                throws Exception {
+            return new Object[0];
+        }
+
+        @Override
+        public Object queryNextChunkMax(
+                JdbcConnection jdbc,
+                TableId tableId,
+                String columnName,
+                int chunkSize,
+                Object includedLowerBound)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public String buildSplitScanQuery(
+                Table table,
+                SeaTunnelRowType splitKeyType,
+                boolean isFirstSplit,
+                boolean isLastSplit) {
+            return null;
+        }
+
+        @Override
+        public SeaTunnelDataType<?> fromDbzColumn(Column splitColumn) {
+            return null;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcherTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcherTest.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader.external;
+
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.data.Envelope;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.debezium.config.CommonConnectorConfig.TRANSACTION_TOPIC;
+import static io.debezium.connector.AbstractSourceInfo.DEBEZIUM_CONNECTOR_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class IncrementalSourceStreamFetcherTest {
+    private static final Configuration dezConf =
+            JdbcConfiguration.create()
+                    .with(Heartbeat.HEARTBEAT_INTERVAL, 1)
+                    .with(TRANSACTION_TOPIC, "test")
+                    .build();
+    private static final String UNKNOWN_SCHEMA_KEY = "UNKNOWN";
+
+    @Test
+    public void testSplitSchemaChangeStream() throws Exception {
+        IncrementalSourceStreamFetcher fetcher = createFetcher();
+
+        List<DataChangeEvent> inputEvents = new ArrayList<>();
+        List<SourceRecords> records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        Iterator<SourceRecords> outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(1, records.size());
+        Assertions.assertEquals(2, records.get(0).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(1)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(2, records.size());
+        Assertions.assertEquals(1, records.get(0).getSourceRecordList().size());
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertEquals(3, records.get(1).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(2)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeUnknownEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(2, records.size());
+        Assertions.assertEquals(3, records.get(0).getSourceRecordList().size());
+        Assertions.assertEquals(3, records.get(1).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(2)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(2)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeUnknownEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(3, records.size());
+        Assertions.assertEquals(1, records.get(0).getSourceRecordList().size());
+        Assertions.assertEquals(3, records.get(1).getSourceRecordList().size());
+        Assertions.assertEquals(2, records.get(2).getSourceRecordList().size());
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(2)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(2).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(2).getSourceRecordList().get(1)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(3, records.size());
+        Assertions.assertEquals(2, records.get(0).getSourceRecordList().size());
+        Assertions.assertEquals(3, records.get(1).getSourceRecordList().size());
+        Assertions.assertEquals(1, records.get(2).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(2)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(2).getSourceRecordList().get(0)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(4, records.size());
+        Assertions.assertEquals(2, records.get(0).getSourceRecordList().size());
+        Assertions.assertEquals(2, records.get(1).getSourceRecordList().size());
+        Assertions.assertEquals(2, records.get(2).getSourceRecordList().size());
+        Assertions.assertEquals(2, records.get(3).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(2).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(2).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(3).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(3).getSourceRecordList().get(1)));
+
+        inputEvents = new ArrayList<>();
+        records = new ArrayList<>();
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createSchemaChangeEvent()));
+        inputEvents.add(new DataChangeEvent(createDataEvent()));
+        inputEvents.add(new DataChangeEvent(createHeartbeatEvent()));
+        outputEvents = fetcher.splitSchemaChangeStream(inputEvents);
+        outputEvents.forEachRemaining(records::add);
+
+        Assertions.assertEquals(11, records.size());
+        Assertions.assertEquals(3, records.get(0).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(0).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(0).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(0).getSourceRecordList().get(2)));
+        Assertions.assertEquals(2, records.get(1).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(1).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(1).getSourceRecordList().get(1)));
+        Assertions.assertEquals(2, records.get(2).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(2).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(2).getSourceRecordList().get(1)));
+        Assertions.assertEquals(2, records.get(3).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(3).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(3).getSourceRecordList().get(1)));
+        Assertions.assertEquals(3, records.get(4).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(4).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(4).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(4).getSourceRecordList().get(2)));
+        Assertions.assertEquals(2, records.get(5).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(5).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(5).getSourceRecordList().get(1)));
+        Assertions.assertEquals(4, records.get(6).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(6).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(6).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(6).getSourceRecordList().get(2)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(6).getSourceRecordList().get(3)));
+        Assertions.assertEquals(3, records.get(7).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(7).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(7).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(7).getSourceRecordList().get(2)));
+        Assertions.assertEquals(3, records.get(8).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(8).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(8).getSourceRecordList().get(1)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeBeforeWatermarkEvent(
+                        records.get(8).getSourceRecordList().get(2)));
+        Assertions.assertEquals(2, records.get(9).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isSchemaChangeEvent(records.get(9).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                WatermarkEvent.isSchemaChangeAfterWatermarkEvent(
+                        records.get(9).getSourceRecordList().get(1)));
+        Assertions.assertEquals(2, records.get(10).getSourceRecordList().size());
+        Assertions.assertTrue(
+                SourceRecordUtils.isDataChangeRecord(records.get(10).getSourceRecordList().get(0)));
+        Assertions.assertTrue(
+                SourceRecordUtils.isHeartbeatRecord(records.get(10).getSourceRecordList().get(1)));
+    }
+
+    static SourceRecord createSchemaChangeEvent() {
+        return createSchemaChangeEvent("SCHEMA_CHANGE_TOPIC");
+    }
+
+    static SourceRecord createSchemaChangeUnknownEvent() {
+        return createSchemaChangeEvent(UNKNOWN_SCHEMA_KEY);
+    }
+
+    static SourceRecord createSchemaChangeEvent(String topic) {
+        Schema keySchema =
+                SchemaBuilder.struct().name("io.debezium.connector.mysql.SchemaChangeKey").build();
+        Schema valueKeySchema =
+                SchemaBuilder.struct()
+                        .name("io.debezium.connector.mysql.Source")
+                        .field(DEBEZIUM_CONNECTOR_KEY, Schema.STRING_SCHEMA)
+                        .build();
+        Struct valueValues = new Struct(valueKeySchema);
+        valueValues.put(DEBEZIUM_CONNECTOR_KEY, "mysql");
+
+        Schema valueSchema =
+                SchemaBuilder.struct()
+                        .field(Envelope.FieldName.SOURCE, valueKeySchema)
+                        .name("")
+                        .build();
+        Struct value = new Struct(valueSchema);
+        value.put(valueSchema.field(Envelope.FieldName.SOURCE), valueValues);
+        SourceRecord record =
+                new SourceRecord(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        topic,
+                        keySchema,
+                        null,
+                        valueSchema,
+                        value);
+        Assertions.assertTrue(SourceRecordUtils.isSchemaChangeEvent(record));
+        return record;
+    }
+
+    static SourceRecord createDataEvent() {
+        Schema valueSchema =
+                SchemaBuilder.struct()
+                        .field(Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA)
+                        .build();
+        Struct value = new Struct(valueSchema);
+        value.put(valueSchema.field(Envelope.FieldName.OPERATION), "c");
+        SourceRecord record =
+                new SourceRecord(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        null,
+                        null,
+                        null,
+                        valueSchema,
+                        value);
+        Assertions.assertTrue(SourceRecordUtils.isDataChangeRecord(record));
+        return record;
+    }
+
+    static SourceRecord createHeartbeatEvent() throws InterruptedException {
+        TestConnectorConfig testConnectorConfig = new TestConnectorConfig(dezConf, "test", 1000);
+        HeartbeatFactory<TableId> heartbeatFactory =
+                new HeartbeatFactory<>(
+                        testConnectorConfig,
+                        TopicSelector.defaultSelector(
+                                testConnectorConfig, (id, prefix, delimiter) -> "test"),
+                        SchemaNameAdjuster.create());
+        Heartbeat heartbeat = heartbeatFactory.createHeartbeat();
+        AtomicReference<SourceRecord> eventRef = new AtomicReference<>();
+        heartbeat.forcedBeat(
+                Collections.singletonMap("heartbeat", "heartbeat"),
+                Collections.singletonMap("heartbeat", "heartbeat"),
+                sourceRecord -> eventRef.set(sourceRecord));
+        return eventRef.get();
+    }
+
+    static IncrementalSourceStreamFetcher createFetcher() {
+        SchemaChangeResolver schemaChangeResolver = mock(SchemaChangeResolver.class);
+        when(schemaChangeResolver.support(any()))
+                .thenAnswer(
+                        (Answer<Boolean>)
+                                invocationOnMock -> {
+                                    SourceRecord record = invocationOnMock.getArgument(0);
+                                    return record.topic() == null
+                                            || !record.topic().equalsIgnoreCase(UNKNOWN_SCHEMA_KEY);
+                                });
+        IncrementalSourceStreamFetcher fetcher =
+                new IncrementalSourceStreamFetcher(null, 0, schemaChangeResolver);
+        IncrementalSourceStreamFetcher spy = spy(fetcher);
+        doReturn(true).when(spy).shouldEmit(any());
+        return spy;
+    }
+
+    public static class TestConnectorConfig extends CommonConnectorConfig {
+
+        protected TestConnectorConfig(
+                Configuration config, String logicalName, int defaultSnapshotFetchSize) {
+            super(config, logicalName, defaultSnapshotFetchSize);
+        }
+
+        @Override
+        public String getContextName() {
+            return null;
+        }
+
+        @Override
+        public String getConnectorName() {
+            return null;
+        }
+
+        @Override
+        protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+            return null;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/IncrementalSplitStateTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/split/state/IncrementalSplitStateTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.split.state;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.CompletedSnapshotSplitInfo;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IncrementalSplitStateTest {
+
+    @Test
+    public void testMarkEnterPureIncrementPhaseIfNeed() {
+        Offset startupOffset = new TestOffset(100);
+        List<CompletedSnapshotSplitInfo> snapshotSplits = Collections.emptyList();
+        IncrementalSplit split = createIncrementalSplit(startupOffset, snapshotSplits);
+        IncrementalSplitState splitState = new IncrementalSplitState(split);
+        Assertions.assertNull(splitState.getMaxSnapshotSplitsHighWatermark());
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(null));
+
+        startupOffset = new TestOffset(100);
+        snapshotSplits =
+                Stream.of(
+                                createCompletedSnapshotSplitInfo(
+                                        "test1", new TestOffset(100), new TestOffset(100)),
+                                createCompletedSnapshotSplitInfo(
+                                        "test2", new TestOffset(100), new TestOffset(100)))
+                        .collect(Collectors.toList());
+        split = createIncrementalSplit(startupOffset, snapshotSplits);
+        splitState = new IncrementalSplitState(split);
+        Assertions.assertEquals(startupOffset, splitState.getMaxSnapshotSplitsHighWatermark());
+        Assertions.assertFalse(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(99)));
+        Assertions.assertFalse(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(snapshotSplits.isEmpty());
+        Assertions.assertTrue(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(100)));
+        Assertions.assertTrue(snapshotSplits.isEmpty());
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(100)));
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(101)));
+
+        startupOffset = new TestOffset(100);
+        snapshotSplits =
+                Stream.of(
+                                createCompletedSnapshotSplitInfo(
+                                        "test1", new TestOffset(1), new TestOffset(50)),
+                                createCompletedSnapshotSplitInfo(
+                                        "test2", new TestOffset(50), new TestOffset(200)))
+                        .collect(Collectors.toList());
+        split = createIncrementalSplit(startupOffset, snapshotSplits);
+        splitState = new IncrementalSplitState(split);
+        Assertions.assertEquals(
+                new TestOffset(200), splitState.getMaxSnapshotSplitsHighWatermark());
+        Assertions.assertFalse(splitState.isEnterPureIncrementPhase());
+        Assertions.assertTrue(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(201)));
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+        Assertions.assertTrue(snapshotSplits.isEmpty());
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(200)));
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(201)));
+        Assertions.assertFalse(splitState.markEnterPureIncrementPhaseIfNeed(new TestOffset(202)));
+    }
+
+    @Test
+    public void testAutoEnterPureIncrementPhaseIfAllowed() {
+        Offset startupOffset = new TestOffset(100);
+        List<CompletedSnapshotSplitInfo> snapshotSplits = Collections.emptyList();
+        IncrementalSplit split = createIncrementalSplit(startupOffset, snapshotSplits);
+        IncrementalSplitState splitState = new IncrementalSplitState(split);
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.autoEnterPureIncrementPhaseIfAllowed());
+
+        startupOffset = new TestOffset(100);
+        snapshotSplits =
+                Stream.of(
+                                createCompletedSnapshotSplitInfo(
+                                        "test1", new TestOffset(100), new TestOffset(100)),
+                                createCompletedSnapshotSplitInfo(
+                                        "test2", new TestOffset(100), new TestOffset(100)))
+                        .collect(Collectors.toList());
+        split = createIncrementalSplit(startupOffset, snapshotSplits);
+        splitState = new IncrementalSplitState(split);
+
+        Assertions.assertFalse(splitState.isEnterPureIncrementPhase());
+        Assertions.assertTrue(splitState.autoEnterPureIncrementPhaseIfAllowed());
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.autoEnterPureIncrementPhaseIfAllowed());
+        Assertions.assertTrue(splitState.isEnterPureIncrementPhase());
+
+        startupOffset = new TestOffset(100);
+        snapshotSplits =
+                Stream.of(
+                                createCompletedSnapshotSplitInfo(
+                                        "test1", new TestOffset(100), new TestOffset(100)),
+                                createCompletedSnapshotSplitInfo(
+                                        "test2", new TestOffset(100), new TestOffset(101)))
+                        .collect(Collectors.toList());
+        split = createIncrementalSplit(startupOffset, snapshotSplits);
+        splitState = new IncrementalSplitState(split);
+        Assertions.assertFalse(splitState.isEnterPureIncrementPhase());
+        Assertions.assertFalse(splitState.autoEnterPureIncrementPhaseIfAllowed());
+    }
+
+    private static IncrementalSplit createIncrementalSplit(
+            Offset startupOffset, List<CompletedSnapshotSplitInfo> snapshotSplits) {
+        return new IncrementalSplit(
+                "test",
+                Arrays.asList(new TableId("db", "schema", "table")),
+                startupOffset,
+                null,
+                snapshotSplits,
+                (List<CatalogTable>) null,
+                Collections.emptyMap());
+    }
+
+    private static CompletedSnapshotSplitInfo createCompletedSnapshotSplitInfo(
+            String splitId, Offset lowWatermark, Offset highWatermark) {
+        return new CompletedSnapshotSplitInfo(
+                splitId,
+                new TableId("db", "schema", "table"),
+                null,
+                null,
+                null,
+                new SnapshotSplitWatermark(null, lowWatermark, highWatermark));
+    }
+
+    @ToString
+    @AllArgsConstructor
+    static class TestOffset extends Offset {
+        private int offset;
+
+        @Override
+        public int compareTo(Offset o) {
+            return Integer.compare(offset, ((TestOffset) o).offset);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof TestOffset && offset == ((TestOffset) o).offset;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/utils/MessageDelayedEventLimiterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/utils/MessageDelayedEventLimiterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class MessageDelayedEventLimiterTest {
+
+    @Test
+    public void testAcquire() throws InterruptedException {
+        double permitsPerSecond = 0.5;
+        Duration delayThreshold = Duration.ofMillis(1000);
+        MessageDelayedEventLimiter delayedEventLimiter =
+                new MessageDelayedEventLimiter(delayThreshold, permitsPerSecond);
+
+        long endTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long actualAcquiredCount = 0;
+        while (System.currentTimeMillis() < endTime) {
+            boolean acquired =
+                    delayedEventLimiter.acquire(
+                            System.currentTimeMillis() - (delayThreshold.toMillis() * 10));
+            if (acquired) {
+                actualAcquiredCount++;
+            }
+            Thread.sleep(1);
+        }
+        long expectedAcquiredCount = (long) (TimeUnit.SECONDS.toSeconds(10) * permitsPerSecond);
+
+        Assertions.assertTrue(expectedAcquiredCount >= actualAcquiredCount);
+    }
+
+    @Test
+    public void testNoAcquire() throws InterruptedException {
+        double permitsPerSecond = 0.5;
+        Duration delayThreshold = Duration.ofMillis(1000);
+        MessageDelayedEventLimiter delayedEventLimiter =
+                new MessageDelayedEventLimiter(delayThreshold, permitsPerSecond);
+
+        long endTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long actualAcquiredCount = 0;
+        while (System.currentTimeMillis() < endTime) {
+            boolean acquired = delayedEventLimiter.acquire(System.currentTimeMillis());
+            if (acquired) {
+                actualAcquiredCount++;
+            }
+            Thread.sleep(1);
+        }
+
+        Assertions.assertTrue(actualAcquiredCount == 0);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/debezium/row/DebeziumJsonDeserializeSchemaTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/debezium/row/DebeziumJsonDeserializeSchemaTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.row;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DebeziumJsonDeserializeSchemaTest {
+    @Test
+    void deserializeNonHeartbeatRecord() throws Exception {
+        Map<String, String> debeziumConfig = Collections.EMPTY_MAP;
+        DebeziumJsonDeserializeSchema schema = new DebeziumJsonDeserializeSchema(debeziumConfig);
+
+        // Create a schema for the record
+        SchemaBuilder schemaBuilder =
+                SchemaBuilder.struct()
+                        .name("test")
+                        .field("field", SchemaBuilder.string().optional().build());
+        Struct struct = new Struct(schemaBuilder.build()).put("field", "value");
+        SourceRecord record =
+                new SourceRecord(
+                        null,
+                        null,
+                        "test",
+                        schemaBuilder.build(),
+                        struct,
+                        schemaBuilder.build(),
+                        struct);
+
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        schema.deserialize(record, collector);
+
+        verify(collector, times(1)).collect(any(SeaTunnelRow.class));
+    }
+
+    @Test
+    void skipHeartbeatRecord() throws Exception {
+        Map<String, String> debeziumConfig = Collections.EMPTY_MAP;
+        DebeziumJsonDeserializeSchema schema = new DebeziumJsonDeserializeSchema(debeziumConfig);
+
+        // Create a schema for the record
+        SchemaBuilder schemaBuilder =
+                SchemaBuilder.struct()
+                        .name("io.debezium.connector.common.Heartbeat")
+                        .field("field", SchemaBuilder.string().optional().build());
+        Struct struct = new Struct(schemaBuilder.build()).put("field", "value");
+        SourceRecord record =
+                new SourceRecord(
+                        null,
+                        null,
+                        "test",
+                        schemaBuilder.build(),
+                        struct,
+                        schemaBuilder.build(),
+                        struct);
+
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        schema.deserialize(record, collector);
+
+        verify(collector, times(0)).collect(any(SeaTunnelRow.class));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializationConvertersTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializationConvertersTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.debezium.row;
+
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverter;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverterFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.MetadataConverter;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.data.geometry.Geography;
+import io.debezium.data.geometry.Geometry;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class SeaTunnelRowDebeziumDeserializationConvertersTest {
+
+    @Test
+    void testDefaultValueNotUsed() throws Exception {
+        SeaTunnelRowDebeziumDeserializationConverters converters =
+                new SeaTunnelRowDebeziumDeserializationConverters(
+                        new SeaTunnelRowType(
+                                new String[] {"id", "name"},
+                                new SeaTunnelDataType[] {
+                                    BasicType.INT_TYPE, BasicType.STRING_TYPE
+                                }),
+                        new MetadataConverter[] {},
+                        ZoneId.systemDefault(),
+                        DebeziumDeserializationConverterFactory.DEFAULT);
+        Schema schema =
+                SchemaBuilder.struct()
+                        .field("id", SchemaBuilder.int32().build())
+                        .field("name", SchemaBuilder.string().defaultValue("UL"))
+                        .build();
+        Struct value = new Struct(schema);
+        // the value of `name` is null, so do not put value for it
+        value.put("id", 1);
+        SourceRecord record =
+                new SourceRecord(
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        "topicName",
+                        null,
+                        SchemaBuilder.int32().build(),
+                        1,
+                        schema,
+                        value,
+                        null,
+                        new ArrayList<>());
+
+        SeaTunnelRow row = converters.convert(record, value, schema);
+        Assertions.assertEquals(row.getField(0), 1);
+        Assertions.assertNull(row.getField(1));
+    }
+
+    @Test
+    void testArrayConverter() throws Exception {
+        DebeziumDeserializationConverter converter;
+        // bool array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.BOOLEAN_ARRAY_TYPE);
+        Boolean[] booleans = new Boolean[] {false, true};
+        Assertions.assertTrue(
+                Arrays.equals(
+                        booleans, (Boolean[]) (converter.convert(Arrays.asList(booleans), null))));
+        // smallInt array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.SHORT_ARRAY_TYPE);
+        Short[] shorts = new Short[] {(short) 1, (short) 2};
+        Assertions.assertTrue(
+                Arrays.equals(shorts, (Short[]) (converter.convert(Arrays.asList(shorts), null))));
+        // int array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.INT_ARRAY_TYPE);
+        Integer[] ints = new Integer[] {1, 2};
+        Assertions.assertTrue(
+                Arrays.equals(ints, (Integer[]) (converter.convert(Arrays.asList(ints), null))));
+        // long array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.LONG_ARRAY_TYPE);
+        Long[] longs = new Long[] {1L, 2L};
+        Assertions.assertTrue(
+                Arrays.equals(longs, (Long[]) (converter.convert(Arrays.asList(longs), null))));
+        // float array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.FLOAT_ARRAY_TYPE);
+        Float[] floats = new Float[] {1.0f, 2.0f};
+        Assertions.assertTrue(
+                Arrays.equals(floats, (Float[]) (converter.convert(Arrays.asList(floats), null))));
+        // double array converter
+        converter =
+                SeaTunnelRowDebeziumDeserializationConverters.createArrayConverter(
+                        ArrayType.DOUBLE_ARRAY_TYPE);
+        Double[] doubles = new Double[] {1.0, 2.0};
+        Assertions.assertTrue(
+                Arrays.equals(
+                        doubles, (Double[]) (converter.convert(Arrays.asList(doubles), null))));
+    }
+
+    @Test
+    void testGeometryStringConversion() throws Exception {
+        SeaTunnelRowDebeziumDeserializationConverters converters =
+                new SeaTunnelRowDebeziumDeserializationConverters(
+                        new SeaTunnelRowType(
+                                new String[] {"geo"},
+                                new SeaTunnelDataType[] {BasicType.STRING_TYPE}),
+                        new MetadataConverter[] {},
+                        ZoneId.systemDefault(),
+                        DebeziumDeserializationConverterFactory.DEFAULT);
+
+        byte[] wkb = new byte[] {0x01, 0x02, (byte) 0xFF};
+        Schema geometrySchema = Geometry.builder().optional().build();
+        Schema recordSchema = SchemaBuilder.struct().field("geo", geometrySchema).build();
+
+        Struct geometryValue = Geometry.createValue(geometrySchema, wkb, 4549);
+        Struct recordValue = new Struct(recordSchema);
+        recordValue.put("geo", geometryValue);
+
+        SourceRecord record =
+                new SourceRecord(
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        "topicName",
+                        null,
+                        SchemaBuilder.int32().build(),
+                        1,
+                        recordSchema,
+                        recordValue,
+                        null,
+                        new ArrayList<>());
+
+        SeaTunnelRow row = converters.convert(record, recordValue, recordSchema);
+        Object fieldValue = row.getField(0);
+        Assertions.assertTrue(fieldValue instanceof String);
+        Assertions.assertEquals("0102FF", fieldValue);
+    }
+
+    @Test
+    void testGeographyStringConversion() throws Exception {
+        SeaTunnelRowDebeziumDeserializationConverters converters =
+                new SeaTunnelRowDebeziumDeserializationConverters(
+                        new SeaTunnelRowType(
+                                new String[] {"geo"},
+                                new SeaTunnelDataType[] {BasicType.STRING_TYPE}),
+                        new MetadataConverter[] {},
+                        ZoneId.systemDefault(),
+                        DebeziumDeserializationConverterFactory.DEFAULT);
+
+        byte[] wkb = new byte[] {0x01, 0x02, (byte) 0xFF};
+        Schema geographySchema = Geography.builder().optional().build();
+        Schema recordSchema = SchemaBuilder.struct().field("geo", geographySchema).build();
+
+        Struct geographyValue = Geometry.createValue(geographySchema, wkb, 4549);
+        Struct recordValue = new Struct(recordSchema);
+        recordValue.put("geo", geographyValue);
+
+        SourceRecord record =
+                new SourceRecord(
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        "topicName",
+                        null,
+                        SchemaBuilder.int32().build(),
+                        1,
+                        recordSchema,
+                        recordValue,
+                        null,
+                        new ArrayList<>());
+
+        SeaTunnelRow row = converters.convert(record, recordValue, recordSchema);
+        Object fieldValue = row.getField(0);
+        Assertions.assertTrue(fieldValue instanceof String);
+        Assertions.assertEquals("0102FF", fieldValue);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>connector-cdc</artifactId>
+        <version>2.3.11-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>connector-cdc-postgres</artifactId>
+    <name>SeaTunnel : Connectors V2 : CDC : Postgres</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>connector-jdbc</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>connector-cdc-base</artifactId>
+                <version>${project.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-postgres</artifactId>
+                <version>${debezium.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-cdc-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-connector-postgres</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-jdbc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/CustomPostgresValueConverter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/CustomPostgresValueConverter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.jdbc.TemporalPrecisionMode;
+
+import java.nio.charset.Charset;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public class CustomPostgresValueConverter extends PostgresValueConverter {
+    protected CustomPostgresValueConverter(
+            Charset databaseCharset,
+            DecimalMode decimalMode,
+            TemporalPrecisionMode temporalPrecisionMode,
+            ZoneOffset defaultOffset,
+            BigIntUnsignedMode bigIntUnsignedMode,
+            boolean includeUnknownDatatypes,
+            TypeRegistry typeRegistry,
+            PostgresConnectorConfig.HStoreHandlingMode hStoreMode,
+            CommonConnectorConfig.BinaryHandlingMode binaryMode,
+            PostgresConnectorConfig.IntervalHandlingMode intervalMode,
+            byte[] toastPlaceholder,
+            int moneyFractionDigits) {
+        super(
+                databaseCharset,
+                decimalMode,
+                temporalPrecisionMode,
+                defaultOffset,
+                bigIntUnsignedMode,
+                includeUnknownDatatypes,
+                typeRegistry,
+                hStoreMode,
+                binaryMode,
+                intervalMode,
+                toastPlaceholder,
+                moneyFractionDigits);
+    }
+
+    public static CustomPostgresValueConverter of(
+            PostgresConnectorConfig connectorConfig,
+            Charset databaseCharset,
+            TypeRegistry typeRegistry,
+            ZoneId zoneId) {
+        return new CustomPostgresValueConverter(
+                databaseCharset,
+                connectorConfig.getDecimalMode(),
+                connectorConfig.getTemporalPrecisionMode(),
+                zoneId.getRules().getOffset(Instant.now()),
+                null,
+                connectorConfig.includeUnknownDatatypes(),
+                typeRegistry,
+                connectorConfig.hStoreHandlingMode(),
+                connectorConfig.binaryHandlingMode(),
+                connectorConfig.intervalHandlingMode(),
+                connectorConfig.getUnavailableValuePlaceholder(),
+                connectorConfig.moneyFractionDigits());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/PostgresObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/PostgresObjectUtils.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.relational.TableId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.SQLException;
+import java.time.Duration;
+
+import static org.apache.seatunnel.connectors.seatunnel.cdc.postgres.exception.PostgresConnectorErrorCode.CREATE_REPLICATION_CONNECTION_FAILED;
+
+/**
+ * A factory for creating various Debezium objects
+ *
+ * <p>It is a hack to access package-private constructor in debezium.
+ */
+@Slf4j
+public class PostgresObjectUtils {
+
+    /** Create a new PostgresSchema and initialize the content of the schema. */
+    public static PostgresSchema newSchema(
+            PostgresConnection connection,
+            PostgresConnectorConfig config,
+            TypeRegistry typeRegistry,
+            TopicSelector<TableId> topicSelector,
+            PostgresValueConverter valueConverter)
+            throws SQLException {
+        PostgresSchema schema =
+                new PostgresSchema(
+                        config,
+                        typeRegistry,
+                        connection.getDefaultValueConverter(),
+                        topicSelector,
+                        valueConverter);
+        schema.refresh(connection, false);
+        return schema;
+    }
+
+    public static PostgresEventMetadataProvider newEventMetadataProvider() {
+        return new PostgresEventMetadataProvider();
+    }
+
+    public static PostgresTaskContext newTaskContext(
+            PostgresConnectorConfig connectorConfig,
+            PostgresSchema schema,
+            TopicSelector<TableId> topicSelector) {
+        return new PostgresTaskContext(connectorConfig, schema, topicSelector);
+    }
+
+    // modified from
+    // io.debezium.connector.postgresql.PostgresConnectorTask.createReplicationConnection.
+    // pass connectorConfig instead of maxRetries and retryDelay as parameters.
+    // - old: ReplicationConnection createReplicationConnection(PostgresTaskContext taskContext,
+    // boolean doSnapshot, int maxRetries, Duration retryDelay)
+    // - new: ReplicationConnection createReplicationConnection(PostgresTaskContext taskContext,
+    // PostgresConnection postgresConnection, boolean doSnapshot, PostgresConnectorConfig
+    // connectorConfig)
+    public static ReplicationConnection createReplicationConnection(
+            PostgresTaskContext taskContext,
+            PostgresConnection postgresConnection,
+            boolean doSnapshot,
+            PostgresConnectorConfig connectorConfig) {
+        int maxRetries = connectorConfig.maxRetries();
+        Duration retryDelay = connectorConfig.retryDelay();
+
+        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
+        short retryCount = 0;
+        while (retryCount <= maxRetries) {
+            try {
+                log.info("Creating a new replication connection for {}", taskContext);
+                return taskContext.createReplicationConnection(doSnapshot, postgresConnection);
+            } catch (SQLException ex) {
+                retryCount++;
+                if (retryCount > maxRetries) {
+                    log.error(
+                            "Too many errors connecting to server. All {} retries failed.",
+                            maxRetries);
+                    throw new ConnectException(ex);
+                }
+
+                log.warn(
+                        "Error connecting to server; will attempt retry {} of {} after {} "
+                                + "seconds. Exception message: {}",
+                        retryCount,
+                        maxRetries,
+                        retryDelay.getSeconds(),
+                        ex.getMessage());
+                try {
+                    metronome.pause();
+                } catch (InterruptedException e) {
+                    log.warn("Connection retry sleep interrupted by exception: " + e);
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        throw new SeaTunnelRuntimeException(CREATE_REPLICATION_CONNECTION_FAILED, "" + taskContext);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.SnapshotRecord;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.time.Conversions;
+import io.debezium.util.Clock;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Copied from Debezium 1.9.8.Final
+ *
+ * <p>Line 228 ~ 241 : Modify method {@link PostgresOffsetContext.Loader#readOptionalLong} to
+ * support string type offset value.
+ */
+public class PostgresOffsetContext implements OffsetContext {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(PostgresSnapshotChangeEventSource.class);
+
+    public static final String LAST_COMPLETELY_PROCESSED_LSN_KEY = "lsn_proc";
+    public static final String LAST_COMMIT_LSN_KEY = "lsn_commit";
+
+    private final Schema sourceInfoSchema;
+    private final SourceInfo sourceInfo;
+    private boolean lastSnapshotRecord;
+    private Lsn lastCompletelyProcessedLsn;
+    private Lsn lastCommitLsn;
+    private Lsn streamingStoppingLsn = null;
+    private final TransactionContext transactionContext;
+    private final IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
+
+    private PostgresOffsetContext(
+            PostgresConnectorConfig connectorConfig,
+            Lsn lsn,
+            Lsn lastCompletelyProcessedLsn,
+            Lsn lastCommitLsn,
+            Long txId,
+            Instant time,
+            boolean snapshot,
+            boolean lastSnapshotRecord,
+            TransactionContext transactionContext,
+            IncrementalSnapshotContext<TableId> incrementalSnapshotContext) {
+        sourceInfo = new SourceInfo(connectorConfig);
+
+        this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
+        this.lastCommitLsn = lastCommitLsn;
+        sourceInfo.update(lsn, time, txId, sourceInfo.xmin(), null);
+        sourceInfo.updateLastCommit(lastCommitLsn);
+        sourceInfoSchema = sourceInfo.schema();
+
+        this.lastSnapshotRecord = lastSnapshotRecord;
+        if (this.lastSnapshotRecord) {
+            postSnapshotCompletion();
+        } else {
+            sourceInfo.setSnapshot(snapshot ? SnapshotRecord.TRUE : SnapshotRecord.FALSE);
+        }
+        this.transactionContext = transactionContext;
+        this.incrementalSnapshotContext = incrementalSnapshotContext;
+    }
+
+    @Override
+    public Map<String, ?> getOffset() {
+        Map<String, Object> result = new HashMap<>();
+        if (sourceInfo.timestamp() != null) {
+            result.put(
+                    SourceInfo.TIMESTAMP_USEC_KEY,
+                    Conversions.toEpochMicros(sourceInfo.timestamp()));
+        }
+        if (sourceInfo.txId() != null) {
+            result.put(SourceInfo.TXID_KEY, sourceInfo.txId());
+        }
+        if (sourceInfo.lsn() != null) {
+            result.put(SourceInfo.LSN_KEY, sourceInfo.lsn().asLong());
+        }
+        if (sourceInfo.xmin() != null) {
+            result.put(SourceInfo.XMIN_KEY, sourceInfo.xmin());
+        }
+        if (sourceInfo.isSnapshot()) {
+            result.put(SourceInfo.SNAPSHOT_KEY, true);
+            result.put(SourceInfo.LAST_SNAPSHOT_RECORD_KEY, lastSnapshotRecord);
+        }
+        if (lastCompletelyProcessedLsn != null) {
+            result.put(LAST_COMPLETELY_PROCESSED_LSN_KEY, lastCompletelyProcessedLsn.asLong());
+        }
+        if (lastCommitLsn != null) {
+            result.put(LAST_COMMIT_LSN_KEY, lastCommitLsn.asLong());
+        }
+        return sourceInfo.isSnapshot()
+                ? result
+                : incrementalSnapshotContext.store(transactionContext.store(result));
+    }
+
+    @Override
+    public Schema getSourceInfoSchema() {
+        return sourceInfoSchema;
+    }
+
+    @Override
+    public Struct getSourceInfo() {
+        return sourceInfo.struct();
+    }
+
+    @Override
+    public boolean isSnapshotRunning() {
+        return sourceInfo.isSnapshot();
+    }
+
+    @Override
+    public void preSnapshotStart() {
+        sourceInfo.setSnapshot(SnapshotRecord.TRUE);
+        lastSnapshotRecord = false;
+    }
+
+    @Override
+    public void preSnapshotCompletion() {
+        lastSnapshotRecord = true;
+    }
+
+    @Override
+    public void postSnapshotCompletion() {
+        sourceInfo.setSnapshot(SnapshotRecord.FALSE);
+    }
+
+    public void updateWalPosition(
+            Lsn lsn,
+            Lsn lastCompletelyProcessedLsn,
+            Instant commitTime,
+            Long txId,
+            Long xmin,
+            TableId tableId) {
+        this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
+        sourceInfo.update(lsn, commitTime, txId, xmin, tableId);
+    }
+
+    /** update wal position for lsn events that do not have an associated table or schema */
+    public void updateWalPosition(
+            Lsn lsn, Lsn lastCompletelyProcessedLsn, Instant commitTime, Long txId, Long xmin) {
+        updateWalPosition(lsn, lastCompletelyProcessedLsn, commitTime, txId, xmin, null);
+    }
+
+    public void updateCommitPosition(Lsn lsn, Lsn lastCompletelyProcessedLsn) {
+        this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
+        this.lastCommitLsn = lsn;
+        sourceInfo.updateLastCommit(lsn);
+    }
+
+    boolean hasLastKnownPosition() {
+        return sourceInfo.lsn() != null;
+    }
+
+    boolean hasCompletelyProcessedPosition() {
+        return this.lastCompletelyProcessedLsn != null;
+    }
+
+    Lsn lsn() {
+        return sourceInfo.lsn();
+    }
+
+    Lsn lastCompletelyProcessedLsn() {
+        return lastCompletelyProcessedLsn;
+    }
+
+    Lsn lastCommitLsn() {
+        return lastCommitLsn;
+    }
+
+    /**
+     * Returns the LSN that the streaming phase should stream events up to or null if a stopping
+     * point is not set. If set during the streaming phase, any event with an LSN less than the
+     * stopping LSN will be processed and once the stopping LSN is reached, the streaming phase will
+     * end. Useful for a pre-snapshot catch up streaming phase.
+     */
+    Lsn getStreamingStoppingLsn() {
+        return streamingStoppingLsn;
+    }
+
+    public void setStreamingStoppingLsn(Lsn streamingStoppingLsn) {
+        this.streamingStoppingLsn = streamingStoppingLsn;
+    }
+
+    Long xmin() {
+        return sourceInfo.xmin();
+    }
+
+    public static class Loader implements OffsetContext.Loader<PostgresOffsetContext> {
+
+        private final PostgresConnectorConfig connectorConfig;
+
+        public Loader(PostgresConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        private Long readOptionalLong(Map<String, ?> offset, String key) {
+            final Object obj = offset.get(key);
+            if (obj == null) {
+                return null;
+            }
+            if (obj instanceof Number) {
+                return ((Number) obj).longValue();
+            }
+            try {
+                return Long.parseLong(obj.toString());
+            } catch (NumberFormatException ne) {
+                return Lsn.valueOf((String) obj).asLong();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public PostgresOffsetContext load(Map<String, ?> offset) {
+            final Lsn lsn = Lsn.valueOf(readOptionalLong(offset, SourceInfo.LSN_KEY));
+            final Lsn lastCompletelyProcessedLsn =
+                    Lsn.valueOf(readOptionalLong(offset, LAST_COMPLETELY_PROCESSED_LSN_KEY));
+            Lsn lastCommitLsn = Lsn.valueOf(readOptionalLong(offset, LAST_COMMIT_LSN_KEY));
+            if (lastCommitLsn == null) {
+                lastCommitLsn = lastCompletelyProcessedLsn;
+            }
+            final Long txId = readOptionalLong(offset, SourceInfo.TXID_KEY);
+
+            final Instant useconds =
+                    Conversions.toInstantFromMicros(
+                            (Long) offset.get(SourceInfo.TIMESTAMP_USEC_KEY));
+            final boolean snapshot =
+                    (boolean)
+                            ((Map<String, Object>) offset)
+                                    .getOrDefault(SourceInfo.SNAPSHOT_KEY, Boolean.FALSE);
+            final boolean lastSnapshotRecord =
+                    (boolean)
+                            ((Map<String, Object>) offset)
+                                    .getOrDefault(
+                                            SourceInfo.LAST_SNAPSHOT_RECORD_KEY, Boolean.FALSE);
+            return new PostgresOffsetContext(
+                    connectorConfig,
+                    lsn,
+                    lastCompletelyProcessedLsn,
+                    lastCommitLsn,
+                    txId,
+                    useconds,
+                    snapshot,
+                    lastSnapshotRecord,
+                    TransactionContext.load(offset),
+                    SignalBasedIncrementalSnapshotContext.load(offset, false));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PostgresOffsetContext [sourceInfoSchema="
+                + sourceInfoSchema
+                + ", sourceInfo="
+                + sourceInfo
+                + ", lastSnapshotRecord="
+                + lastSnapshotRecord
+                + ", lastCompletelyProcessedLsn="
+                + lastCompletelyProcessedLsn
+                + ", lastCommitLsn="
+                + lastCommitLsn
+                + ", streamingStoppingLsn="
+                + streamingStoppingLsn
+                + ", transactionContext="
+                + transactionContext
+                + ", incrementalSnapshotContext="
+                + incrementalSnapshotContext
+                + "]";
+    }
+
+    public static PostgresOffsetContext initialContext(
+            PostgresConnectorConfig connectorConfig,
+            PostgresConnection jdbcConnection,
+            Clock clock) {
+        return initialContext(connectorConfig, jdbcConnection, clock, null, null);
+    }
+
+    public static PostgresOffsetContext initialContext(
+            PostgresConnectorConfig connectorConfig,
+            PostgresConnection jdbcConnection,
+            Clock clock,
+            Lsn lastCommitLsn,
+            Lsn lastCompletelyProcessedLsn) {
+        try {
+            LOGGER.info("Creating initial offset context");
+            final Lsn lsn = Lsn.valueOf(jdbcConnection.currentXLogLocation());
+            final Long txId = jdbcConnection.currentTransactionId();
+            LOGGER.info("Read xlogStart at '{}' from transaction '{}'", lsn, txId);
+            return new PostgresOffsetContext(
+                    connectorConfig,
+                    lsn,
+                    lastCompletelyProcessedLsn,
+                    lastCommitLsn,
+                    txId,
+                    clock.currentTimeAsInstant(),
+                    false,
+                    false,
+                    new TransactionContext(),
+                    new SignalBasedIncrementalSnapshotContext<>(false));
+        } catch (SQLException e) {
+            throw new ConnectException("Database processing error", e);
+        }
+    }
+
+    public OffsetState asOffsetState() {
+        return new OffsetState(
+                sourceInfo.lsn(),
+                sourceInfo.txId(),
+                sourceInfo.xmin(),
+                sourceInfo.timestamp(),
+                sourceInfo.isSnapshot());
+    }
+
+    @Override
+    public void markLastSnapshotRecord() {
+        sourceInfo.setSnapshot(SnapshotRecord.LAST);
+    }
+
+    @Override
+    public void event(DataCollectionId tableId, Instant instant) {
+        sourceInfo.update(instant, (TableId) tableId);
+    }
+
+    @Override
+    public TransactionContext getTransactionContext() {
+        return transactionContext;
+    }
+
+    @Override
+    public void incrementalSnapshotEvents() {
+        sourceInfo.setSnapshot(SnapshotRecord.INCREMENTAL);
+    }
+
+    @Override
+    public IncrementalSnapshotContext<?> getIncrementalSnapshotContext() {
+        return incrementalSnapshotContext;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -1,0 +1,494 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.PgDatabaseMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.annotation.Immutable;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.util.Collect;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Copied from Debezium 1.9.8.Final
+ *
+ * <p>Line 91 : For {@link io.debezium.connector.postgresql.TypeRegistry#SQL_TYPES} add condition
+ * <code> and t.typtypmod != 0</code>.
+ *
+ * <p>A registry of types supported by a PostgreSQL instance. Allows lookup of the types according
+ * to type name or OID.
+ */
+public class TypeRegistry {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypeRegistry.class);
+
+    public static final String TYPE_NAME_GEOGRAPHY = "geography";
+    public static final String TYPE_NAME_GEOMETRY = "geometry";
+    public static final String TYPE_NAME_CITEXT = "citext";
+    public static final String TYPE_NAME_HSTORE = "hstore";
+    public static final String TYPE_NAME_LTREE = "ltree";
+
+    public static final String TYPE_NAME_HSTORE_ARRAY = "_hstore";
+    public static final String TYPE_NAME_GEOGRAPHY_ARRAY = "_geography";
+    public static final String TYPE_NAME_GEOMETRY_ARRAY = "_geometry";
+    public static final String TYPE_NAME_CITEXT_ARRAY = "_citext";
+    public static final String TYPE_NAME_LTREE_ARRAY = "_ltree";
+
+    public static final int NO_TYPE_MODIFIER = -1;
+    public static final int UNKNOWN_LENGTH = -1;
+
+    // PostgreSQL driver reports user-defined Domain types as Types.DISTINCT
+    public static final int DOMAIN_TYPE = Types.DISTINCT;
+
+    private static final String CATEGORY_ARRAY = "A";
+    private static final String CATEGORY_ENUM = "E";
+
+    private static final String SQL_ENUM_VALUES =
+            "SELECT t.enumtypid as id, array_agg(t.enumlabel) as values "
+                    + "FROM pg_catalog.pg_enum t GROUP BY id";
+
+    private static final String SQL_TYPES =
+            "SELECT t.oid AS oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod as modifiers, t.typcategory as category, e.values as enum_values "
+                    + "FROM pg_catalog.pg_type t "
+                    + "JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
+                    + "LEFT JOIN ("
+                    + SQL_ENUM_VALUES
+                    + ") e ON (t.oid = e.id) "
+                    + "WHERE n.nspname != 'pg_toast' and t.typtypmod != 0";
+
+    private static final String SQL_NAME_LOOKUP = SQL_TYPES + " AND t.typname = ?";
+
+    private static final String SQL_OID_LOOKUP = SQL_TYPES + " AND t.oid = ?";
+
+    private static final Map<String, String> LONG_TYPE_NAMES =
+            Collections.unmodifiableMap(getLongTypeNames());
+
+    private static Map<String, String> getLongTypeNames() {
+        Map<String, String> longTypeNames = new HashMap<>();
+
+        longTypeNames.put("bigint", "int8");
+        longTypeNames.put("bit varying", "varbit");
+        longTypeNames.put("boolean", "bool");
+        longTypeNames.put("character", "bpchar");
+        longTypeNames.put("character varying", "varchar");
+        longTypeNames.put("double precision", "float8");
+        longTypeNames.put("integer", "int4");
+        longTypeNames.put("real", "float4");
+        longTypeNames.put("smallint", "int2");
+        longTypeNames.put("timestamp without time zone", "timestamp");
+        longTypeNames.put("timestamp with time zone", "timestamptz");
+        longTypeNames.put("time without time zone", "time");
+        longTypeNames.put("time with time zone", "timetz");
+
+        return longTypeNames;
+    }
+
+    private final Map<String, PostgresType> nameToType = new HashMap<>();
+    private final Map<Integer, PostgresType> oidToType = new HashMap<>();
+
+    private final PostgresConnection connection;
+    private final SqlTypeMapper sqlTypeMapper;
+
+    private int geometryOid = Integer.MIN_VALUE;
+    private int geographyOid = Integer.MIN_VALUE;
+    private int citextOid = Integer.MIN_VALUE;
+    private int hstoreOid = Integer.MIN_VALUE;
+    private int ltreeOid = Integer.MIN_VALUE;
+
+    private int hstoreArrayOid = Integer.MIN_VALUE;
+    private int geometryArrayOid = Integer.MIN_VALUE;
+    private int geographyArrayOid = Integer.MIN_VALUE;
+    private int citextArrayOid = Integer.MIN_VALUE;
+    private int ltreeArrayOid = Integer.MIN_VALUE;
+
+    public TypeRegistry(PostgresConnection connection) {
+        try {
+            this.connection = connection;
+            sqlTypeMapper = new SqlTypeMapper(this.connection);
+
+            prime();
+        } catch (SQLException e) {
+            throw new DebeziumException("Couldn't initialize type registry", e);
+        }
+    }
+
+    private void addType(PostgresType type) {
+        oidToType.put(type.getOid(), type);
+        nameToType.put(type.getName(), type);
+
+        if (TYPE_NAME_GEOMETRY.equals(type.getName())) {
+            geometryOid = type.getOid();
+        } else if (TYPE_NAME_GEOGRAPHY.equals(type.getName())) {
+            geographyOid = type.getOid();
+        } else if (TYPE_NAME_CITEXT.equals(type.getName())) {
+            citextOid = type.getOid();
+        } else if (TYPE_NAME_HSTORE.equals(type.getName())) {
+            hstoreOid = type.getOid();
+        } else if (TYPE_NAME_LTREE.equals(type.getName())) {
+            ltreeOid = type.getOid();
+        } else if (TYPE_NAME_HSTORE_ARRAY.equals(type.getName())) {
+            hstoreArrayOid = type.getOid();
+        } else if (TYPE_NAME_GEOMETRY_ARRAY.equals(type.getName())) {
+            geometryArrayOid = type.getOid();
+        } else if (TYPE_NAME_GEOGRAPHY_ARRAY.equals(type.getName())) {
+            geographyArrayOid = type.getOid();
+        } else if (TYPE_NAME_CITEXT_ARRAY.equals(type.getName())) {
+            citextArrayOid = type.getOid();
+        } else if (TYPE_NAME_LTREE_ARRAY.equals(type.getName())) {
+            ltreeArrayOid = type.getOid();
+        }
+    }
+
+    /**
+     * @param oid - PostgreSQL OID
+     * @return type associated with the given OID
+     */
+    public PostgresType get(int oid) {
+        PostgresType r = oidToType.get(oid);
+        if (r == null) {
+            r = resolveUnknownType(oid);
+            if (r == null) {
+                LOGGER.warn("Unknown OID {} requested", oid);
+                r = PostgresType.UNKNOWN;
+            }
+        }
+        return r;
+    }
+
+    /**
+     * @param name - PostgreSQL type name
+     * @return type associated with the given type name
+     */
+    public PostgresType get(String name) {
+        switch (name) {
+            case "serial":
+                name = "int4";
+                break;
+            case "smallserial":
+                name = "int2";
+                break;
+            case "bigserial":
+                name = "int8";
+                break;
+        }
+        String[] parts = name.split("\\.");
+        if (parts.length > 1) {
+            name = parts[1];
+        }
+        if (name.charAt(0) == '"') {
+            name = name.substring(1, name.length() - 1);
+        }
+        PostgresType r = nameToType.get(name);
+        if (r == null) {
+            r = resolveUnknownType(name);
+            if (r == null) {
+                LOGGER.warn("Unknown type named {} requested", name);
+                r = PostgresType.UNKNOWN;
+            }
+        }
+        return r;
+    }
+
+    /** @return OID for {@code GEOMETRY} type of this PostgreSQL instance */
+    public int geometryOid() {
+        return geometryOid;
+    }
+
+    /** @return OID for {@code GEOGRAPHY} type of this PostgreSQL instance */
+    public int geographyOid() {
+        return geographyOid;
+    }
+
+    /** @return OID for {@code CITEXT} type of this PostgreSQL instance */
+    public int citextOid() {
+        return citextOid;
+    }
+
+    /** @return OID for {@code HSTORE} type of this PostgreSQL instance */
+    public int hstoreOid() {
+        return hstoreOid;
+    }
+
+    /** @return OID for {@code LTREE} type of this PostgreSQL instance */
+    public int ltreeOid() {
+        return ltreeOid;
+    }
+
+    /** @return OID for array of {@code HSTORE} type of this PostgreSQL instance */
+    public int hstoreArrayOid() {
+        return hstoreArrayOid;
+    }
+
+    /** @return OID for array of {@code GEOMETRY} type of this PostgreSQL instance */
+    public int geometryArrayOid() {
+        return geometryArrayOid;
+    }
+
+    /** @return OID for array of {@code GEOGRAPHY} type of this PostgreSQL instance */
+    public int geographyArrayOid() {
+        return geographyArrayOid;
+    }
+
+    /** @return OID for array of {@code CITEXT} type of this PostgreSQL instance */
+    public int citextArrayOid() {
+        return citextArrayOid;
+    }
+
+    /** @return OID for array of {@code LTREE} type of this PostgreSQL instance */
+    public int ltreeArrayOid() {
+        return ltreeArrayOid;
+    }
+
+    /**
+     * Converts a type name in long (readable) format like <code>boolean</code> to s standard data
+     * type name like <code>bool</code>.
+     *
+     * @param typeName - a type name in long format
+     * @return - the type name in standardized format
+     */
+    public static String normalizeTypeName(String typeName) {
+        return LONG_TYPE_NAMES.getOrDefault(typeName, typeName);
+    }
+
+    /** Prime the {@link TypeRegistry} with all existing database types */
+    private void prime() throws SQLException {
+        try (final Statement statement = connection.connection().createStatement();
+                final ResultSet rs = statement.executeQuery(SQL_TYPES)) {
+            final List<PostgresType.Builder> delayResolvedBuilders = new ArrayList<>();
+            while (rs.next()) {
+                PostgresType.Builder builder = createTypeBuilderFromResultSet(rs);
+
+                // If the type does have have a base type, we can build/add immediately.
+                if (!builder.hasParentType()) {
+                    addType(builder.build());
+                    continue;
+                }
+
+                // For types with base type mappings, they need to be delayed.
+                delayResolvedBuilders.add(builder);
+            }
+
+            // Resolve delayed builders
+            for (PostgresType.Builder builder : delayResolvedBuilders) {
+                addType(builder.build());
+            }
+        }
+    }
+
+    private PostgresType.Builder createTypeBuilderFromResultSet(ResultSet rs) throws SQLException {
+        // Coerce long to int so large unsigned values are represented as signed
+        // Same technique is used in TypeInfoCache
+        final int oid = (int) rs.getLong("oid");
+        final int parentTypeOid = (int) rs.getLong("parentoid");
+        final int modifiers = (int) rs.getLong("modifiers");
+        String typeName = rs.getString("name");
+        String category = rs.getString("category");
+
+        PostgresType.Builder builder =
+                new PostgresType.Builder(
+                        this,
+                        typeName,
+                        oid,
+                        sqlTypeMapper.getSqlType(typeName),
+                        modifiers,
+                        getTypeInfo(connection));
+
+        if (CATEGORY_ENUM.equals(category)) {
+            String[] enumValues = (String[]) rs.getArray("enum_values").getArray();
+            builder = builder.enumValues(Arrays.asList(enumValues));
+        } else if (CATEGORY_ARRAY.equals(category)) {
+            builder = builder.elementType((int) rs.getLong("element"));
+        }
+        return builder.parentType(parentTypeOid);
+    }
+
+    private PostgresType resolveUnknownType(String name) {
+        try {
+            LOGGER.trace("Type '{}' not cached, attempting to lookup from database.", name);
+
+            try (final PreparedStatement statement =
+                    connection.connection().prepareStatement(SQL_NAME_LOOKUP)) {
+                statement.setString(1, name);
+                return loadType(statement);
+            }
+        } catch (SQLException e) {
+            throw new ConnectException(
+                    "Database connection failed during resolving unknown type", e);
+        }
+    }
+
+    private PostgresType resolveUnknownType(int lookupOid) {
+        try {
+            LOGGER.trace(
+                    "Type OID '{}' not cached, attempting to lookup from database.", lookupOid);
+
+            try (final PreparedStatement statement =
+                    connection.connection().prepareStatement(SQL_OID_LOOKUP)) {
+                statement.setInt(1, lookupOid);
+                return loadType(statement);
+            }
+        } catch (SQLException e) {
+            throw new ConnectException(
+                    "Database connection failed during resolving unknown type", e);
+        }
+    }
+
+    private PostgresType loadType(PreparedStatement statement) throws SQLException {
+        try (final ResultSet rs = statement.executeQuery()) {
+            while (rs.next()) {
+                PostgresType result = createTypeBuilderFromResultSet(rs).build();
+                addType(result);
+                return result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Allows to obtain the SQL type corresponding to PG types. This uses a custom statement instead
+     * of going through {@link PgDatabaseMetaData#getTypeInfo()} as the latter causes N+1 SELECTs,
+     * making it very slow on installations with many custom types.
+     *
+     * @author Gunnar Morling
+     * @see DBZ-899
+     */
+    private static class SqlTypeMapper {
+
+        /**
+         * Based on org.postgresql.jdbc.TypeInfoCache.getSQLType(String). To emulate the original
+         * statement's behavior (which works for single types only), PG's DISTINCT ON extension is
+         * used to just return the first entry should a type exist in multiple schemas.
+         */
+        private static final String SQL_TYPE_DETAILS =
+                "SELECT DISTINCT ON (typname) typname, typinput='array_in'::regproc, typtype, sp.r, pg_type.oid "
+                        + "  FROM pg_catalog.pg_type "
+                        + "  LEFT "
+                        + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
+                        + "          from pg_namespace as ns "
+                        // -- go with older way of unnesting array to be compatible with 8.0
+                        + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
+                        + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
+                        + "         using ( nspname ) "
+                        + "       ) as sp "
+                        + "    ON sp.nspoid = typnamespace "
+                        + " ORDER BY typname, sp.r, pg_type.oid;";
+
+        private final PostgresConnection connection;
+
+        @Immutable private final Set<String> preloadedSqlTypes;
+
+        @Immutable private final Map<String, Integer> sqlTypesByPgTypeNames;
+
+        private SqlTypeMapper(PostgresConnection connection) throws SQLException {
+            this.connection = connection;
+            this.preloadedSqlTypes =
+                    Collect.unmodifiableSet(getTypeInfo(connection).getPGTypeNamesWithSQLTypes());
+            this.sqlTypesByPgTypeNames = Collections.unmodifiableMap(getSqlTypes(connection));
+        }
+
+        public int getSqlType(String typeName) throws SQLException {
+            boolean isCoreType = preloadedSqlTypes.contains(typeName);
+
+            // obtain core types such as bool, int2 etc. from the driver, as it correctly maps these
+            // types to the JDBC
+            // type codes. Also those values are cached in TypeInfoCache.
+            if (isCoreType) {
+                return getTypeInfo(connection).getSQLType(typeName);
+            }
+            if (typeName.endsWith("[]")) {
+                return Types.ARRAY;
+            }
+            // get custom type mappings from the map which was built up with a single query
+            else {
+                try {
+                    final Integer pgType = sqlTypesByPgTypeNames.get(typeName);
+                    if (pgType != null) {
+                        return pgType;
+                    }
+                    LOGGER.info(
+                            "Failed to obtain SQL type information for type {} via custom statement, falling back to TypeInfo#getSQLType()",
+                            typeName);
+                    return getTypeInfo(connection).getSQLType(typeName);
+                } catch (Exception e) {
+                    LOGGER.warn(
+                            "Failed to obtain SQL type information for type {} via custom statement, falling back to TypeInfo#getSQLType()",
+                            typeName,
+                            e);
+                    return getTypeInfo(connection).getSQLType(typeName);
+                }
+            }
+        }
+
+        /**
+         * Builds up a map of SQL (JDBC) types by PG type name; contains only values for non-core
+         * types.
+         */
+        private static Map<String, Integer> getSqlTypes(PostgresConnection connection)
+                throws SQLException {
+            Map<String, Integer> sqlTypesByPgTypeNames = new HashMap<>();
+
+            try (final Statement statement = connection.connection().createStatement()) {
+                try (final ResultSet rs = statement.executeQuery(SQL_TYPE_DETAILS)) {
+                    while (rs.next()) {
+                        int type;
+                        boolean isArray = rs.getBoolean(2);
+                        String typtype = rs.getString(3);
+                        if (isArray) {
+                            type = Types.ARRAY;
+                        } else if ("c".equals(typtype)) {
+                            type = Types.STRUCT;
+                        } else if ("d".equals(typtype)) {
+                            type = Types.DISTINCT;
+                        } else if ("e".equals(typtype)) {
+                            type = Types.VARCHAR;
+                        } else {
+                            type = Types.OTHER;
+                        }
+
+                        sqlTypesByPgTypeNames.put(rs.getString(1), type);
+                    }
+                }
+            }
+
+            return sqlTypesByPgTypeNames;
+        }
+    }
+
+    private static TypeInfo getTypeInfo(PostgresConnection connection) throws SQLException {
+        return ((BaseConnection) connection.connection()).getTypeInfo();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config;
+
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.StartupConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.StopConfig;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.RelationalTableFilters;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class PostgresSourceConfig extends JdbcSourceConfig {
+    private static final long serialVersionUID = 1L;
+
+    public PostgresSourceConfig(
+            StartupConfig startupConfig,
+            StopConfig stopConfig,
+            List<String> databaseList,
+            List<String> tableList,
+            int splitSize,
+            Map<String, String> splitColumn,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            int sampleShardingThreshold,
+            int inverseSamplingRate,
+            Properties dbzProperties,
+            String driverClassName,
+            String hostname,
+            int port,
+            String username,
+            String password,
+            String originUrl,
+            int fetchSize,
+            String serverTimeZone,
+            long connectTimeoutMillis,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            boolean exactlyOnce) {
+        super(
+                startupConfig,
+                stopConfig,
+                databaseList,
+                tableList,
+                splitSize,
+                splitColumn,
+                distributionFactorUpper,
+                distributionFactorLower,
+                sampleShardingThreshold,
+                inverseSamplingRate,
+                dbzProperties,
+                driverClassName,
+                hostname,
+                port,
+                username,
+                password,
+                originUrl,
+                fetchSize,
+                serverTimeZone,
+                connectTimeoutMillis,
+                connectMaxRetries,
+                connectionPoolSize,
+                exactlyOnce);
+    }
+
+    @Override
+    public PostgresConnectorConfig getDbzConnectorConfig() {
+        return new PostgresConnectorConfig(getDbzConfiguration());
+    }
+
+    public RelationalTableFilters getTableFilters() {
+        return getDbzConnectorConfig().getTableFilters();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfigFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.option.PostgresOptions;
+
+import io.debezium.connector.postgresql.PostgresConnector;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
+
+public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
+
+    private static final String DATABASE_SERVER_NAME = "postgres_cdc_source";
+
+    private static final String DRIVER_CLASS_NAME = "org.postgresql.Driver";
+
+    private String decodingPluginName = PostgresOptions.DECODING_PLUGIN_NAME.defaultValue();
+
+    private String slotName = PostgresOptions.SLOT_NAME.defaultValue();
+
+    private List<String> schemaList;
+
+    @Override
+    public JdbcSourceConfigFactory fromReadonlyConfig(ReadonlyConfig config) {
+        super.fromReadonlyConfig(config);
+        this.decodingPluginName = config.get(PostgresOptions.DECODING_PLUGIN_NAME);
+        this.slotName = config.get(PostgresOptions.SLOT_NAME);
+        this.schemaList = config.get(PostgresOptions.SCHEMA_NAME);
+        return this;
+    }
+
+    @Override
+    public PostgresSourceConfig create(int subtask) {
+        Properties props = new Properties();
+        props.setProperty("connector.class", PostgresConnector.class.getCanonicalName());
+        // hard code server name, because we don't need to distinguish it, docs:
+        // Logical name that identifies and provides a namespace for the particular PostgreSQL
+        // database server/cluster being monitored. The logical name should be unique across
+        // all other connectors, since it is used as a prefix for all Kafka topic names coming
+        // from this connector. Only alphanumeric characters and underscores should be used.
+        props.setProperty("database.server.name", DATABASE_SERVER_NAME);
+        props.setProperty("database.hostname", checkNotNull(hostname));
+        props.setProperty("database.user", checkNotNull(username));
+        props.setProperty("database.password", checkNotNull(password));
+        props.setProperty("database.port", String.valueOf(port));
+        props.setProperty("database.dbname", checkNotNull(databaseList.get(0)));
+        props.setProperty("plugin.name", decodingPluginName);
+        props.setProperty("slot.name", slotName);
+
+        // database history
+        props.setProperty("database.history", EmbeddedDatabaseHistory.class.getCanonicalName());
+        props.setProperty("database.history.instance.name", UUID.randomUUID() + "_" + subtask);
+        props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
+        props.setProperty("database.history.refer.ddl", String.valueOf(true));
+
+        props.setProperty("database.tcpKeepAlive", String.valueOf(true));
+        props.setProperty("include.schema.changes", String.valueOf(false));
+
+        if (schemaList != null) {
+            props.setProperty("schema.include.list", String.join(",", schemaList));
+        }
+
+        if (tableList != null) {
+            // pg identifier is of the form schemaName.tableName
+            props.setProperty(
+                    "table.include.list",
+                    tableList.stream()
+                            .map(
+                                    tableStr -> {
+                                        String[] splits = tableStr.split("\\.");
+                                        if (splits.length == 2) {
+                                            return tableStr;
+                                        }
+                                        if (splits.length == 3) {
+                                            return String.join(".", splits[1], splits[2]);
+                                        }
+                                        throw new IllegalArgumentException(
+                                                "Invalid table name: "
+                                                        + tableStr
+                                                        + " ,Postgres identifier is of the form schemaName.tableName");
+                                    })
+                            .collect(Collectors.joining(",")));
+        }
+
+        if (dbzProperties != null) {
+            props.putAll(dbzProperties);
+        }
+
+        return new PostgresSourceConfig(
+                startupConfig,
+                stopConfig,
+                databaseList,
+                tableList,
+                splitSize,
+                splitColumn,
+                distributionFactorUpper,
+                distributionFactorLower,
+                sampleShardingThreshold,
+                inverseSamplingRate,
+                props,
+                DRIVER_CLASS_NAME,
+                hostname,
+                port,
+                username,
+                password,
+                originUrl,
+                fetchSize,
+                serverTimeZone,
+                connectTimeoutMillis,
+                connectMaxRetries,
+                connectionPoolSize,
+                exactlyOnce);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/exception/PostgresConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/exception/PostgresConnectorErrorCode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum PostgresConnectorErrorCode implements SeaTunnelErrorCode {
+    NEW_SCHEMA_FAILED("POSTGRES-01", "Failed to initialize PostgresSchema"),
+    CREATE_REPLICATION_CONNECTION_FAILED("POSTGRES-02", "Failed to create replication connection");
+    private final String code;
+    private final String description;
+
+    PostgresConnectorErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/option/PostgresOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/option/PostgresOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.option;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.List;
+
+public interface PostgresOptions {
+
+    Option<String> DECODING_PLUGIN_NAME =
+            Options.key("decoding.plugin.name")
+                    .stringType()
+                    .defaultValue("pgoutput")
+                    .withDescription(
+                            "The name of the Postgres logical decoding plug-in installed on the server.\n"
+                                    + "Supported values are decoderbufs, wal2json, wal2json_rds, wal2json_streaming,\n"
+                                    + "wal2json_rds_streaming and pgoutput.");
+
+    Option<String> SLOT_NAME =
+            Options.key("slot.name")
+                    .stringType()
+                    .defaultValue("seatunnel")
+                    .withDescription(
+                            "The name of the PostgreSQL logical decoding slot that was created for streaming changes "
+                                    + "from a particular plug-in for a particular database/schema. The server uses this slot "
+                                    + "to stream events to the connector that you are configuring. Default is \"seatunnel\".");
+
+    Option<List<String>> SCHEMA_NAME =
+            Options.key("schema-name")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Schema name of the database to monitor.");
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDebeziumDeserializationConverterFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDebeziumDeserializationConverterFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SqlType;
+import org.apache.seatunnel.common.utils.BufferUtils;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverter;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverterFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Optional;
+
+/** PostgreSQL-specific Debezium converters for types not handled by the CDC base module. */
+public final class PostgresDebeziumDeserializationConverterFactory
+        implements DebeziumDeserializationConverterFactory {
+
+    public static final PostgresDebeziumDeserializationConverterFactory INSTANCE =
+            new PostgresDebeziumDeserializationConverterFactory();
+
+    private static final int PGVECTOR_HEADER_BYTES = 4;
+
+    private PostgresDebeziumDeserializationConverterFactory() {}
+
+    @Override
+    public Optional<DebeziumDeserializationConverter> createUserDefinedConverter(
+            SeaTunnelDataType<?> type, ZoneId serverTimeZone) {
+        if (type.getSqlType() == SqlType.FLOAT_VECTOR) {
+            return Optional.of(
+                    new DebeziumDeserializationConverter() {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public Object convert(
+                                Object dbzObj, org.apache.kafka.connect.data.Schema schema) {
+                            return convertFloatVector(dbzObj);
+                        }
+                    });
+        }
+        return Optional.empty();
+    }
+
+    private static ByteBuffer convertFloatVector(Object value) {
+        if (value instanceof CharSequence) {
+            return parseTextVector(value.toString());
+        }
+        if (value instanceof byte[]) {
+            return parseVectorBytes((byte[]) value);
+        }
+        if (value instanceof ByteBuffer) {
+            ByteBuffer source = ((ByteBuffer) value).duplicate();
+            byte[] bytes = new byte[source.remaining()];
+            source.get(bytes);
+            return parseVectorBytes(bytes);
+        }
+        throw new IllegalArgumentException(
+                "Unsupported PostgreSQL vector value type: " + value.getClass().getName());
+    }
+
+    private static ByteBuffer parseVectorBytes(byte[] bytes) {
+        String text = new String(bytes, StandardCharsets.UTF_8).trim();
+        if (text.startsWith("[") && text.endsWith("]")) {
+            return parseTextVector(text);
+        }
+
+        ByteBuffer binary = ByteBuffer.wrap(bytes);
+        if (binary.remaining() < PGVECTOR_HEADER_BYTES) {
+            throw new IllegalArgumentException("Invalid PostgreSQL vector binary value");
+        }
+        int dimension = Short.toUnsignedInt(binary.getShort());
+        int reserved = Short.toUnsignedInt(binary.getShort());
+        int expectedBytes = PGVECTOR_HEADER_BYTES + dimension * Float.BYTES;
+        if (dimension == 0 || reserved != 0 || bytes.length != expectedBytes) {
+            throw new IllegalArgumentException("Invalid PostgreSQL vector binary value");
+        }
+
+        Float[] values = new Float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            values[i] = binary.getFloat();
+        }
+        return BufferUtils.toByteBuffer(values);
+    }
+
+    private static ByteBuffer parseTextVector(String value) {
+        String text = value.trim();
+        if (!text.startsWith("[") || !text.endsWith("]")) {
+            throw new IllegalArgumentException("Invalid PostgreSQL vector text value");
+        }
+        String body = text.substring(1, text.length() - 1).trim();
+        if (body.isEmpty()) {
+            throw new IllegalArgumentException("PostgreSQL vector must not be empty");
+        }
+
+        String[] components = body.split(",");
+        Float[] values = new Float[components.length];
+        for (int i = 0; i < components.length; i++) {
+            values[i] = Float.parseFloat(components[i].trim());
+        }
+        return BufferUtils.toByteBuffer(values);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDialect.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDialect.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.ConstraintKey;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.utils.CatalogTableUtils;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfigFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.enumerator.PostgresChunkSplitter;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.PostgresSourceFetchTaskContext;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot.PostgresSnapshotFetchTask;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.wal.PostgresWalFetchTask;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresSchema;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.TableDiscoveryUtils;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ServerInfo;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresConnectionUtils.newPostgresValueConverterBuilder;
+
+public class PostgresDialect implements JdbcDataSourceDialect {
+
+    private static final long serialVersionUID = 1L;
+    private final PostgresSourceConfig sourceConfig;
+
+    private transient PostgresSchema postgresSchema;
+    private PostgresWalFetchTask postgresWalFetchTask;
+
+    private final Map<TableId, CatalogTable> tableMap;
+
+    public PostgresDialect(
+            PostgresSourceConfigFactory configFactory, List<CatalogTable> catalogTables) {
+        this.sourceConfig = configFactory.create(0);
+        this.tableMap = CatalogTableUtils.convertTables(catalogTables);
+    }
+
+    @Override
+    public String getName() {
+        return DatabaseIdentifier.POSTGRESQL;
+    }
+
+    @Override
+    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+        // todo: need to check the case sensitive of the database
+        return true;
+    }
+
+    @Override
+    public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
+        PostgresConnectorConfig conf =
+                (PostgresConnectorConfig) sourceConfig.getDbzConnectorConfig();
+        return new PostgresConnection(
+                conf.getJdbcConfig(),
+                newPostgresValueConverterBuilder(
+                        conf, "postgres-dialect", sourceConfig.getServerTimeZone()),
+                "postgres-dialect");
+    }
+
+    @Override
+    public ChunkSplitter createChunkSplitter(JdbcSourceConfig sourceConfig) {
+        return new PostgresChunkSplitter(sourceConfig, this);
+    }
+
+    @Override
+    public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
+        PostgresSourceConfig postgresSourceConfig = (PostgresSourceConfig) sourceConfig;
+        try (JdbcConnection jdbcConnection = openJdbcConnection(sourceConfig)) {
+            List<TableId> tables =
+                    TableDiscoveryUtils.listTables(
+                            jdbcConnection, postgresSourceConfig.getTableFilters());
+            this.checkAllTablesEnabledCapture(jdbcConnection, tables);
+            return tables;
+        } catch (SQLException e) {
+            throw new SeaTunnelException("Error to discover tables: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void checkAllTablesEnabledCapture(JdbcConnection jdbcConnection, List<TableId> tableIds)
+            throws SQLException {
+        PostgresConnection postgresConnection = (PostgresConnection) jdbcConnection;
+        for (TableId tableId : tableIds) {
+            ServerInfo.ReplicaIdentity replicaIdentity =
+                    postgresConnection.readReplicaIdentityInfo(tableId);
+            if (!ServerInfo.ReplicaIdentity.FULL.equals(replicaIdentity)) {
+                throw new SeaTunnelException(
+                        String.format(
+                                "Table %s does not have a full replica identity, please execute: ALTER TABLE %s REPLICA IDENTITY FULL;",
+                                tableId, tableId));
+            }
+        }
+    }
+
+    @Override
+    public TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
+        if (postgresSchema == null) {
+            postgresSchema = new PostgresSchema(sourceConfig.getDbzConnectorConfig(), tableMap);
+        }
+        return postgresSchema.getTableSchema(jdbc, tableId);
+    }
+
+    @Override
+    public PostgresSourceFetchTaskContext createFetchTaskContext(
+            SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
+
+        RelationalDatabaseConnectorConfig dbzConnectorConfig =
+                taskSourceConfig.getDbzConnectorConfig();
+
+        PostgresConnection jdbcConnection =
+                new PostgresConnection(
+                        dbzConnectorConfig.getJdbcConfig(),
+                        newPostgresValueConverterBuilder(
+                                (PostgresConnectorConfig) dbzConnectorConfig,
+                                "postgres-source-fetch-task",
+                                taskSourceConfig.getServerTimeZone()),
+                        "postgres-source-fetch-task");
+
+        List<TableChanges.TableChange> tableChangeList = new ArrayList<>();
+        // TODO: support save table schema
+        if (sourceSplitBase instanceof SnapshotSplit) {
+            SnapshotSplit snapshotSplit = (SnapshotSplit) sourceSplitBase;
+            tableChangeList.add(queryTableSchema(jdbcConnection, snapshotSplit.getTableId()));
+        } else {
+            IncrementalSplit incrementalSplit = (IncrementalSplit) sourceSplitBase;
+            for (TableId tableId : incrementalSplit.getTableIds()) {
+                tableChangeList.add(queryTableSchema(jdbcConnection, tableId));
+            }
+        }
+
+        return new PostgresSourceFetchTaskContext(
+                taskSourceConfig, this, jdbcConnection, tableChangeList);
+    }
+
+    @Override
+    public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
+        if (sourceSplitBase.isSnapshotSplit()) {
+            return new PostgresSnapshotFetchTask(sourceSplitBase.asSnapshotSplit());
+        } else {
+            try (JdbcConnection jdbcConnection = openJdbcConnection(sourceConfig)) {
+                List<TableId> tables = sourceSplitBase.asIncrementalSplit().getTableIds();
+                this.checkAllTablesEnabledCapture(jdbcConnection, tables);
+            } catch (SQLException e) {
+                throw new SeaTunnelException("Error to check tables: " + e.getMessage(), e);
+            }
+            postgresWalFetchTask = new PostgresWalFetchTask(sourceSplitBase.asIncrementalSplit());
+            return postgresWalFetchTask;
+        }
+    }
+
+    @Override
+    public void commitChangeLogOffset(Offset offset) throws Exception {
+        if (postgresWalFetchTask != null) {
+            postgresWalFetchTask.commitCurrentOffset((LsnOffset) offset);
+        }
+    }
+
+    @Override
+    public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId) {
+        return Optional.ofNullable(tableMap.get(tableId).getTableSchema().getPrimaryKey());
+    }
+
+    @Override
+    public List<ConstraintKey> getConstraintKeys(JdbcConnection jdbcConnection, TableId tableId) {
+        return tableMap.get(tableId).getTableSchema().getConstraintKeys();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresIncrementalSource.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresIncrementalSource.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.SupportParallelism;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.common.utils.JdbcUrlUtil;
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.option.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.option.StopMode;
+import org.apache.seatunnel.connectors.cdc.base.source.IncrementalSource;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.seatunnel.connectors.cdc.debezium.row.SeaTunnelRowDebeziumDeserializeSchema;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfigFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffsetFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.JdbcCatalogOptions;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.ConnectTableChangeSerializer;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PostgresIncrementalSource<T> extends IncrementalSource<T, JdbcSourceConfig>
+        implements SupportParallelism {
+
+    static final String IDENTIFIER = "Postgres-CDC";
+
+    public PostgresIncrementalSource(ReadonlyConfig options, List<CatalogTable> catalogTables) {
+        super(options, catalogTables);
+    }
+
+    @Override
+    public String getPluginName() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Option<StartupMode> getStartupModeOption() {
+        return PostgresSourceOptions.STARTUP_MODE;
+    }
+
+    @Override
+    public Option<StopMode> getStopModeOption() {
+        return PostgresSourceOptions.STOP_MODE;
+    }
+
+    @Override
+    public SourceConfig.Factory<JdbcSourceConfig> createSourceConfigFactory(ReadonlyConfig config) {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+        configFactory.fromReadonlyConfig(readonlyConfig);
+        JdbcUrlUtil.UrlInfo urlInfo =
+                JdbcUrlUtil.getUrlInfo(config.get(JdbcCatalogOptions.BASE_URL));
+        configFactory.originUrl(urlInfo.getOrigin());
+        configFactory.hostname(urlInfo.getHost());
+        configFactory.port(urlInfo.getPort());
+        configFactory.startupOptions(startupConfig);
+        configFactory.stopOptions(stopConfig);
+        return configFactory;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DebeziumDeserializationSchema<T> createDebeziumDeserializationSchema(
+            ReadonlyConfig config) {
+        String zoneId = config.get(JdbcSourceOptions.SERVER_TIME_ZONE);
+        return (DebeziumDeserializationSchema<T>)
+                SeaTunnelRowDebeziumDeserializeSchema.builder()
+                        .setTables(catalogTables)
+                        .setServerTimeZone(ZoneId.of(zoneId))
+                        .setUserDefinedConverterFactory(
+                                PostgresDebeziumDeserializationConverterFactory.INSTANCE)
+                        .build();
+    }
+
+    @Override
+    public DataSourceDialect<JdbcSourceConfig> createDataSourceDialect(ReadonlyConfig config) {
+        return new PostgresDialect((PostgresSourceConfigFactory) configFactory, catalogTables);
+    }
+
+    @Override
+    public OffsetFactory createOffsetFactory(ReadonlyConfig config) {
+        return new LsnOffsetFactory(
+                (PostgresSourceConfigFactory) configFactory, (PostgresDialect) dataSourceDialect);
+    }
+
+    private Map<TableId, Struct> tableChanges() {
+        JdbcSourceConfig jdbcSourceConfig = configFactory.create(0);
+        PostgresDialect dialect =
+                new PostgresDialect((PostgresSourceConfigFactory) configFactory, catalogTables);
+        List<TableId> discoverTables = dialect.discoverDataCollections(jdbcSourceConfig);
+        SchemaNameAdjuster adjuster = SchemaNameAdjuster.create();
+        ConnectTableChangeSerializer connectTableChangeSerializer =
+                new ConnectTableChangeSerializer(adjuster);
+        try (JdbcConnection jdbcConnection = dialect.openJdbcConnection(jdbcSourceConfig)) {
+            return discoverTables.stream()
+                    .collect(
+                            Collectors.toMap(
+                                    Function.identity(),
+                                    (tableId) -> {
+                                        TableChanges tableChanges = new TableChanges();
+                                        tableChanges.create(
+                                                dialect.queryTableSchema(jdbcConnection, tableId)
+                                                        .getTable());
+                                        return connectTableChangeSerializer
+                                                .serialize(tableChanges)
+                                                .get(0);
+                                    }));
+        } catch (Exception e) {
+            throw new SeaTunnelException(e);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresIncrementalSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresIncrementalSourceFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceTableConfig;
+import org.apache.seatunnel.connectors.cdc.base.option.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.utils.CatalogTableUtils;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.option.PostgresOptions;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.JdbcCatalogOptions;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+@AutoService(Factory.class)
+public class PostgresIncrementalSourceFactory implements TableSourceFactory {
+    @Override
+    public String factoryIdentifier() {
+        return PostgresIncrementalSource.IDENTIFIER;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return JdbcSourceOptions.getBaseRule()
+                .required(
+                        JdbcSourceOptions.USERNAME,
+                        JdbcSourceOptions.PASSWORD,
+                        JdbcCatalogOptions.BASE_URL)
+                .exclusive(ConnectorCommonOptions.TABLE_NAMES, ConnectorCommonOptions.TABLE_PATTERN)
+                .optional(
+                        JdbcSourceOptions.DATABASE_NAMES,
+                        JdbcSourceOptions.SERVER_TIME_ZONE,
+                        JdbcSourceOptions.CONNECT_TIMEOUT_MS,
+                        JdbcSourceOptions.CONNECT_MAX_RETRIES,
+                        JdbcSourceOptions.CONNECTION_POOL_SIZE,
+                        PostgresOptions.DECODING_PLUGIN_NAME,
+                        PostgresOptions.SLOT_NAME,
+                        JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND,
+                        JdbcSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND,
+                        JdbcSourceOptions.SAMPLE_SHARDING_THRESHOLD,
+                        JdbcSourceOptions.TABLE_NAMES_CONFIG)
+                .optional(PostgresSourceOptions.STARTUP_MODE, PostgresSourceOptions.STOP_MODE)
+                .conditional(
+                        PostgresSourceOptions.STARTUP_MODE,
+                        StartupMode.INITIAL,
+                        JdbcSourceOptions.EXACTLY_ONCE)
+                .build();
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return PostgresIncrementalSource.class;
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        return () -> {
+            List<CatalogTable> catalogTables =
+                    CatalogTableUtil.getCatalogTables(
+                            context.getOptions(), context.getClassLoader());
+            Optional<List<JdbcSourceTableConfig>> tableConfigs =
+                    context.getOptions().getOptional(JdbcSourceOptions.TABLE_NAMES_CONFIG);
+            if (tableConfigs.isPresent()) {
+                catalogTables =
+                        CatalogTableUtils.mergeCatalogTableConfig(
+                                catalogTables, tableConfigs.get(), s -> TablePath.of(s, true));
+            }
+            return (SeaTunnelSource<T, SplitT, StateT>)
+                    new PostgresIncrementalSource<>(context.getOptions(), catalogTables);
+        };
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresSourceOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.configuration.SingleChoiceOption;
+import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.option.StopMode;
+
+import java.util.Arrays;
+
+public class PostgresSourceOptions {
+    public static final SingleChoiceOption<StartupMode> STARTUP_MODE =
+            (SingleChoiceOption)
+                    Options.key(SourceOptions.STARTUP_MODE_KEY)
+                            .singleChoice(
+                                    StartupMode.class,
+                                    Arrays.asList(
+                                            StartupMode.INITIAL,
+                                            StartupMode.EARLIEST,
+                                            StartupMode.LATEST))
+                            .defaultValue(StartupMode.INITIAL)
+                            .withDescription(
+                                    "Optional startup mode for CDC source, valid enumerations are "
+                                            + "\"initial\", \"earliest\", \"latest\"");
+
+    public static final SingleChoiceOption<StopMode> STOP_MODE =
+            (SingleChoiceOption)
+                    Options.key(SourceOptions.STOP_MODE_KEY)
+                            .singleChoice(StopMode.class, Arrays.asList(StopMode.NEVER))
+                            .defaultValue(StopMode.NEVER)
+                            .withDescription(
+                                    "Optional stop mode for CDC source, valid enumerations are "
+                                            + "\"never\"");
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/enumerator/PostgresChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/enumerator/PostgresChunkSplitter.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.enumerator;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.AbstractJdbcSourceChunkSplitter;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresTypeUtils;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresUtils;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.SQLException;
+
+/** The {@code ChunkSplitter} used to split table into a set of chunks for JDBC data source. */
+@Slf4j
+public class PostgresChunkSplitter extends AbstractJdbcSourceChunkSplitter {
+
+    public PostgresChunkSplitter(JdbcSourceConfig sourceConfig, JdbcDataSourceDialect dialect) {
+        super(sourceConfig, dialect);
+    }
+
+    @Override
+    public Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+            throws SQLException {
+        return PostgresUtils.queryMinMax(jdbc, tableId, columnName, null);
+    }
+
+    @Override
+    public Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, Column column)
+            throws SQLException {
+        return PostgresUtils.queryMinMax(jdbc, tableId, column.name(), column);
+    }
+
+    @Override
+    public Object queryMin(
+            JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+            throws SQLException {
+        return PostgresUtils.queryMin(jdbc, tableId, columnName, null, excludedLowerBound);
+    }
+
+    @Override
+    public Object queryMin(
+            JdbcConnection jdbc, TableId tableId, Column column, Object excludedLowerBound)
+            throws SQLException {
+        return PostgresUtils.queryMin(jdbc, tableId, column.name(), column, excludedLowerBound);
+    }
+
+    @Override
+    public Object[] sampleDataFromColumn(
+            JdbcConnection jdbc, TableId tableId, String columnName, int inverseSamplingRate)
+            throws Exception {
+        return PostgresUtils.skipReadAndSortSampleData(
+                jdbc, tableId, columnName, null, inverseSamplingRate);
+    }
+
+    @Override
+    public Object[] sampleDataFromColumn(
+            JdbcConnection jdbc, TableId tableId, Column column, int inverseSamplingRate)
+            throws Exception {
+        return PostgresUtils.skipReadAndSortSampleData(
+                jdbc, tableId, column.name(), column, inverseSamplingRate);
+    }
+
+    @Override
+    public Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String columnName,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        return PostgresUtils.queryNextChunkMax(
+                jdbc, tableId, columnName, null, chunkSize, includedLowerBound);
+    }
+
+    @Override
+    public Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            Column column,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        return PostgresUtils.queryNextChunkMax(
+                jdbc, tableId, column.name(), column, chunkSize, includedLowerBound);
+    }
+
+    @Override
+    public Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId) throws SQLException {
+        return PostgresUtils.queryApproximateRowCnt(jdbc, tableId);
+    }
+
+    @Override
+    public String buildSplitScanQuery(
+            Table table, SeaTunnelRowType splitKeyType, boolean isFirstSplit, boolean isLastSplit) {
+        return PostgresUtils.buildSplitScanQuery(table, splitKeyType, isFirstSplit, isLastSplit);
+    }
+
+    @Override
+    public SeaTunnelDataType<?> fromDbzColumn(Column splitColumn) {
+        return PostgresTypeUtils.convertFromColumn(splitColumn);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+
+import io.debezium.connector.postgresql.SourceInfo;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.time.Conversions;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LsnOffset extends Offset {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final LsnOffset INITIAL_OFFSET =
+            new LsnOffset(Lsn.INVALID_LSN.asLong(), null, Instant.MIN);
+    public static final LsnOffset NO_STOPPING_OFFSET =
+            new LsnOffset(Lsn.valueOf("FFFFFFFF/FFFFFFFF").asLong(), null, Instant.MAX);
+
+    /**
+     * the position in the server WAL for a particular event; may be null indicating that this
+     * information is not available.
+     */
+    private Lsn lsn;
+
+    /**
+     * the ID of the transaction that generated the transaction; may be null if this information is
+     * not available.
+     */
+    private Long txId;
+
+    /** the xmin of the slot, may be null. */
+    private Long xmin;
+
+    public LsnOffset(Map<String, String> offset) {
+        this.offset = offset;
+    }
+
+    public LsnOffset(Long lsn, Long txId, Instant lastCommitTs) {
+        Map<String, String> offsetMap = new HashMap<>();
+        // keys are from io.debezium.connector.postgresql.PostgresOffsetContext.Loader.load
+        offsetMap.put(SourceInfo.LSN_KEY, lsn.toString());
+        if (txId != null) {
+            offsetMap.put(SourceInfo.TXID_KEY, txId.toString());
+        }
+        if (lastCommitTs != null) {
+            offsetMap.put(
+                    SourceInfo.TIMESTAMP_USEC_KEY,
+                    String.valueOf(Conversions.toEpochMicros(lastCommitTs)));
+        }
+        this.offset = offsetMap;
+    }
+
+    public static LsnOffset of(Map<String, ?> offsetMap) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+
+        return new LsnOffset(offsetStrMap);
+    }
+
+    public Lsn getLsn() {
+        return Lsn.valueOf(Long.valueOf(offset.get(SourceInfo.LSN_KEY)));
+    }
+
+    public Long getTxId() {
+        return Long.parseLong(offset.get(SourceInfo.TXID_KEY));
+    }
+
+    public Long getXmin() {
+        return Long.parseLong(offset.get(SourceInfo.XMIN_KEY));
+    }
+
+    @Override
+    public int compareTo(Offset o) {
+        LsnOffset that = (LsnOffset) o;
+        if (NO_STOPPING_OFFSET.equals(that) && NO_STOPPING_OFFSET.equals(this)) {
+            return 0;
+        }
+        if (NO_STOPPING_OFFSET.equals(this)) {
+            return 1;
+        }
+        if (NO_STOPPING_OFFSET.equals(that)) {
+            return -1;
+        }
+
+        Lsn thisLsn = this.getLsn();
+        Lsn thatLsn = that.getLsn();
+        if (thatLsn.isValid()) {
+            if (thisLsn.isValid()) {
+                return thisLsn.compareTo(thatLsn);
+            }
+            return -1;
+        } else if (thisLsn.isValid()) {
+            return 1;
+        }
+        return 0;
+    }
+
+    @SuppressWarnings("checkstyle:EqualsHashCode")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LsnOffset)) {
+            return false;
+        }
+        LsnOffset that = (LsnOffset) o;
+        return offset.equals(that.offset);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffsetFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffsetFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.OffsetFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfigFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.PostgresDialect;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresUtils;
+
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.jdbc.JdbcConnection;
+
+import java.util.Map;
+
+public class LsnOffsetFactory extends OffsetFactory {
+
+    private final PostgresSourceConfig sourceConfig;
+
+    private final PostgresDialect dialect;
+
+    public LsnOffsetFactory(PostgresSourceConfigFactory configFactory, PostgresDialect dialect) {
+        this.sourceConfig = configFactory.create(0);
+        this.dialect = dialect;
+    }
+
+    @Override
+    public Offset earliest() {
+        return LsnOffset.INITIAL_OFFSET;
+    }
+
+    @Override
+    public Offset neverStop() {
+        return LsnOffset.NO_STOPPING_OFFSET;
+    }
+
+    @Override
+    public Offset latest() {
+        try (JdbcConnection jdbcConnection = dialect.openJdbcConnection(sourceConfig)) {
+            return PostgresUtils.currentLsn((PostgresConnection) jdbcConnection);
+        } catch (Exception e) {
+            throw new RuntimeException("Read the binlog offset error", e);
+        }
+    }
+
+    @Override
+    public Offset specific(Map<String, String> offset) {
+        return new LsnOffset(offset);
+    }
+
+    @Override
+    public Offset specific(String filename, Long position) {
+        throw new UnsupportedOperationException(
+                "not supported create new Offset by filename and position.");
+    }
+
+    @Override
+    public Offset timestamp(long timestamp) {
+        throw new UnsupportedOperationException("not supported create new Offset by timestamp.");
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.exception.PostgresConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresUtils;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresErrorHandler;
+import io.debezium.connector.postgresql.PostgresEventDispatcher;
+import io.debezium.connector.postgresql.PostgresObjectUtils;
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.PostgresPartition;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresTaskContext;
+import io.debezium.connector.postgresql.PostgresTopicSelector;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.LoggingContext;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.PLUGIN_NAME;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SLOT_NAME;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresConnectionUtils.newPostgresValueConverterBuilder;
+
+@Slf4j
+public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
+
+    private static final String CONTEXT_NAME = "postgres-cdc-connector-task";
+
+    private final PostgresConnection dataConnection;
+
+    @Getter private ReplicationConnection replicationConnection;
+
+    private final EventMetadataProvider metadataProvider;
+
+    @Getter private Snapshotter snapshotter;
+    private PostgresSchema databaseSchema;
+    private PostgresOffsetContext offsetContext;
+    private PostgresPartition partition;
+    private TopicSelector<TableId> topicSelector;
+    private JdbcSourceEventDispatcher<PostgresPartition> dispatcher;
+    private PostgresEventDispatcher<TableId> pgEventDispatcher;
+    private ChangeEventQueue<DataChangeEvent> queue;
+    private PostgresErrorHandler errorHandler;
+
+    @Getter private PostgresTaskContext taskContext;
+
+    private SnapshotChangeEventSourceMetrics<PostgresPartition> snapshotChangeEventSourceMetrics;
+
+    private PostgresConnection.PostgresValueConverterBuilder postgresValueConverterBuilder;
+
+    private Collection<TableChanges.TableChange> engineHistory;
+
+    public PostgresSourceFetchTaskContext(
+            JdbcSourceConfig sourceConfig,
+            JdbcDataSourceDialect dataSourceDialect,
+            PostgresConnection dataConnection,
+            Collection<TableChanges.TableChange> engineHistory) {
+        super(sourceConfig, dataSourceDialect);
+        this.dataConnection = dataConnection;
+        this.metadataProvider = PostgresObjectUtils.newEventMetadataProvider();
+        this.engineHistory = engineHistory;
+        this.postgresValueConverterBuilder =
+                newPostgresValueConverterBuilder(
+                        getDbzConnectorConfig(),
+                        "postgres-source-fetch-task-context",
+                        sourceConfig.getServerTimeZone());
+    }
+
+    @Override
+    public void configure(SourceSplitBase sourceSplitBase) {
+        super.registerDatabaseHistory(sourceSplitBase, dataConnection);
+
+        // initial stateful objects
+        final PostgresConnectorConfig connectorConfig = getDbzConnectorConfig();
+        PostgresConnectorConfig.SnapshotMode snapshotMode =
+                PostgresConnectorConfig.SnapshotMode.parse(
+                        connectorConfig.getConfig().getString(SNAPSHOT_MODE));
+        this.snapshotter = snapshotMode.getSnapshotter(connectorConfig.getConfig());
+
+        this.topicSelector = PostgresTopicSelector.create(connectorConfig);
+        final TypeRegistry typeRegistry = dataConnection.getTypeRegistry();
+
+        try {
+            this.databaseSchema =
+                    PostgresObjectUtils.newSchema(
+                            dataConnection,
+                            connectorConfig,
+                            typeRegistry,
+                            topicSelector,
+                            postgresValueConverterBuilder.build(typeRegistry));
+        } catch (SQLException e) {
+            throw new SeaTunnelRuntimeException(PostgresConnectorErrorCode.NEW_SCHEMA_FAILED, e);
+        }
+
+        this.taskContext =
+                PostgresObjectUtils.newTaskContext(connectorConfig, databaseSchema, topicSelector);
+        this.offsetContext =
+                loadStartingOffsetState(
+                        new PostgresOffsetContext.Loader(connectorConfig), sourceSplitBase);
+        this.partition = new PostgresPartition(connectorConfig.getLogicalName());
+
+        // If in the snapshot read phase and enable exactly-once, the queue needs to be set to a
+        // maximum size of `Integer.MAX_VALUE` (buffered a current snapshot all data). otherwise,
+        // use the configuration queue size.
+        final int queueSize =
+                sourceSplitBase.isSnapshotSplit() && isExactlyOnce()
+                        ? Integer.MAX_VALUE
+                        : getSourceConfig().getDbzConnectorConfig().getMaxQueueSize();
+
+        LoggingContext.PreviousContext previousContext =
+                taskContext.configureLoggingContext(CONTEXT_NAME);
+        try {
+            // Print out the server information
+            SlotState slotInfo = null;
+            try {
+                if (log.isInfoEnabled()) {
+                    log.info(dataConnection.serverInfo().toString());
+                }
+                PostgresConnectorConfig.LogicalDecoder logicalDecoder =
+                        PostgresConnectorConfig.LogicalDecoder.parse(
+                                connectorConfig.getConfig().getString(PLUGIN_NAME));
+                slotInfo =
+                        dataConnection.getReplicationSlotState(
+                                connectorConfig.getConfig().getString(SLOT_NAME),
+                                logicalDecoder.getPostgresPluginName());
+            } catch (SQLException e) {
+                log.warn(
+                        "unable to load info of replication slot, Debezium will try to create the slot");
+            }
+
+            if (offsetContext == null) {
+                log.info("No previous offset found");
+                // if we have no initial offset, indicate that to Snapshotter by passing null
+                snapshotter.init(connectorConfig, null, slotInfo);
+            } else {
+                log.info("Found previous offset {}", offsetContext);
+                snapshotter.init(connectorConfig, offsetContext.asOffsetState(), slotInfo);
+            }
+
+            if (snapshotter.shouldStream()) {
+                // we need to create the slot before we start streaming if it doesn't exist
+                // otherwise we can't stream back changes happening while the snapshot is taking
+                // place
+                if (this.replicationConnection == null) {
+                    this.replicationConnection =
+                            PostgresObjectUtils.createReplicationConnection(
+                                    this.taskContext,
+                                    dataConnection,
+                                    snapshotter.shouldSnapshot(),
+                                    connectorConfig);
+                    try {
+                        // create the slot if it doesn't exist, otherwise update slot to add new
+                        // table(job restore and add table)
+                        replicationConnection.createReplicationSlot().orElse(null);
+                    } catch (SQLException ex) {
+                        String message = "Creation of replication slot failed";
+                        if (ex.getMessage().contains("already exists")) {
+                            message +=
+                                    "; when setting up multiple connectors for the same database host, please make sure to use a distinct replication slot name for each.";
+                            log.warn(message);
+                        } else {
+                            throw new DebeziumException(message, ex);
+                        }
+                    }
+                }
+            }
+
+            try {
+                dataConnection.commit();
+            } catch (SQLException e) {
+                throw new DebeziumException(e);
+            }
+
+            this.queue =
+                    new ChangeEventQueue.Builder<DataChangeEvent>()
+                            .pollInterval(connectorConfig.getPollInterval())
+                            .maxBatchSize(connectorConfig.getMaxBatchSize())
+                            .maxQueueSize(queueSize)
+                            .maxQueueSizeInBytes(connectorConfig.getMaxQueueSizeInBytes())
+                            .loggingContextSupplier(
+                                    () -> taskContext.configureLoggingContext(CONTEXT_NAME))
+                            // do not buffer any element, we use signal event
+                            // .buffering()
+                            .build();
+
+            this.dispatcher =
+                    new JdbcSourceEventDispatcher<>(
+                            connectorConfig,
+                            topicSelector,
+                            databaseSchema,
+                            queue,
+                            connectorConfig.getTableFilters().dataCollectionFilter(),
+                            DataChangeEvent::new,
+                            metadataProvider,
+                            schemaNameAdjuster);
+
+            this.pgEventDispatcher =
+                    new PostgresEventDispatcher<>(
+                            connectorConfig,
+                            topicSelector,
+                            databaseSchema,
+                            queue,
+                            connectorConfig.getTableFilters().dataCollectionFilter(),
+                            DataChangeEvent::new,
+                            metadataProvider,
+                            schemaNameAdjuster);
+
+            this.snapshotChangeEventSourceMetrics =
+                    new DefaultChangeEventSourceMetricsFactory()
+                            .getSnapshotMetrics(taskContext, queue, metadataProvider);
+
+            this.errorHandler = new PostgresErrorHandler(connectorConfig, queue);
+        } finally {
+            previousContext.restore();
+        }
+    }
+
+    @Override
+    public PostgresSourceConfig getSourceConfig() {
+        return (PostgresSourceConfig) sourceConfig;
+    }
+
+    public PostgresConnection getDataConnection() {
+        return dataConnection;
+    }
+
+    public SnapshotChangeEventSourceMetrics<PostgresPartition>
+            getSnapshotChangeEventSourceMetrics() {
+        return snapshotChangeEventSourceMetrics;
+    }
+
+    @Override
+    public PostgresConnectorConfig getDbzConnectorConfig() {
+        return (PostgresConnectorConfig) super.getDbzConnectorConfig();
+    }
+
+    @Override
+    public PostgresOffsetContext getOffsetContext() {
+        return offsetContext;
+    }
+
+    @Override
+    public PostgresPartition getPartition() {
+        return partition;
+    }
+
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    @Override
+    public PostgresSchema getDatabaseSchema() {
+        return databaseSchema;
+    }
+
+    @Override
+    public TableId getTableId(SourceRecord record) {
+        Struct value = (Struct) record.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String schemaName = source.getString(SCHEMA_NAME_KEY);
+        String tableName = source.getString(TABLE_NAME_KEY);
+        return new TableId(null, schemaName, tableName);
+    }
+
+    @Override
+    public SeaTunnelRowType getSplitType(Table table) {
+        return PostgresUtils.getSplitType(table);
+    }
+
+    @Override
+    public JdbcSourceEventDispatcher<PostgresPartition> getDispatcher() {
+        return dispatcher;
+    }
+
+    public PostgresEventDispatcher<TableId> getPgEventDispatcher() {
+        return pgEventDispatcher;
+    }
+
+    @Override
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    @Override
+    public Tables.TableFilter getTableFilter() {
+        return getDbzConnectorConfig().getTableFilters().dataCollectionFilter();
+    }
+
+    @Override
+    public Offset getStreamOffset(SourceRecord sourceRecord) {
+        return PostgresUtils.getLsnPosition(sourceRecord);
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (Objects.nonNull(dataConnection)) {
+                this.dataConnection.close();
+            }
+            if (Objects.nonNull(replicationConnection)) {
+                this.replicationConnection.close();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to close connection", e);
+        }
+    }
+
+    /** Loads the connector's persistent offset (if present) via the given loader. */
+    private PostgresOffsetContext loadStartingOffsetState(
+            PostgresOffsetContext.Loader loader, SourceSplitBase split) {
+        Offset offset =
+                split.isSnapshotSplit()
+                        ? LsnOffset.INITIAL_OFFSET
+                        : split.asIncrementalSplit().getStartupOffset();
+        Map<String, String> offsetStrMap =
+                Objects.requireNonNull(offset, "offset is null for the sourceSplitBase")
+                        .getOffset();
+        // all the keys happen to be long type for PostgresOffsetContext.Loader.load
+        Map<String, Object> offsetMap = new HashMap<>();
+        for (String key : offsetStrMap.keySet()) {
+            String value = offsetStrMap.get(key);
+            if (value != null) {
+                offsetMap.put(key, Long.parseLong(value));
+            }
+        }
+        return loader.load(offsetMap);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotFetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotFetchTask.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot;
+
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.PostgresSourceFetchTaskContext;
+
+import io.debezium.pipeline.spi.SnapshotResult;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+public class PostgresSnapshotFetchTask implements FetchTask<SourceSplitBase> {
+
+    private final SnapshotSplit split;
+
+    private volatile boolean taskRunning = false;
+
+    private PostgresSnapshotSplitReadTask snapshotSplitReadTask;
+
+    public PostgresSnapshotFetchTask(SnapshotSplit split) {
+        this.split = split;
+    }
+
+    @Override
+    public void execute(FetchTask.Context context) throws Exception {
+        PostgresSourceFetchTaskContext sourceFetchContext =
+                (PostgresSourceFetchTaskContext) context;
+        taskRunning = true;
+        snapshotSplitReadTask =
+                new PostgresSnapshotSplitReadTask(
+                        sourceFetchContext.getDbzConnectorConfig(),
+                        sourceFetchContext.getOffsetContext(),
+                        sourceFetchContext.getSnapshotChangeEventSourceMetrics(),
+                        sourceFetchContext.getDatabaseSchema(),
+                        sourceFetchContext.getDataConnection(),
+                        sourceFetchContext.getDispatcher(),
+                        split);
+        SnapshotSplitChangeEventSourceContext changeEventSourceContext =
+                new SnapshotSplitChangeEventSourceContext();
+        SnapshotResult snapshotResult =
+                snapshotSplitReadTask.execute(
+                        changeEventSourceContext,
+                        sourceFetchContext.getPartition(),
+                        sourceFetchContext.getOffsetContext());
+        if (!snapshotResult.isCompletedOrSkipped()) {
+            taskRunning = false;
+            throw new IllegalStateException(
+                    String.format("Read snapshot for split %s fail", split));
+        }
+        boolean changed =
+                changeEventSourceContext
+                        .getHighWatermark()
+                        .isAfter(changeEventSourceContext.getLowWatermark());
+        if (!context.isExactlyOnce()) {
+            taskRunning = false;
+            if (changed) {
+                log.debug("Skip merge changelog(exactly-once) for snapshot split {}", split);
+            }
+            return;
+        }
+
+        final IncrementalSplit backfillSplit = createBackFillWalSplit(changeEventSourceContext);
+        // optimization that skip the binlog read when the low watermark equals high
+        // watermark
+        // todo Add backfill task
+        if (true) {
+            dispatchBinlogEndEvent(
+                    backfillSplit,
+                    ((PostgresSourceFetchTaskContext) context).getPartition().getSourcePartition(),
+                    ((PostgresSourceFetchTaskContext) context).getDispatcher());
+            taskRunning = false;
+            return;
+        }
+    }
+
+    private IncrementalSplit createBackFillWalSplit(
+            SnapshotSplitChangeEventSourceContext sourceContext) {
+        return new IncrementalSplit(
+                split.splitId(),
+                Collections.singletonList(split.getTableId()),
+                sourceContext.getLowWatermark(),
+                sourceContext.getHighWatermark(),
+                new ArrayList<>());
+    }
+
+    private void dispatchBinlogEndEvent(
+            IncrementalSplit backFillBinlogSplit,
+            Map<String, ?> sourcePartition,
+            JdbcSourceEventDispatcher eventDispatcher)
+            throws InterruptedException {
+        eventDispatcher.dispatchWatermarkEvent(
+                sourcePartition,
+                backFillBinlogSplit,
+                backFillBinlogSplit.getStopOffset(),
+                WatermarkKind.END);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskRunning;
+    }
+
+    @Override
+    public void shutdown() {
+        taskRunning = false;
+    }
+
+    @Override
+    public SourceSplitBase getSplit() {
+        return split;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTask.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot;
+
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.PostgresUtils;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.PostgresPartition;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.ChangeRecordEmitter;
+import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.SnapshotChangeRecordEmitter;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+import io.debezium.util.ColumnUtils;
+import io.debezium.util.Strings;
+import io.debezium.util.Threads;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+
+@Slf4j
+public class PostgresSnapshotSplitReadTask
+        extends AbstractSnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> {
+
+    /** Interval for showing a log statement with the progress while scanning a single table. */
+    private static final Duration LOG_INTERVAL = Duration.ofMillis(10_000);
+
+    private final PostgresConnectorConfig connectorConfig;
+    private final PostgresSchema databaseSchema;
+    private final PostgresConnection jdbcConnection;
+    private final JdbcSourceEventDispatcher<PostgresPartition> dispatcher;
+    private final Clock clock;
+    private final SnapshotSplit snapshotSplit;
+    private final PostgresOffsetContext offsetContext;
+    private final SnapshotProgressListener<PostgresPartition> snapshotProgressListener;
+
+    public PostgresSnapshotSplitReadTask(
+            PostgresConnectorConfig connectorConfig,
+            PostgresOffsetContext previousOffset,
+            SnapshotProgressListener snapshotProgressListener,
+            PostgresSchema databaseSchema,
+            PostgresConnection jdbcConnection,
+            JdbcSourceEventDispatcher dispatcher,
+            SnapshotSplit snapshotSplit) {
+        super(connectorConfig, snapshotProgressListener);
+        this.offsetContext = previousOffset;
+        this.connectorConfig = connectorConfig;
+        this.databaseSchema = databaseSchema;
+        this.jdbcConnection = jdbcConnection;
+        this.dispatcher = dispatcher;
+        this.clock = Clock.SYSTEM;
+        this.snapshotSplit = snapshotSplit;
+        this.snapshotProgressListener = snapshotProgressListener;
+    }
+
+    @Override
+    public SnapshotResult<PostgresOffsetContext> execute(
+            ChangeEventSource.ChangeEventSourceContext context,
+            PostgresPartition partition,
+            PostgresOffsetContext previousOffset)
+            throws InterruptedException {
+        SnapshottingTask snapshottingTask = getSnapshottingTask(partition, previousOffset);
+        final SnapshotContext<PostgresPartition, PostgresOffsetContext> ctx;
+        try {
+            ctx = prepare(partition);
+        } catch (Exception e) {
+            log.error("Failed to initialize snapshot context.", e);
+            throw new RuntimeException(e);
+        }
+        try {
+            return doExecute(context, previousOffset, ctx, snapshottingTask);
+        } catch (InterruptedException e) {
+            log.warn("Snapshot was interrupted before completion");
+            throw e;
+        } catch (Exception t) {
+            throw new DebeziumException(t);
+        }
+    }
+
+    @Override
+    protected SnapshotResult<PostgresOffsetContext> doExecute(
+            ChangeEventSource.ChangeEventSourceContext context,
+            PostgresOffsetContext previousOffset,
+            SnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext,
+            AbstractSnapshotChangeEventSource.SnapshottingTask snapshottingTask)
+            throws Exception {
+        final PostgresSnapshotContext ctx = (PostgresSnapshotContext) snapshotContext;
+        ctx.offset = offsetContext;
+
+        final LsnOffset lowWatermark = PostgresUtils.currentLsn(jdbcConnection);
+        log.info(
+                "Snapshot step 1 - Determining low watermark {} for split {}",
+                lowWatermark,
+                snapshotSplit);
+        ((SnapshotSplitChangeEventSourceContext) context).setLowWatermark(lowWatermark);
+        dispatcher.dispatchWatermarkEvent(
+                ctx.partition.getSourcePartition(), snapshotSplit, lowWatermark, WatermarkKind.LOW);
+
+        log.info("Snapshot step 2 - Snapshotting data");
+        createDataEvents(ctx, snapshotSplit.getTableId());
+
+        final LsnOffset highWatermark = PostgresUtils.currentLsn(jdbcConnection);
+        log.info(
+                "Snapshot step 3 - Determining high watermark {} for split {}",
+                highWatermark,
+                snapshotSplit);
+        ((SnapshotSplitChangeEventSourceContext) context).setHighWatermark(highWatermark);
+        dispatcher.dispatchWatermarkEvent(
+                ctx.partition.getSourcePartition(),
+                snapshotSplit,
+                highWatermark,
+                WatermarkKind.HIGH);
+        return SnapshotResult.completed(ctx.offset);
+    }
+
+    @Override
+    protected SnapshottingTask getSnapshottingTask(
+            PostgresPartition partition, PostgresOffsetContext previousOffset) {
+        return new SnapshottingTask(false, true);
+    }
+
+    @Override
+    protected SnapshotContext<PostgresPartition, PostgresOffsetContext> prepare(
+            PostgresPartition partition) throws Exception {
+        return new PostgresSnapshotContext(partition);
+    }
+
+    private void createDataEvents(PostgresSnapshotContext snapshotContext, TableId tableId)
+            throws Exception {
+        EventDispatcher.SnapshotReceiver snapshotReceiver =
+                dispatcher.getSnapshotChangeEventReceiver();
+        log.debug("Snapshotting table {}", tableId);
+        TableId newTableId = new TableId(null, tableId.schema(), tableId.table());
+        createDataEventsForTable(
+                snapshotContext, snapshotReceiver, databaseSchema.tableFor(newTableId));
+        snapshotReceiver.completeSnapshot();
+    }
+
+    /** Dispatches the data change events for the records of a single table. */
+    private void createDataEventsForTable(
+            PostgresSnapshotContext snapshotContext,
+            EventDispatcher.SnapshotReceiver snapshotReceiver,
+            Table table)
+            throws InterruptedException {
+
+        long exportStart = clock.currentTimeInMillis();
+        log.info("Exporting data from split '{}' of table {}", snapshotSplit.splitId(), table.id());
+
+        final String selectSql =
+                PostgresUtils.buildSplitScanQuery(
+                        table,
+                        snapshotSplit.getSplitKeyType(),
+                        snapshotSplit.getSplitStart() == null,
+                        snapshotSplit.getSplitEnd() == null);
+        log.info(
+                "For split '{}' of table {} using select statement: '{}'",
+                snapshotSplit.splitId(),
+                table.id(),
+                selectSql);
+
+        try (PreparedStatement selectStatement =
+                        PostgresUtils.readTableSplitDataStatement(
+                                jdbcConnection,
+                                selectSql,
+                                snapshotSplit.getSplitStart() == null,
+                                snapshotSplit.getSplitEnd() == null,
+                                snapshotSplit.getSplitStart(),
+                                snapshotSplit.getSplitEnd(),
+                                snapshotSplit.getSplitKeyType(),
+                                connectorConfig.getQueryFetchSize());
+                ResultSet rs = selectStatement.executeQuery()) {
+
+            ColumnUtils.ColumnArray columnArray = ColumnUtils.toArray(rs, table);
+            long rows = 0;
+            Threads.Timer logTimer = getTableScanLogTimer();
+
+            while (rs.next()) {
+                rows++;
+                final Object[] row = new Object[columnArray.getGreatestColumnPosition()];
+                for (int i = 0; i < columnArray.getColumns().length; i++) {
+                    row[columnArray.getColumns()[i].position() - 1] = rs.getObject(i + 1);
+                }
+                if (logTimer.expired()) {
+                    long stop = clock.currentTimeInMillis();
+                    log.info(
+                            "Exported {} records for split '{}' after {}",
+                            rows,
+                            snapshotSplit.splitId(),
+                            Strings.duration(stop - exportStart));
+                    snapshotProgressListener.rowsScanned(
+                            snapshotContext.partition, table.id(), rows);
+                    logTimer = getTableScanLogTimer();
+                }
+                dispatcher.dispatchSnapshotEvent(
+                        snapshotContext.partition,
+                        table.id(),
+                        getChangeRecordEmitter(snapshotContext, table.id(), row),
+                        snapshotReceiver);
+            }
+            log.info(
+                    "Finished exporting {} records for split '{}', total duration '{}'",
+                    rows,
+                    snapshotSplit.splitId(),
+                    Strings.duration(clock.currentTimeInMillis() - exportStart));
+        } catch (SQLException e) {
+            throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
+        }
+    }
+
+    protected ChangeRecordEmitter getChangeRecordEmitter(
+            PostgresSnapshotContext snapshotContext, TableId tableId, Object[] row) {
+        snapshotContext.offset.event(tableId, clock.currentTime());
+        return new SnapshotChangeRecordEmitter(
+                snapshotContext.partition, snapshotContext.offset, row, clock);
+    }
+
+    private Threads.Timer getTableScanLogTimer() {
+        return Threads.timer(clock, LOG_INTERVAL);
+    }
+
+    private Object readField(ResultSet rs, int columnIndex) throws SQLException {
+        final ResultSetMetaData metaData = rs.getMetaData();
+        final int columnType = metaData.getColumnType(columnIndex);
+
+        if (columnType == Types.TIME) {
+            return rs.getTimestamp(columnIndex);
+        } else {
+            return rs.getObject(columnIndex);
+        }
+    }
+
+    private static class PostgresSnapshotContext
+            extends RelationalSnapshotChangeEventSource.RelationalSnapshotContext<
+                    PostgresPartition, PostgresOffsetContext> {
+
+        public PostgresSnapshotContext(PostgresPartition partition) throws SQLException {
+            super(partition, "");
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/SnapshotSplitChangeEventSourceContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/SnapshotSplitChangeEventSourceContext.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot;
+
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+
+/**
+ * {@link ChangeEventSource.ChangeEventSourceContext} implementation that keeps low/high watermark
+ * for each {@link SnapshotSplit}.
+ */
+public class SnapshotSplitChangeEventSourceContext
+        implements ChangeEventSource.ChangeEventSourceContext {
+
+    private LsnOffset lowWatermark;
+    private LsnOffset highWatermark;
+
+    public LsnOffset getLowWatermark() {
+        return lowWatermark;
+    }
+
+    public void setLowWatermark(LsnOffset lowWatermark) {
+        this.lowWatermark = lowWatermark;
+    }
+
+    public LsnOffset getHighWatermark() {
+        return highWatermark;
+    }
+
+    public void setHighWatermark(LsnOffset highWatermark) {
+        this.highWatermark = highWatermark;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return lowWatermark != null && highWatermark != null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.wal;
+
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
+import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.PostgresSourceFetchTaskContext;
+
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.util.Clock;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class PostgresWalFetchTask implements FetchTask<SourceSplitBase> {
+    private final IncrementalSplit split;
+    private volatile boolean taskRunning = false;
+    private Long lastCommitLsn;
+    private PostgresStreamingChangeEventSource streamingChangeEventSource;
+    private PostgresOffsetContext offsetContext;
+
+    public PostgresWalFetchTask(IncrementalSplit split) {
+        this.split = split;
+    }
+
+    @Override
+    public void execute(FetchTask.Context context) throws Exception {
+        PostgresSourceFetchTaskContext sourceFetchContext =
+                (PostgresSourceFetchTaskContext) context;
+        taskRunning = true;
+
+        streamingChangeEventSource =
+                new PostgresStreamingChangeEventSource(
+                        sourceFetchContext.getDbzConnectorConfig(),
+                        sourceFetchContext.getSnapshotter(),
+                        sourceFetchContext.getDataConnection(),
+                        sourceFetchContext.getPgEventDispatcher(),
+                        sourceFetchContext.getErrorHandler(),
+                        Clock.SYSTEM,
+                        sourceFetchContext.getDatabaseSchema(),
+                        sourceFetchContext.getTaskContext(),
+                        sourceFetchContext.getReplicationConnection());
+
+        offsetContext = sourceFetchContext.getOffsetContext();
+
+        TransactionLogSplitChangeEventSourceContext changeEventSourceContext =
+                new TransactionLogSplitChangeEventSourceContext();
+
+        log.info(
+                "Start streaming change event source for postgres wal split: {}",
+                split.getStartupOffset().toString());
+        streamingChangeEventSource.execute(
+                changeEventSourceContext, sourceFetchContext.getPartition(), offsetContext);
+    }
+
+    public void commitCurrentOffset(LsnOffset offset) {
+        if (streamingChangeEventSource != null && offset != null) {
+
+            // only extracting and storing the lsn of the last commit
+            Long commitLsn = offset.getLsn().asLong();
+            if (commitLsn != null
+                    && (lastCommitLsn == null
+                            || Lsn.valueOf(commitLsn).compareTo(Lsn.valueOf(lastCommitLsn)) > 0)) {
+                lastCommitLsn = commitLsn;
+
+                Map<String, Object> offsets = new HashMap<>();
+                offsets.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, lastCommitLsn);
+                log.info("Committing offset {} for {}", Lsn.valueOf(lastCommitLsn), split);
+                streamingChangeEventSource.commitOffset(offsets);
+            }
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskRunning;
+    }
+
+    @Override
+    public void shutdown() {
+        taskRunning = false;
+    }
+
+    @Override
+    public SourceSplitBase getSplit() {
+        return split;
+    }
+
+    private class TransactionLogSplitChangeEventSourceContext
+            implements ChangeEventSource.ChangeEventSourceContext {
+        @Override
+        public boolean isRunning() {
+            return taskRunning;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresConnectionUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresConnectionUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import io.debezium.connector.postgresql.CustomPostgresValueConverter;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+
+import java.nio.charset.Charset;
+import java.time.ZoneId;
+
+public class PostgresConnectionUtils {
+
+    /**
+     * Create a new PostgresVauleConverterBuilder instance and offer type registry for JDBC
+     * connection.
+     *
+     * <p>It is created in this package because some methods (e.g., includeUnknownDatatypes) of
+     * PostgresConnectorConfig is protected.
+     */
+    public static PostgresConnection.PostgresValueConverterBuilder newPostgresValueConverterBuilder(
+            PostgresConnectorConfig config, String connectionUsage, ZoneId zoneId) {
+        try (PostgresConnection heartbeatConnection =
+                new PostgresConnection(config.getJdbcConfig(), connectionUsage)) {
+            final Charset databaseCharset = heartbeatConnection.getDatabaseCharset();
+            return (typeRegistry) ->
+                    CustomPostgresValueConverter.of(config, databaseCharset, typeRegistry, zoneId);
+        }
+    }
+
+    public static PostgresConnection.PostgresValueConverterBuilder newPostgresValueConverterBuilder(
+            PostgresConnectorConfig config, String connectionUsage, String serverTimezone) {
+        try (PostgresConnection heartbeatConnection =
+                new PostgresConnection(config.getJdbcConfig(), connectionUsage)) {
+            final Charset databaseCharset = heartbeatConnection.getDatabaseCharset();
+            return (typeRegistry) ->
+                    CustomPostgresValueConverter.of(
+                            config, databaseCharset, typeRegistry, ZoneId.of(serverTimezone));
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresSchema.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.utils.CatalogTableUtils;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PostgresSchema {
+
+    private final PostgresConnectorConfig connectorConfig;
+    private final Map<TableId, TableChanges.TableChange> schemasByTableId;
+    private final Map<TableId, CatalogTable> tableMap;
+
+    public PostgresSchema(
+            final PostgresConnectorConfig connectorConfig, Map<TableId, CatalogTable> tableMap) {
+        this.schemasByTableId = new ConcurrentHashMap<>();
+        this.connectorConfig = connectorConfig;
+        this.tableMap = tableMap;
+    }
+
+    public TableChanges.TableChange getTableSchema(JdbcConnection jdbc, TableId tableId) {
+        // read schema from cache first
+        TableChanges.TableChange schema = schemasByTableId.get(tableId);
+        if (schema == null) {
+            schema = readTableSchema(jdbc, tableId);
+        }
+        return schema;
+    }
+
+    private TableChanges.TableChange readTableSchema(JdbcConnection jdbc, TableId tableId) {
+        // Because the catalog is null in the postgresConnection.readSchema method
+        TableId tableIdWithoutCatalog = new TableId(null, tableId.schema(), tableId.table());
+
+        PostgresConnection postgresConnection = (PostgresConnection) jdbc;
+        Tables tables = new Tables();
+        try {
+            postgresConnection.readSchema(
+                    tables,
+                    tableIdWithoutCatalog.catalog(),
+                    tableIdWithoutCatalog.schema(),
+                    connectorConfig.getTableFilters().dataCollectionFilter(),
+                    null,
+                    false);
+            for (TableId id : tables.tableIds()) {
+                TableId idWithCatalog = new TableId(tableId.catalog(), id.schema(), id.table());
+                if (tableMap.containsKey(idWithCatalog)) {
+                    Table table =
+                            CatalogTableUtils.mergeCatalogTableConfig(
+                                    tables.forTable(id), tableMap.get(idWithCatalog));
+                    TableChanges.TableChange tableChange =
+                            new TableChanges.TableChange(
+                                    TableChanges.TableChangeType.CREATE, table);
+                    schemasByTableId.put(idWithCatalog, tableChange);
+                }
+            }
+        } catch (SQLException e) {
+            throw new SeaTunnelException(
+                    String.format("Failed to read schema for table %s ", tableId), e);
+        }
+
+        if (!schemasByTableId.containsKey(tableId)) {
+            throw new SeaTunnelException(
+                    String.format("Can't obtain schema for table %s ", tableId));
+        }
+
+        return schemasByTableId.get(tableId);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresTypeUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresTypeUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter;
+
+import io.debezium.relational.Column;
+
+public class PostgresTypeUtils {
+    private PostgresTypeUtils() {}
+
+    public static SeaTunnelDataType<?> convertFromColumn(Column column) {
+        BasicTypeDefine typeDefine =
+                BasicTypeDefine.builder()
+                        .name(column.name())
+                        .columnType(column.typeName())
+                        .dataType(column.typeName())
+                        .length((long) column.length())
+                        .precision((long) column.length())
+                        .scale(column.scale().orElse(0))
+                        .build();
+        org.apache.seatunnel.api.table.catalog.Column seaTunnelColumn =
+                PostgresTypeConverter.INSTANCE.convert(typeDefine);
+        return seaTunnelColumn.getDataType();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresUtils.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.utils.SeaTunnelException;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresDialect;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.connector.postgresql.SourceInfo;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.time.Conversions;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** The utils for SqlServer data source. */
+@Slf4j
+public class PostgresUtils {
+    private static final int DEFAULT_FETCH_SIZE = 1024;
+    private static final JdbcDialect JDBC_DIALECT = new PostgresDialect();
+
+    private PostgresUtils() {}
+
+    public static Object[] queryMinMax(
+            JdbcConnection jdbc, TableId tableId, String columnName, Column column)
+            throws SQLException {
+        columnName = quote(columnName);
+        if (column != null) {
+            columnName = JDBC_DIALECT.convertType(columnName, column.typeName());
+        }
+        final String minMaxQuery =
+                String.format(
+                        "SELECT MIN(%s), MAX(%s) FROM %s", columnName, columnName, quote(tableId));
+        return jdbc.queryAndMap(
+                minMaxQuery,
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]",
+                                        minMaxQuery));
+                    }
+                    return SourceRecordUtils.rowToArray(rs, 2);
+                });
+    }
+
+    public static long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
+            throws SQLException {
+        // The statement used to get approximate row count which is less
+        // accurate than COUNT(*), but is more efficient for large table.
+        final String rowCountQuery =
+                String.format(
+                        "SELECT reltuples FROM pg_class r WHERE relkind = 'r' AND relname = '%s';",
+                        tableId.table());
+        return jdbc.queryAndMap(
+                rowCountQuery,
+                rs -> {
+                    if (!rs.next()) {
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]",
+                                        rowCountQuery));
+                    }
+                    return rs.getLong(1);
+                });
+    }
+
+    public static Object queryMin(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String columnName,
+            Column column,
+            Object excludedLowerBound)
+            throws SQLException {
+        columnName = quote(columnName);
+        if (column != null) {
+            columnName = JDBC_DIALECT.convertType(columnName, column.typeName());
+        }
+        final String minQuery =
+                String.format(
+                        "SELECT MIN(%s) FROM %s WHERE %s > ?",
+                        columnName, quote(tableId), columnName);
+        return jdbc.prepareQueryAndMap(
+                minQuery,
+                ps -> ps.setObject(1, excludedLowerBound),
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", minQuery));
+                    }
+                    return rs.getObject(1);
+                });
+    }
+
+    public static Object[] sampleDataFromColumn(
+            JdbcConnection jdbc, TableId tableId, String columnName, int inverseSamplingRate)
+            throws SQLException {
+        final String minQuery =
+                String.format(
+                        "SELECT %s FROM %s WHERE MOD((%s - (SELECT MIN(%s) FROM %s)), %s) = 0 ORDER BY %s",
+                        quote(columnName),
+                        quote(tableId),
+                        quote(columnName),
+                        quote(columnName),
+                        quote(tableId),
+                        inverseSamplingRate,
+                        quote(columnName));
+        return jdbc.queryAndMap(
+                minQuery,
+                resultSet -> {
+                    List<Object> results = new ArrayList<>();
+                    while (resultSet.next()) {
+                        results.add(resultSet.getObject(1));
+                    }
+                    return results.toArray();
+                });
+    }
+
+    public static Object[] skipReadAndSortSampleData(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String columnName,
+            Column column,
+            int inverseSamplingRate)
+            throws Exception {
+        columnName = quote(columnName);
+        if (column != null) {
+            columnName = JDBC_DIALECT.convertType(columnName, column.typeName());
+        }
+        final String sampleQuery = String.format("SELECT %s FROM %s", columnName, quote(tableId));
+
+        Statement stmt = null;
+        ResultSet rs = null;
+
+        List<Object> results = new ArrayList<>();
+        try {
+            stmt =
+                    jdbc.connection()
+                            .createStatement(
+                                    ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+
+            stmt.setFetchSize(DEFAULT_FETCH_SIZE);
+            rs = stmt.executeQuery(sampleQuery);
+
+            int count = 0;
+            while (rs.next()) {
+                count++;
+                if (count % 100000 == 0) {
+                    log.info("Processing row index: {}", count);
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException("Thread interrupted");
+                }
+                if (count % inverseSamplingRate == 0) {
+                    results.add(rs.getObject(1));
+                }
+            }
+        } finally {
+            if (rs != null) {
+                try {
+                    rs.close();
+                } catch (SQLException e) {
+                    log.error("Failed to close ResultSet", e);
+                }
+            }
+            if (stmt != null) {
+                try {
+                    stmt.close();
+                } catch (SQLException e) {
+                    log.error("Failed to close Statement", e);
+                }
+            }
+        }
+        Object[] resultsArray = results.toArray();
+        Arrays.sort(resultsArray);
+        return resultsArray;
+    }
+
+    /**
+     * Returns the next LSN to be read from the database. This is the LSN of the last record that
+     * was read from the database.
+     */
+    public static Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String splitColumnName,
+            Column splitColumn,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        String quotedColumn = quote(splitColumnName);
+        if (splitColumn != null) {
+            quotedColumn = JDBC_DIALECT.convertType(quotedColumn, splitColumn.typeName());
+        }
+        String query =
+                String.format(
+                        "SELECT MAX(%s) FROM ("
+                                + "SELECT %s FROM %s WHERE %s >= ? ORDER BY %s ASC "
+                                + "LIMIT %s) AS T",
+                        quotedColumn,
+                        quotedColumn,
+                        quote(tableId),
+                        quotedColumn,
+                        quotedColumn,
+                        chunkSize);
+        return jdbc.prepareQueryAndMap(
+                query,
+                ps -> ps.setObject(1, includedLowerBound),
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", query));
+                    }
+                    return rs.getObject(1);
+                });
+    }
+
+    public static SeaTunnelRowType getSplitType(Table table) {
+        List<Column> primaryKeys = table.primaryKeyColumns();
+        if (primaryKeys.isEmpty()) {
+            throw new SeaTunnelException(
+                    String.format(
+                            "Incremental snapshot for tables requires primary key,"
+                                    + " but table %s doesn't have primary key.",
+                            table.id()));
+        }
+
+        // use first field in primary key as the split key
+        return getSplitType(primaryKeys.get(0));
+    }
+
+    public static SeaTunnelRowType getSplitType(Column splitColumn) {
+        return new SeaTunnelRowType(
+                new String[] {splitColumn.name()},
+                new SeaTunnelDataType<?>[] {PostgresTypeUtils.convertFromColumn(splitColumn)});
+    }
+
+    public static Offset getLsnPosition(SourceRecord record) {
+        return getLsnPosition(record.sourceOffset());
+    }
+
+    public static LsnOffset getLsnPosition(Map<String, ?> offset) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offset.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+        return new LsnOffset(offsetStrMap);
+    }
+
+    /** Fetch current largest log sequence number (LSN) of the database. */
+    public static LsnOffset currentLsn(PostgresConnection jdbcConnection) {
+        Long lsn;
+        Long txId;
+        try {
+            lsn = jdbcConnection.currentXLogLocation();
+            txId = jdbcConnection.currentTransactionId();
+            log.trace("Read xlogStart at '{}' from transaction '{}'", Lsn.valueOf(lsn), txId);
+        } catch (SQLException e) {
+            throw new SeaTunnelException("Error getting current Lsn/txId " + e.getMessage(), e);
+        }
+
+        try {
+            jdbcConnection.commit();
+        } catch (SQLException e) {
+            throw new SeaTunnelException("JDBC connection fails to commit: " + e.getMessage(), e);
+        }
+
+        Map<String, String> offsetMap = new HashMap<>();
+        offsetMap.put(SourceInfo.LSN_KEY, lsn.toString());
+        if (txId != null) {
+            offsetMap.put(SourceInfo.TXID_KEY, txId.toString());
+        }
+        offsetMap.put(
+                SourceInfo.TIMESTAMP_USEC_KEY,
+                String.valueOf(Conversions.toEpochMicros(Instant.MIN)));
+        return LsnOffset.of(offsetMap);
+    }
+
+    /** Get split scan query for the given table. */
+    public static String buildSplitScanQuery(
+            Table table, SeaTunnelRowType rowType, boolean isFirstSplit, boolean isLastSplit) {
+        return buildSplitQuery(table, rowType, isFirstSplit, isLastSplit, -1, true);
+    }
+
+    /** Get table split data PreparedStatement. */
+    public static PreparedStatement readTableSplitDataStatement(
+            JdbcConnection jdbc,
+            String sql,
+            boolean isFirstSplit,
+            boolean isLastSplit,
+            Object[] splitStart,
+            Object[] splitEnd,
+            SeaTunnelRowType splitKeyType,
+            int fetchSize) {
+        try {
+            final PreparedStatement statement = initStatement(jdbc, sql, fetchSize);
+            if (isFirstSplit && isLastSplit) {
+                return statement;
+            }
+            int primaryKeyNum = splitKeyType.getTotalFields();
+            if (isFirstSplit) {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitEnd[i]);
+                    statement.setObject(i + 1 + primaryKeyNum, splitEnd[i]);
+                }
+            } else if (isLastSplit) {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitStart[i]);
+                }
+            } else {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitStart[i]);
+                    statement.setObject(i + 1 + primaryKeyNum, splitEnd[i]);
+                    statement.setObject(i + 1 + 2 * primaryKeyNum, splitEnd[i]);
+                }
+            }
+            return statement;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build the split data read statement.", e);
+        }
+    }
+
+    private static String getPrimaryKeyColumnsProjection(SeaTunnelRowType rowType) {
+        StringBuilder sql = new StringBuilder();
+        for (Iterator<String> fieldNamesIt = Arrays.stream(rowType.getFieldNames()).iterator();
+                fieldNamesIt.hasNext(); ) {
+            sql.append(fieldNamesIt.next());
+            if (fieldNamesIt.hasNext()) {
+                sql.append(" , ");
+            }
+        }
+        return sql.toString();
+    }
+
+    private static String buildSplitQuery(
+            Table table,
+            SeaTunnelRowType rowType,
+            boolean isFirstSplit,
+            boolean isLastSplit,
+            int limitSize,
+            boolean isScanningData) {
+        final String condition;
+
+        if (isFirstSplit && isLastSplit) {
+            condition = null;
+        } else if (isFirstSplit) {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(table, rowType, sql, " <= ?");
+            if (isScanningData) {
+                sql.append(" AND NOT (");
+                addPrimaryKeyColumnsToCondition(table, rowType, sql, " = ?");
+                sql.append(")");
+            }
+            condition = sql.toString();
+        } else if (isLastSplit) {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(table, rowType, sql, " >= ?");
+            condition = sql.toString();
+        } else {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(table, rowType, sql, " >= ?");
+            if (isScanningData) {
+                sql.append(" AND NOT (");
+                addPrimaryKeyColumnsToCondition(table, rowType, sql, " = ?");
+                sql.append(")");
+            }
+            sql.append(" AND ");
+            addPrimaryKeyColumnsToCondition(table, rowType, sql, " <= ?");
+            condition = sql.toString();
+        }
+
+        if (isScanningData) {
+            return buildSelectWithRowLimits(
+                    table.id(), limitSize, "*", Optional.ofNullable(condition), Optional.empty());
+        } else {
+            final String orderBy = String.join(", ", rowType.getFieldNames());
+            return buildSelectWithBoundaryRowLimits(
+                    table.id(),
+                    limitSize,
+                    getPrimaryKeyColumnsProjection(rowType),
+                    getMaxPrimaryKeyColumnsProjection(rowType),
+                    Optional.ofNullable(condition),
+                    orderBy);
+        }
+    }
+
+    private static PreparedStatement initStatement(JdbcConnection jdbc, String sql, int fetchSize)
+            throws SQLException {
+        final Connection connection = jdbc.connection();
+        connection.setAutoCommit(false);
+        final PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
+    }
+
+    private static String getMaxPrimaryKeyColumnsProjection(SeaTunnelRowType rowType) {
+        StringBuilder sql = new StringBuilder();
+        for (Iterator<String> fieldNamesIt = Arrays.stream(rowType.getFieldNames()).iterator();
+                fieldNamesIt.hasNext(); ) {
+            sql.append("MAX(" + fieldNamesIt.next() + ")");
+            if (fieldNamesIt.hasNext()) {
+                sql.append(" , ");
+            }
+        }
+        return sql.toString();
+    }
+
+    private static String buildSelectWithRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            Optional<String> condition,
+            Optional<String> orderBy) {
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        if (limit > 0) {
+            sql.append(" TOP( ").append(limit).append(") ");
+        }
+        sql.append(projection).append(" FROM ");
+        sql.append(quoteSchemaAndTable(tableId));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        if (orderBy.isPresent()) {
+            sql.append(" ORDER BY ").append(orderBy.get());
+        }
+        return sql.toString();
+    }
+
+    private static String quoteSchemaAndTable(TableId tableId) {
+        StringBuilder quoted = new StringBuilder();
+
+        if (tableId.schema() != null && !tableId.schema().isEmpty()) {
+            quoted.append(quote(tableId.schema())).append(".");
+        }
+
+        quoted.append(quote(tableId.table()));
+        return quoted.toString();
+    }
+
+    public static String quote(String dbOrTableName) {
+        return "\"" + dbOrTableName + "\"";
+    }
+
+    public static String quote(TableId tableId) {
+        return "\"" + tableId.schema() + "\".\"" + tableId.table() + "\"";
+    }
+
+    private static void addPrimaryKeyColumnsToCondition(
+            Table table, SeaTunnelRowType rowType, StringBuilder sql, String predicate) {
+        for (int i = 0; i < rowType.getTotalFields(); i++) {
+            String fieldName = quote(rowType.getFieldName(i));
+            fieldName =
+                    JDBC_DIALECT.convertType(
+                            fieldName, table.columnWithName(rowType.getFieldName(i)).typeName());
+            sql.append(fieldName).append(predicate);
+            if (i < rowType.getTotalFields() - 1) {
+                sql.append(" AND ");
+            }
+        }
+    }
+
+    private static String buildSelectWithBoundaryRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            String maxColumnProjection,
+            Optional<String> condition,
+            String orderBy) {
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(maxColumnProjection);
+        sql.append(" FROM (");
+        sql.append("SELECT ");
+        sql.append(" TOP( ").append(limit).append(") ");
+        sql.append(projection);
+        sql.append(" FROM ");
+        sql.append(quoteSchemaAndTable(tableId));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        sql.append(" ORDER BY ").append(orderBy);
+        sql.append(") T");
+        return sql.toString();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/TableDiscoveryUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/TableDiscoveryUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.TableId;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableDiscoveryUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(TableDiscoveryUtils.class);
+
+    @SuppressWarnings("MagicNumber")
+    public static List<TableId> listTables(JdbcConnection jdbc, RelationalTableFilters tableFilters)
+            throws SQLException {
+        final List<TableId> capturedTableIds = new ArrayList<>();
+        // -------------------
+        // READ DATABASE NAMES
+        // -------------------
+        // Get the list of databases ...
+        LOG.info("Read list of available databases");
+        final List<String> databaseNames = new ArrayList<>();
+
+        jdbc.query(
+                "select datname from pg_database",
+                rs -> {
+                    while (rs.next()) {
+                        databaseNames.add(rs.getString(1));
+                    }
+                });
+        LOG.info("\t list of available databases is: {}", databaseNames);
+
+        // ----------------
+        // READ TABLE NAMES
+        // ----------------
+        // Get the list of table IDs for each database. We can't use a prepared statement with
+        // SqlServer, so we have to build the SQL statement each time. Although in other cases this
+        // might lead to SQL injection, in our case we are reading the database names from the
+        // database and not taking them from the user ...
+        LOG.info("Read list of available tables in each database");
+        for (String dbName : databaseNames) {
+            try {
+                jdbc.query(
+                        "SELECT * FROM \""
+                                + dbName
+                                + "\".INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
+                        rs -> {
+                            while (rs.next()) {
+                                TableId tableId =
+                                        new TableId(
+                                                rs.getString(1), rs.getString(2), rs.getString(3));
+                                if (tableFilters.dataCollectionFilter().isIncluded(tableId)) {
+                                    capturedTableIds.add(tableId);
+                                    LOG.info("\t including '{}' for further processing", tableId);
+                                } else {
+                                    LOG.info("\t '{}' is filtered out of capturing", tableId);
+                                }
+                            }
+                        });
+            } catch (SQLException e) {
+                // We were unable to execute the query or process the results, so skip this ...
+                LOG.warn(
+                        "\t skipping database '{}' due to error reading tables: {}",
+                        dbName,
+                        e.getMessage());
+            }
+        }
+        return capturedTableIds;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDebeziumDeserializationConverterFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDebeziumDeserializationConverterFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.VectorType;
+import org.apache.seatunnel.common.utils.BufferUtils;
+import org.apache.seatunnel.connectors.cdc.debezium.DebeziumDeserializationConverter;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgresDebeziumDeserializationConverterFactoryTest {
+
+    @Test
+    void shouldIgnoreNonVectorTypes() {
+        assertFalse(
+                PostgresDebeziumDeserializationConverterFactory.INSTANCE
+                        .createUserDefinedConverter(BasicType.STRING_TYPE, ZoneId.systemDefault())
+                        .isPresent());
+    }
+
+    @Test
+    void shouldConvertVectorText() throws Exception {
+        assertVectorEquals(
+                new Float[] {0.1F, -0.2F, 3.5F},
+                converter().convert("[0.1,-0.2,3.5]", SchemaBuilder.string().build()));
+    }
+
+    @Test
+    void shouldConvertVectorTextBytes() throws Exception {
+        assertVectorEquals(
+                new Float[] {0.1F, -0.2F, 3.5F},
+                converter()
+                        .convert(
+                                "[0.1,-0.2,3.5]".getBytes(StandardCharsets.UTF_8),
+                                SchemaBuilder.bytes().build()));
+    }
+
+    @Test
+    void shouldConvertPgvectorBinary() throws Exception {
+        ByteBuffer pgvector = ByteBuffer.allocate(4 + 3 * Float.BYTES);
+        pgvector.putShort((short) 3);
+        pgvector.putShort((short) 0);
+        pgvector.putFloat(0.1F);
+        pgvector.putFloat(-0.2F);
+        pgvector.putFloat(3.5F);
+
+        assertVectorEquals(
+                new Float[] {0.1F, -0.2F, 3.5F},
+                converter().convert(pgvector.array(), SchemaBuilder.bytes().build()));
+    }
+
+    private DebeziumDeserializationConverter converter() {
+        Optional<DebeziumDeserializationConverter> converter =
+                PostgresDebeziumDeserializationConverterFactory.INSTANCE.createUserDefinedConverter(
+                        VectorType.VECTOR_FLOAT_TYPE, ZoneId.systemDefault());
+        assertTrue(converter.isPresent());
+        return converter.get();
+    }
+
+    private void assertVectorEquals(Float[] expected, Object actual) {
+        assertTrue(actual instanceof ByteBuffer);
+        assertArrayEquals(expected, BufferUtils.toFloatArray(((ByteBuffer) actual).duplicate()));
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/utils/PostgresUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+public class PostgresUtilsTest {
+    @Test
+    public void testSplitScanQuery() {
+        Table table =
+                Table.editor()
+                        .tableId(TableId.parse("db1.schema1.table1"))
+                        .addColumn(Column.editor().name("id").type("int8").create())
+                        .create();
+        String splitScanSQL =
+                PostgresUtils.buildSplitScanQuery(
+                        table,
+                        new SeaTunnelRowType(
+                                new String[] {"id"}, new SeaTunnelDataType[] {BasicType.LONG_TYPE}),
+                        false,
+                        false);
+        Assertions.assertEquals(
+                "SELECT * FROM \"schema1\".\"table1\" WHERE \"id\" >= ? AND NOT (\"id\" = ?) AND \"id\" <= ?",
+                splitScanSQL);
+
+        splitScanSQL =
+                PostgresUtils.buildSplitScanQuery(
+                        table,
+                        new SeaTunnelRowType(
+                                new String[] {"id"}, new SeaTunnelDataType[] {BasicType.LONG_TYPE}),
+                        true,
+                        true);
+        Assertions.assertEquals("SELECT * FROM \"schema1\".\"table1\"", splitScanSQL);
+
+        splitScanSQL =
+                PostgresUtils.buildSplitScanQuery(
+                        table,
+                        new SeaTunnelRowType(
+                                new String[] {"id"}, new SeaTunnelDataType[] {BasicType.LONG_TYPE}),
+                        true,
+                        false);
+        Assertions.assertEquals(
+                "SELECT * FROM \"schema1\".\"table1\" WHERE \"id\" <= ? AND NOT (\"id\" = ?)",
+                splitScanSQL);
+
+        table =
+                Table.editor()
+                        .tableId(TableId.parse("db1.schema1.table1"))
+                        .addColumn(Column.editor().name("id").type("uuid").create())
+                        .create();
+        splitScanSQL =
+                PostgresUtils.buildSplitScanQuery(
+                        table,
+                        new SeaTunnelRowType(
+                                new String[] {"id"},
+                                new SeaTunnelDataType[] {BasicType.STRING_TYPE}),
+                        false,
+                        true);
+        Assertions.assertEquals(
+                "SELECT * FROM \"schema1\".\"table1\" WHERE \"id\"::text >= ?", splitScanSQL);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>2.3.11-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>connector-cdc</artifactId>
+    <packaging>pom</packaging>
+    <name>SeaTunnel : Connectors V2 : CDC :</name>
+
+    <modules>
+        <module>connector-cdc-base</module>
+        <module>connector-cdc-postgres</module>
+    </modules>
+
+    <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
+        <antlr.version>4.8</antlr.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4</artifactId>
+                <version>${antlr.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr4-maven-plugin</artifactId>
+                    <version>${antlr.version}</version>
+                    <configuration>
+                        <sourceDirectory>src/main/antlr4</sourceDirectory>
+                        <outputDirectory>src/main/java</outputDirectory>
+                        <listener>true</listener>
+                        <visitor>true</visitor>
+                        <treatWarningsAsErrors>true</treatWarningsAsErrors>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>antlr4</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -38,6 +38,7 @@
         <module>connector-jdbc</module>
         <module>connector-kafka</module>
         <module>connector-elasticsearch</module>
+        <module>connector-cdc</module>
         <module>connector-mongodb</module>
         <module>connector-iceberg</module>
         <module>connector-milvus</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -202,6 +202,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-cdc-postgres</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-jdbc</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>
@@ -554,6 +560,12 @@
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-milvus</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-cdc-postgres</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>
                 </dependency>

--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -209,6 +209,7 @@
                 <include>org.apache.seatunnel:connector-fake:jar</include>
                 <include>org.apache.seatunnel:connector-console:jar</include>
                 <include>org.apache.seatunnel:connector-milvus:jar</include>
+                <include>org.apache.seatunnel:connector-cdc-postgres:jar</include>
                 <include>org.apache.seatunnel:connector-jdbc:jar</include>
                 <include>org.apache.seatunnel:connector-elasticsearch:jar</include>
                 <include>org.apache.seatunnel:connector-pinecone:jar</include>


### PR DESCRIPTION
## Summary

- restore the SeaTunnel CDC base and PostgreSQL CDC source connector on top of the current VTS `master`, without restoring the old Milvus CDC source connector
- preserve VTS pgvector support by converting PostgreSQL vector text and binary values into SeaTunnel `FLOAT_VECTOR` buffers for both snapshot and WAL records
- apply the upstream PostgreSQL Geometry/Geography Debezium fix from `f08ce7ba8`, emitting WKB/EWKB hexadecimal strings that the Milvus sink can parse with `geometry_convert_mode = "parse"`
- wire the PostgreSQL CDC connector into the Maven reactor and release distribution, and document the PostgreSQL CDC to Milvus Geometry configuration

## Compatibility

- the PostgreSQL snapshot split, WAL reader, offset/checkpoint, and changelog row-kind logic remain unchanged from the restored SeaTunnel connector
- the pgvector converter is selected only for `FLOAT_VECTOR`; null and non-vector fields continue through the existing CDC base converters
- vector output uses the same `BufferUtils` representation as PostgreSQL JDBC full reads and the Milvus sink
- the Geometry/Geography converter and tests are byte-for-byte identical to the upstream fix

## Verification

- `git diff --check origin/master...HEAD`
- PostgreSQL CDC package with targeted Geometry, pgvector, and PostgreSQL utility tests: 7 tests passed
- Milvus Geometry converter and CDC writer package tests: 149 tests passed
- full release distribution build: 84/84 reactor modules succeeded and the binary archive contains `connector-cdc-postgres-2.3.11-SNAPSHOT.jar`

## Notes

- only `connector-cdc-base` and `connector-cdc-postgres` are restored; other upstream CDC connectors are intentionally not included
- PostgreSQL `vector` is supported as dense `FLOAT_VECTOR`; `halfvec`, `sparsevec`, and `bit` are outside this change
