### PR TITLE
[Fix][CI] Download mvnd from the apache archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     
     - name: Install Maven Daemon
       run: |
-        curl -s https://downloads.apache.org/maven/mvnd/1.0.2/maven-mvnd-1.0.2-linux-amd64.zip -o mvnd.zip
+        curl -sf https://archive.apache.org/dist/maven/mvnd/1.0.2/maven-mvnd-1.0.2-linux-amd64.zip -o mvnd.zip
         unzip mvnd.zip
         sudo mv maven-mvnd-1.0.2-linux-amd64 /opt/mvnd
         sudo ln -s /opt/mvnd/bin/mvnd /usr/local/bin/mvnd


### PR DESCRIPTION
## Problem

CI fails for every PR at the `Install Maven Daemon` step after ~10s:

```
unzip: End-of-central-directory signature not found
```

downloads.apache.org only keeps the latest mvnd release; 1.0.2 has been moved to the archive, so the workflow downloads a 404 HTML page and unzip chokes on it.

## Fix

Point the download at the permanent archive (`archive.apache.org/dist/...`, verified 200) and add `-f` to curl so a future broken download fails loudly at the download step instead of cryptically at unzip.