### PR TITLE
[Feature][Connector-Milvus] Support workload identity for stage bucket access

### DIFF
--- a/seatunnel-connectors-v2/connector-milvus/pom.xml
+++ b/seatunnel-connectors-v2/connector-milvus/pom.xml
@@ -29,7 +29,9 @@
     <artifactId>connector-milvus</artifactId>
     <name>SeaTunnel : Connectors V2 : Milvus</name>
     <properties>
-        <milvus.sdk.version>3.0.6</milvus.sdk.version>
+        <!-- 3.0.9 is the first upstream release carrying the refreshable
+             workload-identity credentials (milvus-io/milvus-sdk-java#2058) -->
+        <milvus.sdk.version>3.0.9</milvus.sdk.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/external/dto/InnerImportRequest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/external/dto/InnerImportRequest.java
@@ -3,6 +3,7 @@ package org.apache.seatunnel.connectors.seatunnel.milvus.external.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Data
@@ -11,9 +12,18 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class InnerImportRequest {
     private String objectUrl;
+    // storage credentials; excluded from toString because the import request is logged
+    @ToString.Exclude
     private String accessKey;
+    @ToString.Exclude
     private String secretKey;
+    // workload identity token, request-scoped credential minted at import time: a gcp
+    // bearer token on its own, or the session token of the ak/sk/tokens triple on aws
+    @ToString.Exclude
+    private String token;
     private String clusterId;
+    // the caller's api key is also a credential
+    @ToString.Exclude
     private String apiKey;
     private String dbName;
     private String collectionName;

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/external/dto/StageBucket.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/external/dto/StageBucket.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Data
@@ -19,8 +20,12 @@ public class StageBucket {
     private String minioUrl;
     @SerializedName("region_id")
     private String regionId;
+    // credentials live in this config; keep them out of toString so an accidental
+    // log of the stage bucket never leaks them
+    @ToString.Exclude
     @SerializedName("access_key")
     private String accessKey;
+    @ToString.Exclude
     @SerializedName("secret_key")
     private String secretKey;
     @SerializedName("bucket_name")
@@ -35,6 +40,7 @@ public class StageBucket {
     //config for import
     @SerializedName("instance_id")
     private String instanceId;
+    @ToString.Exclude
     @SerializedName("api_key")
     private String apiKey;
     @Builder.Default
@@ -43,4 +49,27 @@ public class StageBucket {
     @Builder.Default
     @SerializedName("inner_call")
     private Boolean innerCall = false;
+
+    // when true, no static credentials are provided; the writer authenticates to the
+    // bucket through the workload identity of the cluster it runs in
+    // (EKS IRSA / AKS workload identity / GKE workload identity)
+    @SerializedName("use_workload_identity")
+    private Boolean useWorkloadIdentity;
+
+    // aws workload identity, import path only: lifetime of the session credentials
+    // minted for the control plane, whose environment sits outside the identity's trust
+    // boundary and therefore cannot refresh them. Absent means 3600 (the IAM role
+    // default MaxSessionDuration), which stock customer roles accept unmodified
+    @SerializedName("session_duration_seconds")
+    private Integer sessionDurationSeconds;
+
+    // byoc only: the data plane address the import trigger/progress calls are sent to,
+    // replacing the public cloud api the pod cannot reach from the customer vpc
+    @SerializedName("cloud_api_url")
+    private String cloudApiUrl;
+
+    // byoc only: the customer vpc the target instance lives in, carried into the probe
+    // calls so the data plane can locate the right cluster
+    @SerializedName("vpc_id")
+    private String vpcId;
 }

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusImport.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/MilvusImport.java
@@ -43,7 +43,11 @@ public class MilvusImport {
         this.collectionName = collectionName;
         this.partitionName = partitionName;
         this.apiKey = stageBucket.getApiKey();
-        this.baseUrl = ControllerAPI.getControllerAPI(url);
+        // byoc pods cannot reach the public cloud api; the import trigger and progress
+        // polls go to the data plane address handed down in the stage bucket config
+        this.baseUrl = StringUtils.isNotEmpty(stageBucket.getCloudApiUrl())
+                ? stageBucket.getCloudApiUrl()
+                : ControllerAPI.getControllerAPI(url);
     }
     public void importDatas(List<List<String>> objectUrls) {
         for(List<String> objectUrl : objectUrls) {
@@ -70,16 +74,15 @@ public class MilvusImport {
         }
         String objectUrlStr = processUrl(objectUrl);
         log.info("import objectUrl: " + objectUrl);
-        InnerImportRequest importRequest = InnerImportRequest.builder()
+        InnerImportRequest.InnerImportRequestBuilder requestBuilder = InnerImportRequest.builder()
                 .apiKey(apiKey)
                 .clusterId(clusterId)
                 .collectionName(collectionName)
                 .objectUrl(objectUrlStr)
-                .accessKey(stageBucket.getAccessKey())
-                .secretKey(stageBucket.getSecretKey())
                 //the import job will be executed in the background, not showup in the console
-                .innerCall(stageBucket.getInnerCall() == null || stageBucket.getInnerCall())
-                .build();
+                .innerCall(stageBucket.getInnerCall() == null || stageBucket.getInnerCall());
+        applyStorageCredentials(requestBuilder);
+        InnerImportRequest importRequest = requestBuilder.build();
         if(StringUtils.isNotEmpty(dbName) && !dbName.equals("default")){
             importRequest.setDbName(dbName);
         }
@@ -128,6 +131,38 @@ public class MilvusImport {
             }
         }
         return true;
+    }
+
+    // Workload identity credentials have to cross into the control plane, which sits
+    // outside the identity's trust boundary, so they are minted here as one frozen
+    // credential. They are minted per import call rather than reused from writer init:
+    // the upload phase may approach the writer credential's lifetime, and the import
+    // trigger must not inherit a nearly-expired credential.
+    private void applyStorageCredentials(InnerImportRequest.InnerImportRequestBuilder builder) {
+        if (!Boolean.TRUE.equals(stageBucket.getUseWorkloadIdentity())) {
+            builder.accessKey(stageBucket.getAccessKey())
+                    .secretKey(stageBucket.getSecretKey());
+            return;
+        }
+        if ("gcp".equals(stageBucket.getCloudId())) {
+            // GCS accepts a standalone bearer token, no ak/sk needed
+            builder.token(WorkloadIdentityCredentials.fetchGcpAccessToken());
+            return;
+        }
+        if ("az".equals(stageBucket.getCloudId()) || "azure".equals(stageBucket.getCloudId())) {
+            throw new MilvusConnectorException(MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "workload identity import is not supported for azure yet");
+        }
+        // AWS session credentials only authenticate as a full ak/sk/sessionToken triple;
+        // the session duration is fixed at mint time, so it is taken from the stage
+        // bucket config handed down by the control plane (absent = 1h, the IAM role
+        // default that stock customer roles accept)
+        WorkloadIdentityCredentials.AwsSessionCredentials credentials =
+                WorkloadIdentityCredentials.assumeAwsRoleWithWebIdentity(stageBucket.getRegionId(),
+                        stageBucket.getSessionDurationSeconds());
+        builder.accessKey(credentials.getAccessKey())
+                .secretKey(credentials.getSecretKey())
+                .token(credentials.getSessionToken());
     }
 
     private BulkImportResponse importToCloud(String baseUrl, InnerImportRequest importRequest) {

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/StorageConnectParamFactory.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/StorageConnectParamFactory.java
@@ -1,0 +1,105 @@
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import io.milvus.bulkwriter.connect.AzureConnectParam;
+import io.milvus.bulkwriter.connect.GcpMetadataServerCredentialsProvider;
+import io.milvus.bulkwriter.connect.S3ConnectParam;
+import io.milvus.bulkwriter.connect.StorageConnectParam;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.StageBucket;
+
+import java.util.Objects;
+
+/**
+ * Builds the milvus bulk writer's {@link StorageConnectParam} from a {@link StageBucket}.
+ * Two authentication modes are supported:
+ *
+ * <ul>
+ *   <li>static credentials: access_key/secret_key (S3-style) or account name/key
+ *       (Azure connection string), as provided in the stage bucket config;</li>
+ *   <li>workload identity: {@code use_workload_identity} is set and no static credentials
+ *       are provided, so credentials are minted from the identity of the workload running
+ *       the writer (see {@link WorkloadIdentityCredentials}).</li>
+ * </ul>
+ */
+public class StorageConnectParamFactory {
+
+    public static StorageConnectParam create(StageBucket stageBucket) {
+        if (isAzure(stageBucket.getCloudId())) {
+            return useWorkloadIdentity(stageBucket)
+                    ? azureWithWorkloadIdentity(stageBucket)
+                    : azureWithAccountKey(stageBucket);
+        }
+        return useWorkloadIdentity(stageBucket)
+                ? s3WithWorkloadIdentity(stageBucket)
+                : s3WithStaticKeys(stageBucket);
+    }
+
+    private static boolean useWorkloadIdentity(StageBucket stageBucket) {
+        return Boolean.TRUE.equals(stageBucket.getUseWorkloadIdentity());
+    }
+
+    private static boolean isAzure(String cloudId) {
+        return Objects.equals(cloudId, "az") || Objects.equals(cloudId, "azure");
+    }
+
+    private static StorageConnectParam azureWithAccountKey(StageBucket stageBucket) {
+        String connectionStr = "DefaultEndpointsProtocol=https;AccountName=" + stageBucket.getAccessKey()
+                + ";AccountKey=" + stageBucket.getSecretKey() + ";EndpointSuffix=core.windows.net";
+        return AzureConnectParam.newBuilder()
+                .withConnStr(connectionStr)
+                .withContainerName(stageBucket.getBucketName())
+                .build();
+    }
+
+    private static StorageConnectParam azureWithWorkloadIdentity(StageBucket stageBucket) {
+        return AzureConnectParam.newBuilder()
+                .withAccountUrl(azureAccountUrl(stageBucket))
+                .withCredential(new DefaultAzureCredentialBuilder().build())
+                .withContainerName(stageBucket.getBucketName())
+                .build();
+    }
+
+    // the storage account name is not a secret and travels in access_key; when it is
+    // absent, minio_url is expected to carry the full account url instead
+    private static String azureAccountUrl(StageBucket stageBucket) {
+        if (stageBucket.getAccessKey() != null && !stageBucket.getAccessKey().isEmpty()) {
+            return "https://" + stageBucket.getAccessKey() + ".blob.core.windows.net";
+        }
+        if (stageBucket.getMinioUrl() != null && stageBucket.getMinioUrl().startsWith("http")) {
+            return stageBucket.getMinioUrl();
+        }
+        throw new MilvusConnectorException(MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                "use_workload_identity is set but the storage account is unknown: "
+                        + "access_key (account name) and minio_url (account url) are both empty");
+    }
+
+    private static StorageConnectParam s3WithStaticKeys(StageBucket stageBucket) {
+        return s3Builder(stageBucket)
+                .withAccessKey(stageBucket.getAccessKey())
+                .withSecretKey(stageBucket.getSecretKey())
+                .build();
+    }
+
+    private static StorageConnectParam s3WithWorkloadIdentity(StageBucket stageBucket) {
+        S3ConnectParam.Builder builder = s3Builder(stageBucket);
+        // self-refreshing providers: a long-running writer never touches an expired
+        // credential, and no fixed session duration has to be negotiated with the
+        // customer role
+        if (Objects.equals(stageBucket.getCloudId(), "gcp")) {
+            // the bulk writer sends the token as a Bearer credential against the GCS XML API
+            return builder.withCredentialsProvider(new GcpMetadataServerCredentialsProvider()).build();
+        }
+        return builder.withCredentialsProvider(
+                WorkloadIdentityCredentials.awsWebIdentityProvider(stageBucket.getRegionId())).build();
+    }
+
+    private static S3ConnectParam.Builder s3Builder(StageBucket stageBucket) {
+        return S3ConnectParam.newBuilder()
+                .withEndpoint(stageBucket.getMinioUrl())
+                .withRegion(stageBucket.getRegionId())
+                .withBucketName(stageBucket.getBucketName())
+                .withCloudName(stageBucket.getCloudId());
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/WorkloadIdentityCredentials.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/WorkloadIdentityCredentials.java
@@ -1,0 +1,257 @@
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.minio.credentials.Jwt;
+import io.minio.credentials.Provider;
+import io.minio.credentials.WebIdentityProvider;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectionErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Bridges the workload identity of the cluster the writer runs in into object-storage
+ * access, so migrations never have to handle static access keys:
+ *
+ * <ul>
+ *   <li>AWS write path: {@link #awsWebIdentityProvider(String)} hands the bulk writer a
+ *       minio {@link WebIdentityProvider} that exchanges the pod's IRSA token
+ *       (AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE) for session credentials and
+ *       refreshes them automatically before expiry, so long-running jobs never hit an
+ *       expired session.</li>
+ *   <li>AWS import path: {@link #assumeAwsRoleWithWebIdentity(String, Integer)} mints one
+ *       session triple that is forwarded to the control plane, whose environment sits
+ *       outside the identity's trust boundary. Its lifetime is fixed at mint time, so the
+ *       caller passes it explicitly (the stage bucket config handed down by the control
+ *       plane); absent means 1h, the IAM role default that stock roles accept.</li>
+ *   <li>GCP: {@link #fetchGcpAccessToken()} fetches an OAuth2 access token from the GKE
+ *       metadata server for the import path; the write path uses the bulk writer's
+ *       self-refreshing GCP provider instead.</li>
+ *   <li>Azure: handled by the sink through DefaultAzureCredential, which discovers the AKS
+ *       workload identity / managed identity by itself.</li>
+ * </ul>
+ */
+@Slf4j
+public class WorkloadIdentityCredentials {
+
+    private static final int HTTP_TIMEOUT_MS = 10_000;
+    private static final String GCP_TOKEN_URL =
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+    // 1h matches the IAM role default MaxSessionDuration, so stock BYOC roles work
+    // unmodified; raise via the stage bucket config only when the target role allows a
+    // longer MaxSessionDuration
+    public static final int DEFAULT_AWS_SESSION_DURATION_SECONDS = 3600;
+
+    @Value
+    public static class AwsSessionCredentials {
+        String accessKey;
+        String secretKey;
+        String sessionToken;
+        String expiration;
+    }
+
+    @Value
+    private static class AwsWebIdentityEnv {
+        String roleArn;
+        String tokenFile;
+        String sessionName;
+        String stsEndpoint;
+    }
+
+    /**
+     * Builds the self-refreshing credentials provider for the bulk writer's S3 client.
+     * DurationSeconds is deliberately omitted from the STS request (jwt expiry 0 plus a
+     * null durationSeconds), so STS grants the role's default session duration and every
+     * customer role works regardless of its MaxSessionDuration; the provider re-assumes
+     * the role before each session expires.
+     */
+    public static Provider awsWebIdentityProvider(String region) {
+        AwsWebIdentityEnv env = awsWebIdentityEnv(region);
+        return new WebIdentityProvider(
+                () -> new Jwt(readTokenFile(env.getTokenFile()), 0),
+                env.getStsEndpoint(), null, null, env.getRoleArn(), env.getSessionName(), null);
+    }
+
+    /**
+     * Mints one session triple for the import path, where the credentials must cross
+     * into the control plane and are consumed asynchronously. durationSeconds comes from
+     * the stage bucket config; null falls back to the IAM role default (1h).
+     */
+    public static AwsSessionCredentials assumeAwsRoleWithWebIdentity(String region, Integer durationSeconds) {
+        AwsWebIdentityEnv env = awsWebIdentityEnv(region);
+        int duration = validateSessionDurationSeconds(durationSeconds);
+        try {
+            String webIdentityToken = readTokenFile(env.getTokenFile());
+            String body = "Action=AssumeRoleWithWebIdentity&Version=2011-06-15"
+                    + "&RoleArn=" + urlEncode(env.getRoleArn())
+                    + "&RoleSessionName=" + urlEncode(env.getSessionName())
+                    + "&WebIdentityToken=" + urlEncode(webIdentityToken)
+                    + "&DurationSeconds=" + duration;
+            String response = httpRequest("POST", env.getStsEndpoint(),
+                    "application/x-www-form-urlencoded", null, body);
+            AwsSessionCredentials credentials = new AwsSessionCredentials(
+                    xmlTagValue(response, "AccessKeyId"),
+                    xmlTagValue(response, "SecretAccessKey"),
+                    xmlTagValue(response, "SessionToken"),
+                    xmlTagValue(response, "Expiration"));
+            log.info("Obtained AWS session credentials via web identity, roleArn={}, durationSeconds={}, expiration={}",
+                    env.getRoleArn(), duration, credentials.getExpiration());
+            return credentials;
+        } catch (MilvusConnectorException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "failed to assume role via web identity: " + e.getMessage(), e);
+        }
+    }
+
+    private static AwsWebIdentityEnv awsWebIdentityEnv(String region) {
+        String roleArn = System.getenv("AWS_ROLE_ARN");
+        String tokenFile = System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE");
+        if (isEmpty(roleArn) || isEmpty(tokenFile)) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "use_workload_identity is set but AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE are not present; "
+                            + "the writer pod is not running with an IRSA-enabled service account");
+        }
+        String sessionName = System.getenv("AWS_ROLE_SESSION_NAME");
+        if (isEmpty(sessionName)) {
+            sessionName = "vts-bulk-writer";
+        }
+        // regional STS endpoint, matching the AWS_STS_REGIONAL_ENDPOINTS=regional the pod
+        // spec injects; deliberately not configurable — nothing injects such an override
+        // today, and an unused knob is worse than adding one back when a real VPC-endpoint
+        // case shows up
+        String stsEndpoint = "https://sts." + region + ".amazonaws.com";
+        return new AwsWebIdentityEnv(roleArn, tokenFile, sessionName, stsEndpoint);
+    }
+
+    static int validateSessionDurationSeconds(Integer durationSeconds) {
+        if (durationSeconds == null) {
+            return DEFAULT_AWS_SESSION_DURATION_SECONDS;
+        }
+        if (durationSeconds <= 0) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "session_duration_seconds must be a positive integer, got: " + durationSeconds);
+        }
+        return durationSeconds;
+    }
+
+    private static String readTokenFile(String tokenFile) {
+        try {
+            return new String(Files.readAllBytes(Paths.get(tokenFile)), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "failed to read the web identity token file " + tokenFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    public static String fetchGcpAccessToken() {
+        try {
+            String response = httpRequest("GET", GCP_TOKEN_URL, null,
+                    "Metadata-Flavor: Google", null);
+            JsonObject json = new Gson().fromJson(response, JsonObject.class);
+            log.info("Obtained GCP access token from metadata server, expiresIn={}s",
+                    json.get("expires_in").getAsString());
+            return json.get("access_token").getAsString();
+        } catch (Exception e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "failed to fetch an access token from the GKE metadata server; "
+                            + "the writer pod may not be bound to a workload identity: " + e.getMessage(), e);
+        }
+    }
+
+    private static String httpRequest(String method, String url, String contentType,
+                                      String header, String body) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        conn.setRequestMethod(method);
+        conn.setConnectTimeout(HTTP_TIMEOUT_MS);
+        conn.setReadTimeout(HTTP_TIMEOUT_MS);
+        if (contentType != null) {
+            conn.setRequestProperty("Content-Type", contentType);
+        }
+        if (header != null) {
+            int split = header.indexOf(':');
+            conn.setRequestProperty(header.substring(0, split).trim(), header.substring(split + 1).trim());
+        }
+        if (body != null) {
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        int status = conn.getResponseCode();
+        String response;
+        try (InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream()) {
+            response = new String(readAll(stream), StandardCharsets.UTF_8);
+        }
+        if (status >= 400) {
+            throw new IOException("http " + status + " from " + url + ": " + response);
+        }
+        return response;
+    }
+
+    private static byte[] readAll(InputStream stream) throws IOException {
+        if (stream == null) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int n;
+        while ((n = stream.read(buffer)) != -1) {
+            out.write(buffer, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static String xmlTagValue(String xml, String tag) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Document doc = factory.newDocumentBuilder()
+                    .parse(new InputSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
+            NodeList nodes = doc.getElementsByTagName(tag);
+            if (nodes.getLength() == 0) {
+                throw new MilvusConnectorException(
+                        MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                        "STS response is missing " + tag + ": " + xml);
+            }
+            return nodes.item(0).getTextContent();
+        } catch (MilvusConnectorException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MilvusConnectorException(
+                    MilvusConnectionErrorCode.INIT_WRITER_ERROR,
+                    "failed to parse the STS response: " + e.getMessage(), e);
+        }
+    }
+
+    private static String urlEncode(String value) throws IOException {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+    }
+
+    private static boolean isEmpty(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/writer/MilvusBulkWriter.java
@@ -6,8 +6,6 @@ import com.google.gson.reflect.TypeToken;
 import io.milvus.bulkwriter.RemoteBulkWriter;
 import io.milvus.bulkwriter.RemoteBulkWriterParam;
 import io.milvus.bulkwriter.common.clientenum.BulkFileType;
-import io.milvus.bulkwriter.connect.AzureConnectParam;
-import io.milvus.bulkwriter.connect.S3ConnectParam;
 import io.milvus.bulkwriter.connect.StorageConnectParam;
 import io.milvus.param.collection.CollectionSchemaParam;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
@@ -25,13 +23,13 @@ import static org.apache.seatunnel.connectors.seatunnel.milvus.sink.config.Milvu
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.catalog.MilvusFieldSchema;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusImport;
 import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.MilvusSinkConverter;
+import org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils.StorageConnectParamFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
@@ -77,24 +75,7 @@ public class MilvusBulkWriter implements MilvusWriter {
         }
 
         String collectionName = catalogTable.getTablePath().getTableName();
-        StorageConnectParam storageConnectParam;
-        if(Objects.equals(stageBucket.getCloudId(), "az") || Objects.equals(stageBucket.getCloudId(), "azure")){
-            String connectionStr = "DefaultEndpointsProtocol=https;AccountName=" + stageBucket.getAccessKey() +
-                    ";AccountKey=" + stageBucket.getSecretKey() + ";EndpointSuffix=core.windows.net";
-            storageConnectParam = AzureConnectParam.newBuilder()
-                    .withConnStr(connectionStr)
-                    .withContainerName(stageBucket.getBucketName())
-                    .build();
-        }else {
-            storageConnectParam = S3ConnectParam.newBuilder()
-                    .withEndpoint(stageBucket.getMinioUrl())
-                    .withRegion(stageBucket.getRegionId())
-                    .withAccessKey(stageBucket.getAccessKey())
-                    .withSecretKey(stageBucket.getSecretKey())
-                    .withBucketName(stageBucket.getBucketName())
-                    .withCloudName(stageBucket.getCloudId())
-                    .build();
-        }
+        StorageConnectParam storageConnectParam = StorageConnectParamFactory.create(stageBucket);
 
         RemoteBulkWriterParam remoteBulkWriterParam = RemoteBulkWriterParam.newBuilder()
                 .withCollectionSchema(describeCollectionResp.getCollectionSchema())

--- a/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/WorkloadIdentityCredentialsTest.java
+++ b/seatunnel-connectors-v2/connector-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/sink/utils/WorkloadIdentityCredentialsTest.java
@@ -1,0 +1,119 @@
+package org.apache.seatunnel.connectors.seatunnel.milvus.sink.utils;
+
+import com.google.gson.Gson;
+import io.milvus.bulkwriter.connect.GcpMetadataServerCredentialsProvider;
+import io.milvus.bulkwriter.connect.S3ConnectParam;
+import io.milvus.bulkwriter.connect.StorageConnectParam;
+import org.apache.seatunnel.connectors.seatunnel.milvus.exception.MilvusConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.InnerImportRequest;
+import org.apache.seatunnel.connectors.seatunnel.milvus.external.dto.StageBucket;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class WorkloadIdentityCredentialsTest {
+
+    @Test
+    public void sessionDurationDefaultsToOneHour() {
+        Assertions.assertEquals(3600,
+                WorkloadIdentityCredentials.validateSessionDurationSeconds(null));
+    }
+
+    @Test
+    public void sessionDurationAcceptsPositiveInteger() {
+        Assertions.assertEquals(7200, WorkloadIdentityCredentials.validateSessionDurationSeconds(7200));
+    }
+
+    @Test
+    public void sessionDurationRejectsNonPositive() {
+        Assertions.assertThrows(MilvusConnectorException.class,
+                () -> WorkloadIdentityCredentials.validateSessionDurationSeconds(0));
+        Assertions.assertThrows(MilvusConnectorException.class,
+                () -> WorkloadIdentityCredentials.validateSessionDurationSeconds(-100));
+    }
+
+    @Test
+    public void gcpWorkloadIdentityUsesMetadataServerProvider() {
+        StageBucket stageBucket = StageBucket.builder()
+                .cloudId("gcp")
+                .regionId("us-west1")
+                .bucketName("bucket")
+                .minioUrl("storage.googleapis.com")
+                .useWorkloadIdentity(true)
+                .build();
+        StorageConnectParam param = StorageConnectParamFactory.create(stageBucket);
+        Assertions.assertTrue(param instanceof S3ConnectParam);
+        Assertions.assertTrue(((S3ConnectParam) param).getCredentialsProvider()
+                instanceof GcpMetadataServerCredentialsProvider);
+    }
+
+    @Test
+    public void awsWorkloadIdentityFailsFastWithoutIrsaEnv() {
+        // no AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE in the test environment
+        StageBucket stageBucket = StageBucket.builder()
+                .cloudId("aws")
+                .regionId("us-west-2")
+                .bucketName("bucket")
+                .minioUrl("s3.us-west-2.amazonaws.com")
+                .useWorkloadIdentity(true)
+                .build();
+        Assertions.assertThrows(MilvusConnectorException.class,
+                () -> StorageConnectParamFactory.create(stageBucket));
+    }
+
+    @Test
+    public void stageBucketCarriesSessionDurationFromJobConfig() {
+        StageBucket withValue = new Gson().fromJson(
+                "{\"cloud_id\":\"aws\",\"bucket_name\":\"b\",\"session_duration_seconds\":7200}",
+                StageBucket.class);
+        Assertions.assertEquals(7200, withValue.getSessionDurationSeconds());
+
+        StageBucket absent = new Gson().fromJson(
+                "{\"cloud_id\":\"aws\",\"bucket_name\":\"b\"}",
+                StageBucket.class);
+        Assertions.assertNull(absent.getSessionDurationSeconds());
+    }
+
+    @Test
+    public void credentialsNeverLeakIntoToString() {
+        StageBucket stageBucket = StageBucket.builder()
+                .cloudId("aws")
+                .bucketName("bucket")
+                .accessKey("secret-ak")
+                .secretKey("secret-sk")
+                .apiKey("secret-api-key")
+                .build();
+        String rendered = stageBucket.toString();
+        Assertions.assertFalse(rendered.contains("secret-ak"));
+        Assertions.assertFalse(rendered.contains("secret-sk"));
+        Assertions.assertFalse(rendered.contains("secret-api-key"));
+
+        InnerImportRequest importRequest = InnerImportRequest.builder()
+                .accessKey("secret-ak")
+                .secretKey("secret-sk")
+                .token("secret-token")
+                .apiKey("secret-api-key")
+                .objectUrl("https://bucket.s3.us-west-2.amazonaws.com/path")
+                .build();
+        String renderedRequest = importRequest.toString();
+        Assertions.assertFalse(renderedRequest.contains("secret-ak"));
+        Assertions.assertFalse(renderedRequest.contains("secret-sk"));
+        Assertions.assertFalse(renderedRequest.contains("secret-token"));
+        Assertions.assertFalse(renderedRequest.contains("secret-api-key"));
+    }
+
+    @Test
+    public void staticKeysStillWork() {
+        StageBucket stageBucket = StageBucket.builder()
+                .cloudId("aws")
+                .regionId("us-west-2")
+                .bucketName("bucket")
+                .minioUrl("s3.us-west-2.amazonaws.com")
+                .accessKey("ak")
+                .secretKey("sk")
+                .build();
+        S3ConnectParam param = (S3ConnectParam) StorageConnectParamFactory.create(stageBucket);
+        Assertions.assertNull(param.getCredentialsProvider());
+        Assertions.assertEquals("ak", param.getAccessKey());
+        Assertions.assertEquals("sk", param.getSecretKey());
+    }
+}


### PR DESCRIPTION
## Motivation

BYOC migrations run the seatunnel writer pod inside the customer cluster, where the pod's service account already carries an identity (EKS IRSA / GKE workload identity / AKS workload identity) that is authorized for the stage bucket. Passing static bucket ak/sk down to the pod is both a secret-hygiene problem and an operational burden. This PR makes the Milvus sink's bulk-write stage-bucket access run on the pod's own identity, end to end.

## Design

**Write path (self-refreshing, no fixed duration):**
- `StorageConnectParamFactory` hands the bulk writer a refreshable credentials provider instead of frozen credentials:
  - AWS: minio `WebIdentityProvider` over the pod's IRSA env (`AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE`); `DurationSeconds` is deliberately omitted so the role default (1h) applies and stock customer roles work unmodified — the provider re-assumes the role before each session expires.
  - GCP: `GcpMetadataServerCredentialsProvider` (new in milvus-sdk-java 3.0.9, milvus-io/milvus-sdk-java#2058) fetches bearer tokens from the metadata server and refetches before `expires_in`.
  - Azure: unchanged, `DefaultAzureCredential` already refreshes.
- Requires `milvus-sdk-java(-bulkwriter)` 3.0.9, the first upstream release with the provider channel; the pom is bumped accordingly.

**Import trigger path (frozen credential by necessity):**
- The control plane sits outside the identity trust boundary, so the import call still carries one credential minted at import time (never the nearly-expired writer credential).
- AWS now sends the full ak/sk/sessionToken triple — a session token alone cannot authenticate against S3.
- The session duration moved from a hardcoded 12h (which stock customer roles reject, MaxSessionDuration default 1h) to a stage-bucket config knob handed down by the control plane; absent = 1h, the IAM role default.
- Azure workload-identity import fails fast with an explicit "not supported yet" instead of falling into the AWS STS path.

**Log hygiene:** storage credentials are excluded from request/DTO logging on both the stage bucket config and the import call.

## Compatibility

- `use_workload_identity` unset: static ak/sk path is byte-for-byte unchanged (bulkwriter falls back to `StaticProvider`; GCP static session token still works).
- SaaS migrations are untouched; the provider path only activates for identity-enabled BYOC stage buckets.
- Only the in-cluster DNS of the customer cloud-agent tunnel entry is used for the byoc import trigger; saas and byoc share one import code path.

## Testing

- New `WorkloadIdentityCredentialsTest`: session-duration parsing (default/valid/garbage), GCP provider wiring, fail-fast without IRSA env, static-key fallback.
- Full connector-milvus suite: 225 tests, 0 failures (2 pre-existing errors from MilvusSinkTest requiring a live localhost Milvus, unchanged from baseline).
- UAT e2e on AWS BYOC: seatunnel pod wrote 100 rows to the customer dp bucket via IRSA and completed the control-plane import; the same flow on a SaaS target (static creds) verified no regression.