### PR TITLE
[Feature][Connector-CDC-Milvus] Support TEXT field type

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/pom.xml
@@ -29,11 +29,17 @@
     <artifactId>connector-cdc-milvus</artifactId>
     <name>SeaTunnel : Connectors V2 : CDC : Milvus</name>
 
+    <properties>
+        <!-- Must stay aligned with connector-milvus: DataType.Text only exists
+             from 3.0.4 onwards, so the SDK has to be able to deserialize it. -->
+        <milvus.sdk.version>3.0.9</milvus.sdk.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java</artifactId>
-            <version>3.0.2</version>
+            <version>${milvus.sdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/cdc/source/schema/MilvusCdcSchemaDiscovery.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/src/main/java/org/apache/seatunnel/connectors/seatunnel/milvus/cdc/source/schema/MilvusCdcSchemaDiscovery.java
@@ -341,9 +341,12 @@ public class MilvusCdcSchemaDiscovery {
             case Double:
                 builder.dataType(BasicType.DOUBLE_TYPE);
                 break;
+            case Text:
             case VarChar:
                 builder.dataType(BasicType.STRING_TYPE);
-                options.put(MAX_LENGTH, fieldSchema.getMaxLength());
+                if (fieldSchema.getDataType() != DataType.Text) {
+                    options.put(MAX_LENGTH, fieldSchema.getMaxLength());
+                }
                 if (fieldSchema.getEnableAnalyzer() != null) {
                     options.put(ENABLE_ANALYZER, fieldSchema.getEnableAnalyzer());
                 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/cdc/source/schema/MilvusCdcSchemaDiscoveryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-milvus/src/test/java/org/apache/seatunnel/connectors/seatunnel/milvus/cdc/source/schema/MilvusCdcSchemaDiscoveryTest.java
@@ -35,7 +35,12 @@ import io.milvus.v2.service.collection.response.DescribeCollectionResp;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 
+import static org.apache.seatunnel.connectors.seatunnel.milvus.cdc.common.MilvusCdcConstants.ANALYZER_PARAMS;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.cdc.common.MilvusCdcConstants.ENABLE_ANALYZER;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.cdc.common.MilvusCdcConstants.ENABLE_MATCH;
+import static org.apache.seatunnel.connectors.seatunnel.milvus.cdc.common.MilvusCdcConstants.MAX_LENGTH;
 import static org.apache.seatunnel.connectors.seatunnel.milvus.cdc.common.MilvusCdcConstants.MILVUS_INTERNAL_DYNAMIC_FIELD;
 
 class MilvusCdcSchemaDiscoveryTest {
@@ -49,13 +54,7 @@ class MilvusCdcSchemaDiscoveryTest {
                         .isNullable(true)
                         .build();
 
-        Method convertColumn =
-                MilvusCdcSchemaDiscovery.class.getDeclaredMethod(
-                        "convertColumn", CreateCollectionReq.FieldSchema.class);
-        convertColumn.setAccessible(true);
-
-        PhysicalColumn column =
-                (PhysicalColumn) convertColumn.invoke(new MilvusCdcSchemaDiscovery(), fieldSchema);
+        PhysicalColumn column = convertColumn(fieldSchema);
 
         Assertions.assertTrue(column.isNullable());
     }
@@ -90,17 +89,58 @@ class MilvusCdcSchemaDiscoveryTest {
                         .dimension(4)
                         .build();
 
-        Method convertColumn =
-                MilvusCdcSchemaDiscovery.class.getDeclaredMethod(
-                        "convertColumn", CreateCollectionReq.FieldSchema.class);
-        convertColumn.setAccessible(true);
-
-        PhysicalColumn column =
-                (PhysicalColumn) convertColumn.invoke(new MilvusCdcSchemaDiscovery(), fieldSchema);
+        PhysicalColumn column = convertColumn(fieldSchema);
 
         Assertions.assertEquals(VectorType.VECTOR_INT8_TYPE, column.getDataType());
         Assertions.assertEquals("Int8Vector", column.getSourceType());
         Assertions.assertEquals(4, column.getScale());
+    }
+
+    @Test
+    void convertTextColumnKeepsAnalyzerOptions() throws Exception {
+        CreateCollectionReq.FieldSchema fieldSchema =
+                CreateCollectionReq.FieldSchema.builder()
+                        .name("content")
+                        .dataType(DataType.Text)
+                        .enableAnalyzer(true)
+                        .enableMatch(true)
+                        .analyzerParams(Collections.singletonMap("type", "standard"))
+                        .build();
+
+        PhysicalColumn column = convertColumn(fieldSchema);
+
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals("Text", column.getSourceType());
+        Assertions.assertEquals(true, column.getOptions().get(ENABLE_ANALYZER));
+        Assertions.assertEquals(true, column.getOptions().get(ENABLE_MATCH));
+        Assertions.assertEquals(
+                "{\"type\":\"standard\"}", column.getOptions().get(ANALYZER_PARAMS));
+        Assertions.assertFalse(column.getOptions().containsKey(MAX_LENGTH));
+    }
+
+    @Test
+    void convertVarCharColumnKeepsMaxLength() throws Exception {
+        CreateCollectionReq.FieldSchema fieldSchema =
+                CreateCollectionReq.FieldSchema.builder()
+                        .name("title")
+                        .dataType(DataType.VarChar)
+                        .maxLength(128)
+                        .build();
+
+        PhysicalColumn column = convertColumn(fieldSchema);
+
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals("VarChar", column.getSourceType());
+        Assertions.assertEquals(128, column.getOptions().get(MAX_LENGTH));
+    }
+
+    private PhysicalColumn convertColumn(CreateCollectionReq.FieldSchema fieldSchema)
+            throws Exception {
+        Method convertColumn =
+                MilvusCdcSchemaDiscovery.class.getDeclaredMethod(
+                        "convertColumn", CreateCollectionReq.FieldSchema.class);
+        convertColumn.setAccessible(true);
+        return (PhysicalColumn) convertColumn.invoke(new MilvusCdcSchemaDiscovery(), fieldSchema);
     }
 
     @Test


### PR DESCRIPTION
## What

Milvus CDC could not read a source collection containing a `TEXT` field. The job died during source creation:

```
FactoryException: Unable to create a source for identifier 'Milvus-CDC'.
Caused by: io.milvus.v2.exception.MilvusClientException:
  java.lang.IllegalArgumentException: No enum constant io.milvus.v2.common.DataType.Text
```

## Why

Two layers had to change:

1. **The SDK could not represent TEXT at all.** `connector-cdc-milvus` pinned `milvus-sdk-java` to `3.0.2`, whose `DataType` enum jumps straight from `Geometry=24` to `Timestamptz=26` — there is no `Text` (it is `25`). So the SDK failed while deserializing `DescribeCollectionResponse`, before any connector code ran. Bumped to `3.0.9`, the version `connector-milvus` already uses, and turned it into a module property so the two modules stay aligned.

2. **The connector had no `Text` branch.** `MilvusCdcSchemaDiscovery.convertColumn()` mapped only `VarChar` to `STRING` and fell through to the throwing `default` branch. Once the SDK can parse TEXT, this would have been the next failure.

## Changes

- `MilvusCdcSchemaDiscovery`: map `Text` to `STRING` alongside `VarChar`. TEXT has no `maxLength`, so only `VarChar` keeps that option. Analyzer/match parameters are preserved for both.
- `pom.xml`: `milvus.sdk.version` property, `3.0.2` -> `3.0.9`.
- `MilvusCdcSchemaDiscoveryTest`: cover Text (keeps analyzer options, no `maxLength`) and VarChar (keeps `maxLength`) as regression locks.

The CDC sink needs no change: CDC write mode requires a pre-existing target collection (`schema_save_mode` is forced to `ERROR_WHEN_SCHEMA_NOT_EXIST` by `MilvusSinkFactory.validateCdcSaveMode`), and `MilvusSinkConverter` already handles `DataType.Text`. `MILVUS_DATA_TYPE` is deliberately not propagated from the CDC source, since its only consumer is the schema-creation path, which is unreachable in CDC mode.

## Testing

- `connector-cdc-milvus` module tests: **115 pass** (including 6 in `MilvusCdcSchemaDiscoveryTest`). This also covers the SDK 3.0.2 -> 3.0.9 jump, which touches every test in the module.
- `spotless:check` (with `-Dskip.spotless=false`): clean.
- End-to-end against a Zilliz Cloud instance (Milvus 3.0 compatible) with a `TEXT` source collection (`enable_analyzer` + `enable_match`), sink into a pre-created TEXT collection in another database:
  - **Before**: job exited within ~6s with the error above, 0 rows replicated.
  - **After**: job streams; rows inserted after job start are replicated, including a 30000-character text (30006 chars) whose length and SHA-256 match the source exactly.
  - **Regression**: a `VarChar` collection in the same run still replicates normally under 3.0.9.
