### PR TITLE
[Fix][Connector-Milvus] Omit index type for typeless source indexes

### DIFF
--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtils.java
@@ -175,10 +175,7 @@ public class MilvusSourceConnectorUtils {
                 Map<String, String> indexInfo = new HashMap<>();
                 indexInfo.put(MilvusConstants.INDEX_FIELD_NAME, indexDesc.getFieldName());
                 indexInfo.put(MilvusConstants.INDEX_NAME, indexDesc.getIndexName());
-                IndexType indexType = indexDesc.getIndexType();
-                if (indexType != null) {
-                    indexInfo.put(MilvusConstants.INDEX_TYPE, indexType.getName());
-                }
+                putIndexType(indexInfo, indexDesc);
                 if (indexDesc.getMetricType() != MetricType.INVALID) {
                     indexInfo.put(MilvusConstants.METRIC_TYPE, indexDesc.getMetricType().name());
                 }
@@ -208,6 +205,43 @@ public class MilvusSourceConnectorUtils {
 
         return CatalogTable.of(tableId, tableSchema, options, new ArrayList<>(),
                 describeCollectionResp.getDescription());
+    }
+
+    /**
+     * Decide how the source index type is propagated into the catalog table options.
+     *
+     * <ul>
+     *   <li>Known type: passed through as-is.
+     *   <li>{@link IndexType#None} with real index parameters (metric type or extra params):
+     *       the source index type exists but is not recognized by this Milvus Java SDK (which
+     *       maps it to the None sentinel and drops the raw string). Keep the sentinel so the
+     *       sink fails loudly instead of silently downgrading the index to AUTOINDEX.
+     *   <li>{@link IndexType#None} or null with empty params: the source index was created
+     *       without an index_type (e.g. pymilvus create_index with empty params). Omit the
+     *       type so the sink lets the Milvus Java SDK apply its default (AUTOINDEX).
+     * </ul>
+     */
+    static void putIndexType(Map<String, String> indexInfo, DescribeIndexResp.IndexDesc indexDesc) {
+        IndexType indexType = indexDesc.getIndexType();
+        if (indexType != null && indexType != IndexType.None) {
+            indexInfo.put(MilvusConstants.INDEX_TYPE, indexType.getName());
+            return;
+        }
+        boolean hasIndexParams = indexDesc.getMetricType() != MetricType.INVALID
+                || (indexDesc.getExtraParams() != null && !indexDesc.getExtraParams().isEmpty());
+        if (indexType == IndexType.None && hasIndexParams) {
+            indexInfo.put(MilvusConstants.INDEX_TYPE, IndexType.None.getName());
+            log.warn(
+                    "Index '{}' on field '{}' has an index type unrecognized by the Milvus Java SDK, "
+                            + "metricType={}, extraParams={}; propagating 'None' so the sink rejects it explicitly",
+                    indexDesc.getIndexName(), indexDesc.getFieldName(), indexDesc.getMetricType(),
+                    indexDesc.getExtraParams());
+        } else {
+            log.info(
+                    "Index '{}' on field '{}' has no index type in source (empty params); "
+                            + "omitting indexType, the sink will use the SDK default (AUTOINDEX)",
+                    indexDesc.getIndexName(), indexDesc.getFieldName());
+        }
     }
 
     private String getPartitionNames(MilvusClientV2 client, String collection) {

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/source/utils/MilvusSourceConnectorUtilsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.milvus.source.utils;
+
+import io.milvus.v2.common.IndexParam.IndexType;
+import io.milvus.v2.common.IndexParam.MetricType;
+import io.milvus.v2.service.index.response.DescribeIndexResp;
+import org.apache.seatunnel.connectors.seatunnel.milvus.common.MilvusConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MilvusSourceConnectorUtilsTest {
+
+    private DescribeIndexResp.IndexDesc buildIndexDesc(
+            IndexType indexType, MetricType metricType, Map<String, String> extraParams) {
+        return DescribeIndexResp.IndexDesc.builder()
+                .indexName("idx")
+                .fieldName("field")
+                .indexType(indexType)
+                .metricType(metricType)
+                .extraParams(extraParams)
+                .build();
+    }
+
+    @Test
+    void testPutIndexType_knownTypePassedThrough() {
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(IndexType.IVF_FLAT, MetricType.COSINE,
+                        Collections.singletonMap("nlist", "1024")));
+        Assertions.assertEquals("IVF_FLAT", indexInfo.get(MilvusConstants.INDEX_TYPE));
+    }
+
+    @Test
+    void testPutIndexType_noneWithEmptyParamsOmitted() {
+        // Index created without index_type (empty params): omit the type so the sink
+        // lets the Milvus Java SDK apply its default (AUTOINDEX)
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(IndexType.None, MetricType.INVALID, Collections.emptyMap()));
+        Assertions.assertFalse(indexInfo.containsKey(MilvusConstants.INDEX_TYPE));
+    }
+
+    @Test
+    void testPutIndexType_noneWithNullExtraParamsOmitted() {
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(IndexType.None, MetricType.INVALID, null));
+        Assertions.assertFalse(indexInfo.containsKey(MilvusConstants.INDEX_TYPE));
+    }
+
+    @Test
+    void testPutIndexType_nullIndexTypeOmitted() {
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(null, MetricType.INVALID, Collections.emptyMap()));
+        Assertions.assertFalse(indexInfo.containsKey(MilvusConstants.INDEX_TYPE));
+    }
+
+    @Test
+    void testPutIndexType_noneWithMetricTypeKeptForLoudFailure() {
+        // SDK mapped the type to None but a metric type survived: the source index type
+        // is unrecognized by this SDK. Keep the None sentinel so the sink fails loudly
+        // instead of silently downgrading the index to AUTOINDEX.
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(IndexType.None, MetricType.COSINE, Collections.emptyMap()));
+        Assertions.assertEquals("None", indexInfo.get(MilvusConstants.INDEX_TYPE));
+    }
+
+    @Test
+    void testPutIndexType_noneWithExtraParamsKeptForLoudFailure() {
+        Map<String, String> indexInfo = new HashMap<>();
+        MilvusSourceConnectorUtils.putIndexType(indexInfo,
+                buildIndexDesc(IndexType.None, MetricType.INVALID,
+                        Collections.singletonMap("nlist", "1024")));
+        Assertions.assertEquals("None", indexInfo.get(MilvusConstants.INDEX_TYPE));
+    }
+}


