### PR TITLE
[Feature][Connector-Milvus] Support TEXT field type

### DIFF
--- a/seatunnel-connectors-v2/connector-milvus/pom.xml
+++ b/seatunnel-connectors-v2/connector-milvus/pom.xml
@@ -28,6 +28,9 @@
 
     <artifactId>connector-milvus</artifactId>
     <name>SeaTunnel : Connectors V2 : Milvus</name>
+    <properties>
+        <milvus.sdk.version>3.0.5-SNAPSHOT</milvus.sdk.version>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -41,7 +44,7 @@
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java</artifactId>
-            <version>3.0.2</version>
+            <version>${milvus.sdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -52,7 +55,7 @@
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java-bulkwriter</artifactId>
-            <version>3.0.2</version>
+            <version>${milvus.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.jts</groupId>
@@ -70,10 +73,10 @@
                 <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <relocations>
                                 <relocation>

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/common/MilvusConstants.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/common/MilvusConstants.java
@@ -45,6 +45,7 @@ public class MilvusConstants {
     public static final String TIMEZONE = "timezone";
 
     // Field properties from source metadata
+    public static final String MILVUS_DATA_TYPE = "milvus_data_type";
     public static final String IS_PARTITION_KEY = "is_partition_key";
     public static final String AUTO_ID = "auto_id";
     public static final String IS_NULLABLE = "is_nullable";

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/catalog/CatalogUtils.java
@@ -407,6 +407,7 @@ public class CatalogUtils {
                     return Float.valueOf(defaultValue.toString());
                 case Double:
                     return Double.valueOf(defaultValue.toString());
+                case Text:
                 case VarChar:
                 case String:
                     return defaultValue.toString();

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSchemaConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSchemaConverter.java
@@ -30,8 +30,9 @@ public class MilvusSchemaConverter {
             Column column, PrimaryKey primaryKey) {
 
         SeaTunnelDataType<?> seaTunnelDataType = column.getDataType();
+        Map<String, Object> options = column.getOptions();
 
-        io.milvus.v2.common.DataType milvusDataType = convertSqlTypeToDataType(seaTunnelDataType.getSqlType());
+        io.milvus.v2.common.DataType milvusDataType = getColumnMilvusDataType(column);
 
         CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
                 .name(column.getName())
@@ -39,7 +40,6 @@ public class MilvusSchemaConverter {
                 .build();
         // Handle column options safely - these come from source metadata
         boolean nullableSetFromOptions = false;
-        Map<String, Object> options = column.getOptions();
         if (options != null) {
             // Handle analyzer settings from source
             Boolean enableAnalyzer = (Boolean) options.get(MilvusConstants.ENABLE_ANALYZER);
@@ -150,8 +150,8 @@ public class MilvusSchemaConverter {
                         && (Boolean) column.getOptions().get(CommonOptions.JSON.getName())) {
                     // check if is json
                     fieldSchema.setDataType(io.milvus.v2.common.DataType.JSON);
-                } else if (column.getOptions() != null && column.getOptions().get(MilvusConstants.MAX_LENGTH) != null) {
-                    fieldSchema.setMaxLength((Integer) column.getOptions().get(MilvusConstants.MAX_LENGTH));
+                } else if (options != null && options.get(MilvusConstants.MAX_LENGTH) != null) {
+                    fieldSchema.setMaxLength((Integer) options.get(MilvusConstants.MAX_LENGTH));
                 } else {
                     fieldSchema.setMaxLength(65535);
                 }
@@ -222,6 +222,19 @@ public class MilvusSchemaConverter {
         }
 
         return fieldSchema;
+    }
+
+    private static io.milvus.v2.common.DataType getColumnMilvusDataType(Column column) {
+        io.milvus.v2.common.DataType dataType =
+                convertSqlTypeToDataType(column.getDataType().getSqlType());
+        Map<String, Object> options = column.getOptions();
+        if (options != null
+                && Objects.equals(
+                        options.get(MilvusConstants.MILVUS_DATA_TYPE),
+                        io.milvus.v2.common.DataType.Text.getCode())) {
+            return io.milvus.v2.common.DataType.Text;
+        }
+        return dataType;
     }
 
     public static io.milvus.v2.common.DataType convertSqlTypeToDataType(SqlType sqlType) {

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusSinkConverter.java
@@ -476,6 +476,7 @@ public class MilvusSinkConverter {
                 return Double.parseDouble(value.toString());
             case Bool:
                 return Boolean.parseBoolean(value.toString());
+            case Text:
             case VarChar:
             case String:
                 return value.toString();

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConverter.java
@@ -329,9 +329,15 @@ public class MilvusSourceConverter {
             case Double:
                 builder.dataType(BasicType.DOUBLE_TYPE);
                 break;
+            case Text:
             case VarChar:
                 builder.dataType(BasicType.STRING_TYPE);
-                optionsMap.put(MilvusConstants.MAX_LENGTH, fieldSchema.getMaxLength());
+                if (dataType == DataType.Text) {
+                    optionsMap.put(
+                            MilvusConstants.MILVUS_DATA_TYPE, DataType.Text.getCode());
+                } else {
+                    optionsMap.put(MilvusConstants.MAX_LENGTH, fieldSchema.getMaxLength());
+                }
                 if (fieldSchema.getEnableAnalyzer() != null) {
                     optionsMap.put(MilvusConstants.ENABLE_ANALYZER, fieldSchema.getEnableAnalyzer());
                 }
@@ -347,7 +353,6 @@ public class MilvusSourceConverter {
                     optionsMap.put(MilvusConstants.MULTI_ANALYZER_PARAMS,
                             gson.toJson(fieldSchema.getMultiAnalyzerParams()));
                 }
-
                 break;
             case String:
                 builder.dataType(BasicType.STRING_TYPE);

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/TextSupportTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/TextSupportTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus;
+
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusSchemaConverter;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusSinkConverter;
+import org.apache.seatunnel.connectors.seatunnel.milvus.source.utils.MilvusSourceConverter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.milvus.param.collection.CollectionSchemaParam;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq.FieldSchema;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class TextSupportTest {
+
+    @Test
+    public void testSourceSchemaConvertsTextAndPreservesMilvusType() {
+        FieldSchema sourceField = textField();
+
+        PhysicalColumn column = MilvusSourceConverter.convertColumn(sourceField);
+
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals("Text", column.getSourceType());
+        Assertions.assertEquals(
+                DataType.Text.getCode(), column.getOptions().get(MilvusConstants.MILVUS_DATA_TYPE));
+        Assertions.assertEquals(true, column.getOptions().get(MilvusConstants.ENABLE_ANALYZER));
+        Assertions.assertEquals(true, column.getOptions().get(MilvusConstants.ENABLE_MATCH));
+        Assertions.assertEquals(
+                "{\"type\":\"standard\"}",
+                column.getOptions().get(MilvusConstants.ANALYZER_PARAMS));
+        Assertions.assertFalse(column.getOptions().containsKey(MilvusConstants.MAX_LENGTH));
+    }
+
+    @Test
+    public void testVarCharSourceDoesNotPreserveMilvusType() {
+        FieldSchema sourceField =
+                FieldSchema.builder()
+                        .name("title")
+                        .dataType(DataType.VarChar)
+                        .maxLength(128)
+                        .build();
+
+        PhysicalColumn column = MilvusSourceConverter.convertColumn(sourceField);
+
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(128, column.getOptions().get(MilvusConstants.MAX_LENGTH));
+        Assertions.assertFalse(
+                column.getOptions().containsKey(MilvusConstants.MILVUS_DATA_TYPE));
+    }
+
+    @Test
+    public void testMilvusToMilvusSchemaRestoresText() {
+        PhysicalColumn column = MilvusSourceConverter.convertColumn(textField());
+
+        FieldSchema targetField = MilvusSchemaConverter.convertToFieldType(column, null);
+
+        Assertions.assertEquals(DataType.Text, targetField.getDataType());
+        Assertions.assertTrue(targetField.getEnableAnalyzer());
+        Assertions.assertTrue(targetField.getEnableMatch());
+        Assertions.assertEquals(
+                Collections.singletonMap("type", "standard"), targetField.getAnalyzerParams());
+    }
+
+    @Test
+    public void testPlainStringStillMapsToVarChar() {
+        PhysicalColumn column =
+                PhysicalColumn.of(
+                        "content", BasicType.STRING_TYPE, 0L, true, null, null, null, null);
+
+        FieldSchema targetField = MilvusSchemaConverter.convertToFieldType(column, null);
+
+        Assertions.assertEquals(DataType.VarChar, targetField.getDataType());
+        Assertions.assertEquals(65535, targetField.getMaxLength());
+    }
+
+    @Test
+    public void testSinkConvertsTextValue() {
+        String value = "hello";
+
+        Object converted = new MilvusSinkConverter().convertByMilvusType(textField(), value);
+
+        Assertions.assertEquals(value, converted);
+    }
+
+    @Test
+    public void testBulkWriterSchemaUsesGrpcTextType() {
+        DescribeCollectionResp describeCollectionResp =
+                DescribeCollectionResp.builder()
+                        .collectionName("text_collection")
+                        .autoID(false)
+                        .enableDynamicField(false)
+                        .collectionSchema(
+                                CreateCollectionReq.CollectionSchema.builder()
+                                        .fieldSchemaList(Collections.singletonList(textField()))
+                                        .functionList(new ArrayList<>())
+                                        .build())
+                        .build();
+
+        CollectionSchemaParam schema =
+                MilvusSinkConverter.convertToMilvusSchema(describeCollectionResp);
+
+        Assertions.assertEquals(1, schema.getFieldTypes().size());
+        Assertions.assertEquals(
+                io.milvus.grpc.DataType.Text, schema.getFieldTypes().get(0).getDataType());
+    }
+
+    private FieldSchema textField() {
+        return FieldSchema.builder()
+                .name("content")
+                .dataType(DataType.Text)
+                .isNullable(true)
+                .enableAnalyzer(true)
+                .enableMatch(true)
+                .analyzerParams(Collections.singletonMap("type", "standard"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- upgrade Milvus Java SDK and BulkWriter SDK to `3.0.5-SNAPSHOT`, which exposes `DataType.Text`
- preserve Milvus TEXT metadata when the source schema is represented as a SeaTunnel STRING, and restore TEXT when creating the target collection
- support TEXT in sink value conversion, catalog/default-value conversion, and BulkWriter schema conversion
- keep ordinary STRING columns mapped to VarChar unless TEXT is explicitly preserved or configured
- add focused unit coverage for source schema conversion, VarChar compatibility, TEXT schema restoration, value conversion, and BulkWriter schema conversion

## Behavior

- Milvus TEXT to Milvus migration preserves the TEXT type automatically
- non-Milvus text-like sources can target Milvus TEXT through `field_schema` with `data_type = 25`
- explicitly targeting VarChar still enforces its configured `max_length`; oversized values fail instead of being silently truncated

## Verification

- `TextSupportTest`: 6 tests passed, 0 failures, 0 errors
- Spotless check passed for every file changed by this PR using JDK 17
- release distribution build completed successfully
- live Milvus-to-Milvus E2E preserved a 32-byte short value and a 70,010-byte TEXT value exactly; explicit VarChar(65535) rejected the long value without truncation
- live PostgreSQL-to-Milvus E2E mapped VARCHAR, large VARCHAR, TEXT, CHAR, and nullable TEXT columns to Milvus TEXT; 70,000-byte and 100,000-byte values matched the JDBC source exactly

## Notes

- Milvus TEXT requires StorageV3 (`common.storage.useLoonFFI = true`) on the target instance
- the SDK may report `maxLength = 65535` for a TEXT field, but live validation confirmed that it does not impose the VarChar length limit on TEXT values