### PR DESCRIPTION
## Summary

Source indexes created without an `index_type` (e.g. `pymilvus` `create_index` with empty params) are reported by the Milvus Java SDK with the `IndexType.None` sentinel and empty params. Previously VTS propagated the literal `"None"` type to the sink, which failed the job during `handleSaveMode` with `MILVUS-15` ("refusing to create AUTOINDEX implicitly").

This PR changes the Milvus source to omit the index type for such typeless indexes, letting the sink apply the SDK default (`AUTOINDEX`).

## Root cause

`milvus-sdk-java` maps an unrecognized/missing `index_type` to `IndexType.None` (and drops the raw string). Two cases collapse into `None`:

1. **Typeless index** — created with empty params (no `index_type` key at all). `metricType == INVALID` and `extraParams` empty.
2. **Unrecognized index type** — a real type the SDK can't map. `metricType`/`extraParams` still carry the index configuration.

## Change

In `MilvusSourceConnectorUtils`, extract the propagation decision into `putIndexType(...)`:

| Source index | Behavior |
|---|---|
| Known type | pass through as-is |
| `None` + empty params (typeless) | omit `indexType` → sink applies SDK default (`AUTOINDEX`) |
| `None` + metric/params present (unrecognized type) | keep `"None"` sentinel → sink keeps failing loudly (no silent downgrade) |

No sink-side change needed; `CatalogUtils.parseIndexType` already returns `null` for a blank/missing type.

## Validation

- New `MilvusSourceConnectorUtilsTest` (6 cases) covering all branches.
- Existing `CatalogUtilsTest` and module unit tests pass.
- Reproduced the full chain against a Zilliz Cloud UAT instance with `milvus-sdk-java` 3.0.6: pymilvus-created typeless index → SDK `describeIndex` returns `None`/`INVALID`/`{}` → previously `MILVUS-15`, now omitted.